### PR TITLE
Fix login 500 error and production setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-FLASK_APP=crunevo/app.py
+FLASK_APP=crunevo.wsgi
 FLASK_ENV=production
 SECRET_KEY=changeme
 DATABASE_URL=postgresql://user:password@localhost:5432/dbname

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY crunevo /app/crunevo
 COPY migrations /app/migrations  # ← Aquí falla si está vacía
 
-COPY run.py /app/run.py
-
-CMD ["gunicorn", "-b", "0.0.0.0:8080", "run:app"]
+CMD ["gunicorn", "-b", "0.0.0.0:8080", "crunevo.wsgi:app"]

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -1,4 +1,7 @@
 from flask import Flask
+import logging
+from logging.handlers import RotatingFileHandler
+import os
 
 from .extensions import db, login_manager, migrate
 
@@ -50,6 +53,7 @@ def create_app():
     from .routes.store_routes import store_bp
     from .routes.chat_routes import chat_bp
     from .routes.admin_routes import admin_bp
+    from .routes.errors import errors_bp
 
     app.register_blueprint(auth_bp)
     app.register_blueprint(notes_bp)
@@ -57,10 +61,16 @@ def create_app():
     app.register_blueprint(store_bp)
     app.register_blueprint(chat_bp)
     app.register_blueprint(admin_bp)
+    app.register_blueprint(errors_bp)
+
+    if not app.debug:
+        if not os.path.exists('logs'):
+            os.mkdir('logs')
+        file_handler = RotatingFileHandler('logs/crunevo.log', maxBytes=10240, backupCount=10)
+        file_handler.setLevel(logging.INFO)
+        app.logger.addHandler(file_handler)
+
+        app.logger.setLevel(logging.INFO)
+        app.logger.info('CRUNEVO startup')
 
     return app
-
-app = create_app()
-
-if __name__ == '__main__':
-    app.run(debug=True)

--- a/crunevo/routes/errors.py
+++ b/crunevo/routes/errors.py
@@ -1,0 +1,7 @@
+from flask import Blueprint, render_template
+
+errors_bp = Blueprint('errors', __name__)
+
+@errors_bp.app_errorhandler(500)
+def internal_error(error):
+    return render_template('errors/500.html'), 500

--- a/crunevo/templates/errors/500.html
+++ b/crunevo/templates/errors/500.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="text-center mt-5">
+  <h1>Error interno del servidor</h1>
+  <p>Algo salió mal. Intenta nuevamente más tarde.</p>
+</div>
+{% endblock %}

--- a/crunevo/templates/feed/feed.html
+++ b/crunevo/templates/feed/feed.html
@@ -21,9 +21,11 @@
       </h5>
       <p class="card-text">{{ note.description }}</p>
       <div class="mb-2">
-        {% for tag in note.tags.split(',') if note.tags %}
-        <span class="badge bg-secondary">{{ tag }}</span>
-        {% endfor %}
+        {% if note.tags %}
+          {% for tag in note.tags.split(',') %}
+          <span class="badge bg-secondary">{{ tag }}</span>
+          {% endfor %}
+        {% endif %}
       </div>
       <a href="{{ url_for('notes.detail', note_id=note.id) }}" class="btn btn-sm btn-primary">Ver apunte</a>
     </div>

--- a/crunevo/wsgi.py
+++ b/crunevo/wsgi.py
@@ -1,0 +1,3 @@
+from crunevo.app import create_app
+
+app = create_app()

--- a/fly.toml
+++ b/fly.toml
@@ -3,6 +3,9 @@ app = "crunevo2"
 [build]
   dockerfile = "Dockerfile"
 
+[env]
+  FLASK_APP = "crunevo.wsgi"
+
 [deploy]
   release_command = "flask db upgrade"
 


### PR DESCRIPTION
## Summary
- fix rendering of tags in the feed template
- add rotating file logging in `create_app`
- add error blueprint with 500 handler
- create wsgi entrypoint
- use new wsgi file in Dockerfile and Fly config
- document FLASK_APP change

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684a25f2cdb4832593a90c8297a68302