### PR TITLE
Enable automatic Donador achievement on transfers

### DIFF
--- a/crunevo/models/__init__.py
+++ b/crunevo/models/__init__.py
@@ -8,4 +8,5 @@ from .post import Post
 from .credit import Credit
 from .ranking import RankingCache
 from .achievement import UserAchievement
+from .login_history import LoginHistory
 

--- a/crunevo/models/login_history.py
+++ b/crunevo/models/login_history.py
@@ -1,0 +1,10 @@
+from datetime import date
+from crunevo.extensions import db
+
+
+class LoginHistory(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    login_date = db.Column(db.Date, default=date.today, nullable=False)
+
+    user = db.relationship('User', backref='login_history')

--- a/crunevo/routes/auth_routes.py
+++ b/crunevo/routes/auth_routes.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse  # ✅ Corrección aquí
 from crunevo.extensions import db
 from crunevo.models import User
 from crunevo.utils.helpers import admin_required
-from crunevo.utils import spend_credit
+from crunevo.utils import spend_credit, record_login
 from crunevo.constants import CreditReasons
 from werkzeug.security import generate_password_hash
 
@@ -34,6 +34,7 @@ def login():
         user = User.query.filter_by(username=username).first()
         if user and user.check_password(password):
             login_user(user)
+            record_login(user)
             next_page = request.args.get('next')
             if not next_page or urlparse(next_page).netloc != '':
                 next_page = url_for('feed.index')

--- a/crunevo/utils/__init__.py
+++ b/crunevo/utils/__init__.py
@@ -1,4 +1,5 @@
 from .helpers import admin_required
 from .credits import add_credit, spend_credit
 from .achievements import unlock_achievement
+from .login_history import record_login
 

--- a/crunevo/utils/credits.py
+++ b/crunevo/utils/credits.py
@@ -1,5 +1,7 @@
 from crunevo.models import Credit
 from crunevo.extensions import db
+from crunevo.constants import AchievementCodes, CreditReasons
+from crunevo.utils.achievements import unlock_achievement
 
 
 def add_credit(user, amount, reason, related_id=None):
@@ -20,3 +22,13 @@ def spend_credit(user, amount, reason, related_id=None):
     user.credits -= amount
     db.session.add(credit)
     db.session.commit()
+
+    voluntary_reasons = {
+        CreditReasons.DONACION,
+        CreditReasons.AGRADECIMIENTO,
+        "donacion",
+        "agradecimiento",
+        "donación",
+    }
+    if isinstance(reason, str) and reason.lower() in voluntary_reasons:
+        unlock_achievement(user, AchievementCodes.DONADOR)

--- a/crunevo/utils/login_history.py
+++ b/crunevo/utils/login_history.py
@@ -1,0 +1,34 @@
+from datetime import date, timedelta
+from crunevo.models import LoginHistory
+from crunevo.extensions import db
+from crunevo.utils.achievements import unlock_achievement
+from crunevo.constants import AchievementCodes
+
+
+def record_login(user, login_date=None):
+    """Store a login date and unlock the 7-day streak achievement."""
+    if login_date is None:
+        login_date = date.today()
+
+    exists = LoginHistory.query.filter_by(user_id=user.id, login_date=login_date).first()
+    if not exists:
+        entry = LoginHistory(user_id=user.id, login_date=login_date)
+        db.session.add(entry)
+        db.session.commit()
+
+    last_entries = (
+        LoginHistory.query.filter_by(user_id=user.id)
+        .order_by(LoginHistory.login_date.desc())
+        .limit(7)
+        .all()
+    )
+    if len(last_entries) < 7:
+        return
+
+    expected = login_date
+    for item in last_entries:
+        if item.login_date != expected:
+            return
+        expected -= timedelta(days=1)
+
+    unlock_achievement(user, AchievementCodes.CONECTADO_7D)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,3 +34,12 @@ def test_user(db_session):
     db_session.add(user)
     db_session.commit()
     return user
+
+
+@pytest.fixture
+def another_user(db_session):
+    user = User(username='tester2', email='tester2@example.com')
+    user.set_password('secret')
+    db_session.add(user)
+    db_session.commit()
+    return user

--- a/tests/test_credits.py
+++ b/tests/test_credits.py
@@ -1,5 +1,5 @@
 from crunevo.utils.credits import add_credit, spend_credit
-from crunevo.constants import CreditReasons
+from crunevo.constants import CreditReasons, AchievementCodes
 import pytest
 
 
@@ -24,3 +24,9 @@ def test_spend_credit(db_session, test_user):
 def test_spend_insufficient(db_session, test_user):
     with pytest.raises(ValueError):
         spend_credit(test_user, 1, CreditReasons.COMPRA)
+
+
+def test_donor_achievement(db_session, test_user, another_user):
+    add_credit(test_user, 5, CreditReasons.DONACION)
+    spend_credit(test_user, 5, CreditReasons.DONACION, related_id=another_user.id)
+    assert any(a.badge_code == AchievementCodes.DONADOR for a in test_user.achievements)

--- a/tests/test_login_history.py
+++ b/tests/test_login_history.py
@@ -1,0 +1,19 @@
+from datetime import date, timedelta
+from crunevo.utils.login_history import record_login
+from crunevo.constants import AchievementCodes
+
+
+def test_login_streak_unlocks(db_session, test_user):
+    start = date.today() - timedelta(days=6)
+    for i in range(7):
+        record_login(test_user, start + timedelta(days=i))
+
+    assert any(a.badge_code == AchievementCodes.CONECTADO_7D for a in test_user.achievements)
+
+
+def test_login_streak_not_enough(db_session, test_user):
+    start = date.today() - timedelta(days=5)
+    for i in range(6):
+        record_login(test_user, start + timedelta(days=i))
+
+    assert not any(a.badge_code == AchievementCodes.CONECTADO_7D for a in test_user.achievements)


### PR DESCRIPTION
## Summary
- unlock Donador achievement when credits are voluntarily transferred
- provide a fixture for another test user
- add regression test for Donador achievement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a612e41788325be90994df7658e14