### PR TITLE
Implement like feature for notes

### DIFF
--- a/crunevo/constants/achievement_codes.py
+++ b/crunevo/constants/achievement_codes.py
@@ -4,4 +4,5 @@ class AchievementCodes:
     DONADOR = "donador"
     CONECTADO_7D = "conectado_7d"
     COMPARTIDOR = "compartidor"
+    DESCARGA_100 = "100_descargas"
 

--- a/crunevo/constants/credit_reasons.py
+++ b/crunevo/constants/credit_reasons.py
@@ -3,3 +3,4 @@ class CreditReasons:
     DONACION = "donación"
     COMPRA = "compra"
     AGRADECIMIENTO = "agradecimiento"
+    VOTO_POSITIVO = "voto_positivo"

--- a/crunevo/models/note.py
+++ b/crunevo/models/note.py
@@ -10,6 +10,8 @@ class Note(db.Model):
     tags = db.Column(db.String(200))
     category = db.Column(db.String(100))
     views = db.Column(db.Integer, default=0)
+    downloads = db.Column(db.Integer, default=0)
+    likes = db.Column(db.Integer, default=0)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
     comments = db.relationship('Comment', backref='note', lazy=True)

--- a/crunevo/templates/notes/detalle.html
+++ b/crunevo/templates/notes/detalle.html
@@ -20,7 +20,16 @@
       <span class="badge bg-secondary me-1">{{ tag }}</span>
       {% endfor %}
     </div>
-    <a href="/{{ note.filename }}" class="btn btn-primary mb-3" target="_blank">Descargar</a>
+      <a href="{{ url_for('notes.download_note', note_id=note.id) }}" class="btn btn-primary mb-3" target="_blank">Descargar</a>
+      <form action="{{ url_for('notes.share_note', note_id=note.id) }}" method="post" style="display:inline;">
+        <button class="btn btn-outline-primary btn-sm" type="submit">🔗 Compartir</button>
+      </form>
+      {% if current_user.id != note.author.id %}
+      <form method="post" action="{{ url_for('notes.like_note', note_id=note.id) }}" style="display:inline;">
+        <button class="btn btn-outline-success btn-sm">👍 Me gusta</button>
+      </form>
+      {% endif %}
+      <p><strong>Likes:</strong> {{ note.likes }}</p>
     <div class="ratio ratio-16x9 mb-4">
       <iframe src="/{{ note.filename }}" frameborder="0"></iframe>
     </div>

--- a/migrations/versions/ad2c58317e3c_add_downloads_to_note.py
+++ b/migrations/versions/ad2c58317e3c_add_downloads_to_note.py
@@ -1,0 +1,24 @@
+"""add downloads to note
+
+Revision ID: ad2c58317e3c
+Revises: 25c67a28b1b9
+Create Date: 2025-06-12 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'ad2c58317e3c'
+down_revision = '25c67a28b1b9'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('note', sa.Column('downloads', sa.Integer(), nullable=True, server_default='0'))
+    op.alter_column('note', 'downloads', server_default=None)
+
+
+def downgrade():
+    op.drop_column('note', 'downloads')

--- a/migrations/versions/ee8b2f2a9f0c_add_likes_to_note.py
+++ b/migrations/versions/ee8b2f2a9f0c_add_likes_to_note.py
@@ -1,0 +1,24 @@
+"""add likes to note
+
+Revision ID: ee8b2f2a9f0c
+Revises: ad2c58317e3c
+Create Date: 2025-06-12 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'ee8b2f2a9f0c'
+down_revision = 'ad2c58317e3c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('note', sa.Column('likes', sa.Integer(), nullable=True, server_default='0'))
+    op.alter_column('note', 'likes', server_default=None)
+
+
+def downgrade():
+    op.drop_column('note', 'likes')

--- a/tests/test_achievements.py
+++ b/tests/test_achievements.py
@@ -7,3 +7,23 @@ def test_unlock_achievement(db_session, test_user):
     unlock_achievement(test_user, AchievementCodes.PRIMER_APUNTE)
     assert any(a.badge_code == AchievementCodes.PRIMER_APUNTE for a in test_user.achievements)
 
+
+def test_share_unlocks_sharing_badge(db_session, test_user):
+    unlock_achievement(test_user, AchievementCodes.COMPARTIDOR)
+    assert any(a.badge_code == AchievementCodes.COMPARTIDOR for a in test_user.achievements)
+
+
+def test_downloads_unlocks_badge(db_session, test_user):
+    from crunevo.models import Note
+    note = Note(title="test", author=test_user)
+    db_session.add(note)
+    db_session.commit()
+
+    for _ in range(100):
+        note.downloads += 1
+    db_session.commit()
+
+    unlock_achievement(test_user, AchievementCodes.DESCARGA_100)
+
+    assert any(a.badge_code == AchievementCodes.DESCARGA_100 for a in test_user.achievements)
+

--- a/tests/test_likes.py
+++ b/tests/test_likes.py
@@ -1,0 +1,34 @@
+from crunevo.models import Note
+
+
+def login(client, username, password):
+    return client.post('/login', data={'username': username, 'password': password})
+
+
+def test_like_adds_credit_and_counts(client, db_session, test_user, another_user):
+    note = Note(title="test", author=another_user)
+    db_session.add(note)
+    db_session.commit()
+
+    login(client, 'tester', 'secret')
+    resp = client.post(f'/notes/{note.id}/like')
+    assert resp.status_code == 200
+    assert resp.get_json()['likes'] == 1
+
+    db_session.refresh(note)
+    db_session.refresh(another_user)
+    assert note.likes == 1
+    assert another_user.credits == 1
+
+
+def test_cannot_like_own_note(client, db_session, test_user):
+    note = Note(title="self", author=test_user)
+    db_session.add(note)
+    db_session.commit()
+
+    login(client, 'tester', 'secret')
+    resp = client.post(f'/notes/{note.id}/like')
+    assert resp.status_code == 403
+
+    db_session.refresh(note)
+    assert note.likes == 0


### PR DESCRIPTION
## Summary
- allow users to like notes
- award a credit to the note author for each like
- display like count and button on note detail page
- add migration for `likes` column on notes
- test liking behaviour and credit awarding

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a64e7db4c83258cb3263e5ffb8643