### PR TITLE
Enable Fly.io deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+SECRET_KEY=changeme
+DATABASE_URL=postgresql://user:password@localhost:5432/dbname
+UPLOAD_FOLDER=static/uploads
+CLOUDINARY_CLOUD_NAME=
+CLOUDINARY_API_KEY=
+CLOUDINARY_API_SECRET=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+COPY requirements.txt /app/
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY crunevo /app/crunevo
+
+ENV FLASK_APP=crunevo.app
+
+CMD ["gunicorn", "-b", "0.0.0.0:8080", "crunevo.app:app"]

--- a/crunevo/config.py
+++ b/crunevo/config.py
@@ -6,6 +6,11 @@ load_dotenv()
 
 class Config:
     SECRET_KEY = os.getenv('SECRET_KEY', 'devkey')
-    SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URL', 'sqlite:///crunevo.db')
+
+    _db_uri = os.getenv('DATABASE_URL', 'sqlite:///crunevo.db')
+    if _db_uri.startswith('postgres://'):
+        _db_uri = _db_uri.replace('postgres://', 'postgresql://', 1)
+    SQLALCHEMY_DATABASE_URI = _db_uri
+
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     UPLOAD_FOLDER = os.getenv('UPLOAD_FOLDER', 'static/uploads')

--- a/crunevo/requirements.txt
+++ b/crunevo/requirements.txt
@@ -18,3 +18,4 @@ SQLAlchemy==2.0.41
 typing_extensions==4.14.0
 Werkzeug==3.1.3
 WTForms==3.2.1
+cloudinary==1.40.0

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,19 @@
+app = "crunevo2"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  PYTHONUNBUFFERED = "1"
+  FLASK_APP = "crunevo.app"
+
+[deploy]
+  release_command = "flask db upgrade"
+
+[[services]]
+  internal_port = 8080
+  protocol = "tcp"
+
+  [[services.ports]]
+    handlers = ["http"]
+    port = 8080

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ SQLAlchemy==2.0.41
 typing_extensions==4.14.0
 Werkzeug==3.1.3
 WTForms==3.2.1
+cloudinary==1.40.0


### PR DESCRIPTION
## Summary
- add Dockerfile for Gunicorn server
- configure Fly.io app with `fly.toml`
- provide `.env.example` with required vars
- adjust config to normalize `DATABASE_URL` strings
- include Cloudinary dependency

## Testing
- `pip install -r requirements.txt`
- `python -m compileall -q crunevo`
- `pip check`
- `flask --app crunevo.app routes | head`


------
https://chatgpt.com/codex/tasks/task_e_684924dbfb888325be495f8d9b5cdcfa