### PR TITLE
Fix Fly.io launch config and add Cloudinary uploads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,5 @@
+FLASK_APP=crunevo/app.py
+FLASK_ENV=production
 SECRET_KEY=changeme
 DATABASE_URL=postgresql://user:password@localhost:5432/dbname
-UPLOAD_FOLDER=static/uploads
-CLOUDINARY_CLOUD_NAME=
-CLOUDINARY_API_KEY=
-CLOUDINARY_API_SECRET=
+CLOUDINARY_URL=cloudinary://APIKEY:SECRET@cloudname

--- a/crunevo/config.py
+++ b/crunevo/config.py
@@ -1,5 +1,6 @@
 import os
 from dotenv import load_dotenv
+import cloudinary
 
 load_dotenv()
 
@@ -14,3 +15,7 @@ class Config:
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     UPLOAD_FOLDER = os.getenv('UPLOAD_FOLDER', 'static/uploads')
+
+    CLOUDINARY_URL = os.getenv('CLOUDINARY_URL')
+    if CLOUDINARY_URL:
+        cloudinary.config(cloudinary_url=CLOUDINARY_URL)

--- a/crunevo/routes/admin_routes.py
+++ b/crunevo/routes/admin_routes.py
@@ -1,8 +1,11 @@
-from flask import Blueprint, render_template, redirect, url_for, flash
+import os
+from flask import Blueprint, render_template, redirect, url_for, flash, request, current_app
 from flask_login import login_required
+from werkzeug.utils import secure_filename
 from crunevo.extensions import db
 from crunevo.models import User, Product, Report
 from crunevo.utils.helpers import admin_required
+import cloudinary.uploader
 
 admin_bp = Blueprint('admin', __name__, url_prefix='/admin')
 
@@ -29,6 +32,38 @@ def manage_users():
 def manage_store():
     products = Product.query.all()
     return render_template('admin/manage_store.html', products=products)
+
+
+@admin_bp.route('/products/new', methods=['GET', 'POST'])
+@login_required
+@admin_required
+def add_product():
+    if request.method == 'POST':
+        name = request.form['name']
+        description = request.form.get('description')
+        price = request.form['price']
+        stock = request.form.get('stock', 0)
+        file = request.files.get('image')
+        image_url = None
+        if file and file.filename:
+            cloud_url = current_app.config.get('CLOUDINARY_URL')
+            if cloud_url:
+                res = cloudinary.uploader.upload(file)
+                image_url = res['secure_url']
+            else:
+                filename = secure_filename(file.filename)
+                upload_folder = current_app.config['UPLOAD_FOLDER']
+                os.makedirs(upload_folder, exist_ok=True)
+                filepath = os.path.join(upload_folder, filename)
+                file.save(filepath)
+                image_url = filepath
+        product = Product(name=name, description=description, price=price,
+                          stock=stock, image=image_url)
+        db.session.add(product)
+        db.session.commit()
+        flash('Producto agregado')
+        return redirect(url_for('admin.manage_store'))
+    return render_template('admin/add_edit_product.html')
 
 
 @admin_bp.route('/reports')

--- a/crunevo/routes/notes_routes.py
+++ b/crunevo/routes/notes_routes.py
@@ -2,6 +2,7 @@ import os
 from flask import Blueprint, render_template, request, redirect, url_for, flash, current_app, jsonify
 from flask_login import login_required, current_user
 from werkzeug.utils import secure_filename
+import cloudinary.uploader
 from crunevo.extensions import db
 from crunevo.models import Note, Comment
 
@@ -33,11 +34,16 @@ def search_notes():
 def upload_note():
     if request.method == 'POST':
         f = request.files['file']
-        filename = secure_filename(f.filename)
-        upload_folder = current_app.config['UPLOAD_FOLDER']
-        os.makedirs(upload_folder, exist_ok=True)
-        filepath = os.path.join(upload_folder, filename)
-        f.save(filepath)
+        cloud_url = current_app.config.get('CLOUDINARY_URL')
+        if cloud_url:
+            result = cloudinary.uploader.upload(f)
+            filepath = result['secure_url']
+        else:
+            filename = secure_filename(f.filename)
+            upload_folder = current_app.config['UPLOAD_FOLDER']
+            os.makedirs(upload_folder, exist_ok=True)
+            filepath = os.path.join(upload_folder, filename)
+            f.save(filepath)
         note = Note(title=request.form['title'],
                     description=request.form['description'],
                     filename=filepath,

--- a/crunevo/templates/admin/add_edit_product.html
+++ b/crunevo/templates/admin/add_edit_product.html
@@ -1,10 +1,12 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Agregar/Editar Producto</h2>
-<form method="post">
+<form method="post" enctype="multipart/form-data">
   <div class="mb-3"><input type="text" name="name" class="form-control" placeholder="Nombre" required></div>
   <div class="mb-3"><textarea name="description" class="form-control" placeholder="Descripción"></textarea></div>
   <div class="mb-3"><input type="number" step="0.01" name="price" class="form-control" placeholder="Precio" required></div>
+  <div class="mb-3"><input type="number" name="stock" class="form-control" placeholder="Stock" value="0"></div>
+  <div class="mb-3"><input type="file" name="image" class="form-control"></div>
   <button class="btn btn-primary" type="submit">Guardar</button>
 </form>
 {% endblock %}

--- a/crunevo/templates/admin/manage_store.html
+++ b/crunevo/templates/admin/manage_store.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Administrar Tienda</h2>
+<a href="{{ url_for('admin.add_product') }}" class="btn btn-success mb-3">Nuevo producto</a>
 <table class="table">
   <thead><tr><th>ID</th><th>Nombre</th><th>Stock</th></tr></thead>
   <tbody>

--- a/fly.toml
+++ b/fly.toml
@@ -3,17 +3,12 @@ app = "crunevo2"
 [build]
   dockerfile = "Dockerfile"
 
-[env]
-  PYTHONUNBUFFERED = "1"
-  FLASK_APP = "crunevo.app"
-
 [deploy]
   release_command = "flask db upgrade"
 
 [[services]]
   internal_port = 8080
   protocol = "tcp"
-
   [[services.ports]]
     handlers = ["http"]
     port = 8080


### PR DESCRIPTION
## Summary
- recreate `fly.toml` using Docker build for Fly.io
- connect to Cloudinary through `CLOUDINARY_URL`
- support Cloudinary uploads for notes and products
- provide admin route to add products with image upload
- update templates and example environment variables

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68492a9acb488325b4d9034ff28bace0