### PR TITLE
Improve user profile features

### DIFF
--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -22,9 +22,9 @@ def create_app():
         if not hasattr(app, 'tables_created'):
             db.create_all()
             if not User.query.first():
-                admin = User(username="admin", email="admin@example.com", role="admin")
+                admin = User(username="admin", email="admin@example.com", role="admin", avatar_url='static/img/default.png')
                 admin.set_password("admin")
-                user = User(username="estudiante", email="user@example.com")
+                user = User(username="estudiante", email="user@example.com", avatar_url='static/img/default.png')
                 user.set_password("test")
                 db.session.add_all([admin, user])
                 db.session.add(Product(

--- a/crunevo/models/user.py
+++ b/crunevo/models/user.py
@@ -13,6 +13,7 @@ class User(UserMixin, db.Model):
     points = db.Column(db.Integer, default=0)
     credits = db.Column(db.Integer, default=0)
     chat_enabled = db.Column(db.Boolean, default=True)
+    avatar_url = db.Column(db.String(255))
     about = db.Column(db.Text)
     notes = db.relationship('Note', backref='author', lazy=True)
     comments = db.relationship('Comment', backref='author', lazy=True)

--- a/crunevo/routes/auth_routes.py
+++ b/crunevo/routes/auth_routes.py
@@ -52,6 +52,16 @@ def logout():
 def perfil():
     if request.method == 'POST':
         current_user.about = request.form.get('about')
+        avatar_url = request.form.get('avatar_url')
+        if avatar_url:
+            current_user.avatar_url = avatar_url
         db.session.commit()
         flash('Perfil actualizado')
     return render_template('auth/perfil.html')
+
+
+@auth_bp.route('/user/<int:user_id>')
+@login_required
+def public_profile(user_id):
+    user = User.query.get_or_404(user_id)
+    return render_template('perfil_publico.html', user=user)

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -1,9 +1,15 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Mi perfil</h2>
+<div class="mb-3 text-center">
+  <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle" width="100" height="100" alt="avatar">
+</div>
 <form method="post">
   <div class="mb-3">
     <textarea class="form-control" name="about" placeholder="Sobre mí">{{ current_user.about }}</textarea>
+  </div>
+  <div class="mb-3">
+    <input type="text" class="form-control" name="avatar_url" placeholder="URL del avatar" value="{{ current_user.avatar_url }}">
   </div>
   <button class="btn btn-primary" type="submit">Guardar</button>
 </form>

--- a/crunevo/templates/feed/feed.html
+++ b/crunevo/templates/feed/feed.html
@@ -9,7 +9,9 @@
     <div class="card-body">
       <div class="d-flex align-items-center mb-2">
         <img src="{{ note.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
-        <strong class="me-auto">{{ note.author.username }}</strong>
+        <a href="{{ url_for('auth.public_profile', user_id=note.author.id) }}" class="me-auto text-decoration-none">
+          <strong>{{ note.author.username }}</strong>
+        </a>
         <small class="text-muted">{{ note.created_at.strftime('%Y-%m-%d') }}</small>
       </div>
       <h5 class="card-title">{{ note.title }}

--- a/crunevo/templates/notes/detalle.html
+++ b/crunevo/templates/notes/detalle.html
@@ -5,7 +5,9 @@
     <div class="d-flex align-items-center mb-3">
       <img src="{{ note.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
       <div>
-        <strong>{{ note.author.username }}</strong><br>
+        <a href="{{ url_for('auth.public_profile', user_id=note.author.id) }}" class="text-decoration-none">
+          <strong>{{ note.author.username }}</strong>
+        </a><br>
         <small class="text-muted">{{ note.created_at.strftime('%Y-%m-%d') }}</small>
       </div>
       <span class="badge bg-secondary ms-auto"><i class="bi bi-eye"></i> {{ note.views }}</span>
@@ -28,7 +30,9 @@
       <div class="d-flex mb-3 comment">
         <img src="{{ c.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
         <div>
-          <div class="small text-muted">{{ c.author.username }} • {{ c.timestamp.strftime('%Y-%m-%d %H:%M') }}</div>
+          <div class="small text-muted">
+            <a href="{{ url_for('auth.public_profile', user_id=c.author.id) }}" class="text-decoration-none">{{ c.author.username }}</a> • {{ c.timestamp.strftime('%Y-%m-%d %H:%M') }}
+          </div>
           <div>{{ c.body }}</div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- support avatar URL in the `User` model
- initialize default avatars when seeding
- allow editing avatar URL on profile page
- add a public profile route and template links

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68491a0fb4f883259ba59ac8fc2ac622