### PR TITLE
UI improvements: dark mode persistence and new components

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Guidelines for Codex agents
+
+- Always run `make fmt` and `make test` before committing.
+- Use Tailwind CSS utilities when updating templates, but keep Bootstrap components unless instructed otherwise.
+- Do not modify models or database migrations unless explicitly requested.
+- The notes blueprint exposes both `notes.detail` and `notes.view_note` for `/notes/<id>`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,4 @@
 - Use Tailwind CSS utilities when updating templates, but keep Bootstrap components unless instructed otherwise.
 - Do not modify models or database migrations unless explicitly requested.
 - The notes blueprint exposes both `notes.detail` and `notes.view_note` for `/notes/<id>`.
+- Merge duplicated `DOMContentLoaded` listeners into a single entry point in `main.js`.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ y se muestra un distintivo en la barra de navegación.
 - Modificar las variables `FEED_LIKE_W`, `FEED_DL_W`, `FEED_COM_W` y
   `FEED_HALF_LIFE_H` para ajustar pesos sin tocar el código.
 
+### Rutas
+
+La ruta `/notes/<id>` responde tanto al endpoint `notes.detail` como a `notes.view_note` (alias para plantillas).
+
 ## Contribuir y correr las pruebas
 
 Instala las dependencias:

--- a/README.md
+++ b/README.md
@@ -97,7 +97,14 @@ y se muestra un distintivo en la barra de navegación.
 
 ### Rutas
 
+
 La ruta `/notes/<id>` responde tanto al endpoint `notes.detail` como a `notes.view_note` (alias para plantillas).
+
+Ejemplo:
+```
+url_for('notes.detail', note_id=42)  => /notes/42
+url_for('notes.view_note', id=42)   => /notes/42
+```
 
 ## Contribuir y correr las pruebas
 

--- a/crunevo/routes/notes_routes.py
+++ b/crunevo/routes/notes_routes.py
@@ -88,6 +88,11 @@ def detail(note_id):
     return render_template("notes/detalle.html", note=note)
 
 
+# Alias endpoint for backward compatibility with templates using
+# `notes.view_note` and parameter name `id`.
+notes_bp.add_url_rule("/<int:id>", endpoint="view_note", view_func=detail)
+
+
 @notes_bp.route("/<int:note_id>/comment", methods=["POST"])
 @activated_required
 def add_comment(note_id):

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -79,8 +79,3 @@ body[data-bs-theme="dark"] {
   transition: .15s ease;
 }
 
-:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 2px var(--primary);
-}
-

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -79,3 +79,8 @@ body[data-bs-theme="dark"] {
   transition: .15s ease;
 }
 
+:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--primary);
+}
+

--- a/crunevo/static/css/tokens.css
+++ b/crunevo/static/css/tokens.css
@@ -29,3 +29,8 @@ h1, h2, h3, h4, h5, h6 {
   font-weight: 600;
 }
 code, pre { font-family: "JetBrains Mono", monospace; }
+
+:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--primary);
+}

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -1,4 +1,7 @@
+// Main entry point
+
 document.addEventListener('DOMContentLoaded', () => {
+  // theme persistence
   const saved = localStorage.getItem('theme');
   if (saved) {
     document.documentElement.dataset.bsTheme = saved;
@@ -10,44 +13,45 @@ document.addEventListener('DOMContentLoaded', () => {
     html.dataset.bsTheme = next;
     localStorage.setItem('theme', next);
   });
-});
 
-// simple AJAX search suggestions
-document.addEventListener('DOMContentLoaded', function(){
+  // simple AJAX search suggestions
   const input = document.getElementById('globalSearchInput');
   const box = document.getElementById('searchSuggestions');
-  if(!input) return;
-  input.addEventListener('input', function(){
-    const q = this.value.trim();
-    if(q.length < 2){ box.innerHTML=''; return; }
-    fetch(`/search?q=${encodeURIComponent(q)}`)
-      .then(r => r.json())
-      .then(data => {
+  if (input) {
+    input.addEventListener('input', function () {
+      const q = this.value.trim();
+      if (q.length < 2) {
         box.innerHTML = '';
-        data.forEach(item => {
-          const a = document.createElement('a');
-          a.className = 'block px-2 py-1 hover:bg-gray-100 dark:hover:bg-gray-700';
-          a.href = item.url;
-          a.textContent = item.title;
-          box.appendChild(a);
+        return;
+      }
+      fetch(`/search?q=${encodeURIComponent(q)}`)
+        .then((r) => r.json())
+        .then((data) => {
+          box.innerHTML = '';
+          data.forEach((item) => {
+            const a = document.createElement('a');
+            a.className = 'block px-2 py-1 hover:bg-gray-100 dark:hover:bg-gray-700';
+            a.href = item.url;
+            a.textContent = item.title;
+            box.appendChild(a);
+          });
         });
-      });
-  });
+    });
 
-  // hide search suggestions on blur
-  input.addEventListener('blur', function(){
-    setTimeout(() => { box.innerHTML = ''; }, 100);
-  });
-});
+    // hide suggestions after blur
+    input.addEventListener('blur', function () {
+      setTimeout(() => {
+        box.innerHTML = '';
+      }, 100);
+    });
+  }
 
-// close mobile menu when a link is clicked
-document.addEventListener('DOMContentLoaded', function(){
-  document.querySelectorAll('.navbar-crunevo .navbar-nav .nav-link').forEach(el => {
+  // close mobile menu when a link is clicked
+  document.querySelectorAll('.navbar-crunevo .navbar-nav .nav-link').forEach((el) => {
     el.addEventListener('click', () => {
       const collapse = document.getElementById('navbarNav');
       const bsCollapse = bootstrap.Collapse.getInstance(collapse);
-      if(bsCollapse) bsCollapse.hide();
+      if (bsCollapse) bsCollapse.hide();
     });
   });
 });
-

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -26,7 +26,7 @@ document.addEventListener('DOMContentLoaded', function(){
         box.innerHTML = '';
         data.forEach(item => {
           const a = document.createElement('a');
-          a.className = 'list-group-item list-group-item-action';
+          a.className = 'block px-2 py-1 hover:bg-gray-100 dark:hover:bg-gray-700';
           a.href = item.url;
           a.textContent = item.title;
           box.appendChild(a);

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -1,19 +1,16 @@
-// dark mode toggle
-(function(){
-  const theme = localStorage.getItem('theme') || 'light';
-  document.documentElement.setAttribute('data-bs-theme', theme);
-  document.addEventListener('DOMContentLoaded', function(){
-    const btn = document.getElementById('themeToggle');
-    if(btn){
-      btn.addEventListener('click', function(){
-        const current = document.documentElement.getAttribute('data-bs-theme');
-        const next = current === 'dark' ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-bs-theme', next);
-        localStorage.setItem('theme', next);
-      });
-    }
+document.addEventListener('DOMContentLoaded', () => {
+  const saved = localStorage.getItem('theme');
+  if (saved) {
+    document.documentElement.dataset.bsTheme = saved;
+  }
+  const toggle = document.getElementById('themeToggle');
+  toggle?.addEventListener('click', () => {
+    const html = document.documentElement;
+    const next = html.dataset.bsTheme === 'dark' ? 'light' : 'dark';
+    html.dataset.bsTheme = next;
+    localStorage.setItem('theme', next);
   });
-})();
+});
 
 // simple AJAX search suggestions
 document.addEventListener('DOMContentLoaded', function(){
@@ -54,8 +51,3 @@ document.addEventListener('DOMContentLoaded', function(){
   });
 });
 
-// simple dark mode toggle using dataset
-document.getElementById('themeToggle')?.addEventListener('click', () => {
-  const html = document.documentElement;
-  html.dataset.bsTheme = html.dataset.bsTheme === 'dark' ? 'light' : 'dark';
-});

--- a/crunevo/templates/auth/login.html
+++ b/crunevo/templates/auth/login.html
@@ -1,13 +1,13 @@
 {% extends 'base.html' %}
+{% import 'components/input.html' as forms %}
+{% import 'components/button.html' as btn %}
 {% block content %}
-<h2>Iniciar sesión</h2>
-<form method="post">
-  <div class="mb-3">
-    <input type="text" name="username" class="form-control" placeholder="Usuario" required>
-  </div>
-  <div class="mb-3">
-    <input type="password" name="password" class="form-control" placeholder="Contraseña" required>
-  </div>
-  <button class="btn btn-primary" type="submit">Entrar</button>
-</form>
+<div class="max-w-md mx-auto my-16 card">
+  <h2>Iniciar sesión</h2>
+  <form method="post" class="space-y-4">
+    {{ forms.input('username', placeholder='Usuario') }}
+    {{ forms.input('password', type='password', placeholder='Contraseña') }}
+    {{ btn.button('Entrar', type='submit') }}
+  </form>
+</div>
 {% endblock %}

--- a/crunevo/templates/auth/register.html
+++ b/crunevo/templates/auth/register.html
@@ -1,16 +1,14 @@
 {% extends 'base.html' %}
+{% import 'components/input.html' as forms %}
+{% import 'components/button.html' as btn %}
 {% block content %}
-<h2>Registro</h2>
-<form method="post">
-  <div class="mb-3">
-    <input type="text" name="username" class="form-control" placeholder="Usuario" required>
-  </div>
-  <div class="mb-3">
-    <input type="email" name="email" class="form-control" placeholder="Email" required>
-  </div>
-  <div class="mb-3">
-    <input type="password" name="password" class="form-control" placeholder="Contraseña" required>
-  </div>
-  <button class="btn btn-primary" type="submit">Registrar</button>
-</form>
+<div class="max-w-md mx-auto my-16 card">
+  <h2>Registro</h2>
+  <form method="post" class="space-y-4">
+    {{ forms.input('username', placeholder='Usuario') }}
+    {{ forms.input('email', type='email', placeholder='Email') }}
+    {{ forms.input('password', type='password', placeholder='Contraseña') }}
+    {{ btn.button('Registrar', type='submit') }}
+  </form>
+</div>
 {% endblock %}

--- a/crunevo/templates/components/button.html
+++ b/crunevo/templates/components/button.html
@@ -1,0 +1,15 @@
+{% macro button(text, href=None, type='button', variant='primary', class='') %}
+{% set base = 'inline-flex items-center justify-center rounded-md px-4 py-2 font-medium transition-transform active:scale-[0.98] focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 ' + class %}
+{% if variant == 'primary' %}
+  {% set classes = base + ' bg-[var(--primary)] text-white' %}
+{% elif variant == 'secondary' %}
+  {% set classes = base + ' bg-gray-100 text-gray-900' %}
+{% else %}
+  {% set classes = base + ' text-[var(--primary)]' %}
+{% endif %}
+{% if href %}
+<a href="{{ href }}" class="{{ classes }}">{{ text }}</a>
+{% else %}
+<button type="{{ type }}" class="{{ classes }}">{{ text }}</button>
+{% endif %}
+{% endmacro %}

--- a/crunevo/templates/components/edu_badge.html
+++ b/crunevo/templates/components/edu_badge.html
@@ -1,1 +1,2 @@
-<span class="inline-flex items-center gap-1 rounded-full bg-[var(--success)]/10 px-2 py-0.5 text-xs font-medium text-[var(--success)]"><i class="bi bi-mortarboard-fill"></i> Verificado</span>
+<style>@keyframes shimmer{from{opacity:.6}to{opacity:1}}</style>
+<span class="inline-flex items-center gap-1 rounded-full bg-[var(--success)]/10 px-2 py-0.5 text-xs font-medium text-[var(--success)]" style="animation:shimmer 1.5s ease-in-out 4s infinite"><i class="bi bi-mortarboard-fill"></i> Verificado</span>

--- a/crunevo/templates/components/input.html
+++ b/crunevo/templates/components/input.html
@@ -1,0 +1,8 @@
+{% macro input(name, type='text', value='', placeholder='', error=None) %}
+<div>
+  <input name="{{ name }}" type="{{ type }}" value="{{ value }}" placeholder="{{ placeholder }}" class="block w-full bg-transparent border-b py-2 outline-none transition-colors {{ 'border-red-500' if error else 'border-gray-300' }} focus:border-[var(--primary)]">
+  {% if error %}
+  <p class="mt-1 text-sm text-red-600">{{ error }}</p>
+  {% endif %}
+</div>
+{% endmacro %}

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -3,7 +3,7 @@
     <a class="navbar-brand" href="{{ url_for('feed.index') }}">Crunevo</a>
   <form class="d-none d-lg-flex mx-4 flex-grow-1 position-relative" id="globalSearchForm">
       <input class="form-control" type="search" placeholder="Buscar" aria-label="Buscar" id="globalSearchInput" autocomplete="off">
-      <div id="searchSuggestions" class="list-group position-absolute w-100"></div>
+      <div id="searchSuggestions" class="absolute left-0 z-10 w-full bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded shadow"></div>
     </form>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
       <span class="navbar-toggler-icon"></span>

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -34,7 +34,7 @@
         {% endif %}
         {% endif %}
           <li class="nav-item">
-            <button id="themeToggle" class="btn btn-sm btn-secondary ml-2" type="button"><i class="bi bi-moon"></i></button>
+            <button id="themeToggle" class="btn btn-sm btn-secondary ml-2 focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2" type="button"><i class="bi bi-moon"></i></button>
           </li>
       </ul>
     </div>

--- a/crunevo/templates/components/note_card.html
+++ b/crunevo/templates/components/note_card.html
@@ -10,5 +10,5 @@
       <li>#{{ tag }}</li>
     {% endfor %}
   </ul>
-  <a href="{{ url_for('notes.detail', note_id=note.id) }}" class="inline-block bg-[var(--primary)] text-white px-3 py-1 rounded">Ver apunte</a>
+  <a href="{{ url_for('notes.view_note', id=note.id) }}" class="inline-block bg-[var(--primary)] text-white px-3 py-1 rounded">Ver apunte</a>
 </article>

--- a/crunevo/templates/notes/detalle.html
+++ b/crunevo/templates/notes/detalle.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
+{% import 'components/button.html' as btn %}
 {% block content %}
-<div class="card mb-3 shadow-sm">
-  <div class="card-body">
+<article class="prose lg:prose-lg mx-auto card">
     <div class="d-flex align-items-center mb-3">
       <img src="{{ note.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
       <div>
@@ -20,7 +20,7 @@
       <span class="badge bg-secondary me-1">{{ tag }}</span>
       {% endfor %}
     </div>
-      <a href="{{ url_for('notes.download_note', note_id=note.id) }}" class="btn btn-primary mb-3" target="_blank">Descargar</a>
+      {{ btn.button('Descargar', href=url_for('notes.download_note', note_id=note.id), class='mb-3') }}
       <form action="{{ url_for('notes.share_note', note_id=note.id) }}" method="post" style="display:inline;">
         <button class="btn btn-outline-primary btn-sm" type="submit">🔗 Compartir</button>
       </form>
@@ -53,8 +53,7 @@
         <button class="btn btn-primary" type="submit">Enviar</button>
       </div>
     </form>
-  </div>
-</div>
+</article>
 <script>
   document.getElementById('commentForm').addEventListener('submit', function(e){
     e.preventDefault();

--- a/crunevo/templates/notes/list.html
+++ b/crunevo/templates/notes/list.html
@@ -32,7 +32,7 @@ document.getElementById('noteSearch').addEventListener('input', function(e){
       data.forEach(n => {
         const div = document.createElement('div');
         div.className = 'col';
-        div.innerHTML = `<div class="card h-100 shadow-sm"><div class="card-body d-flex flex-column"><h6 class="card-title">${n.title}</h6><p class="card-text flex-grow-1">${n.description || ''}</p><a href="/notes/${n.id}" class="btn btn-primary mt-auto">Ver</a></div></div>`;
+        div.innerHTML = `<div class="card h-100 shadow-sm"><div class="card-body d-flex flex-column"><h6 class="card-title">${n.title}</h6><p class="card-text flex-grow-1">${n.description || ''}</p><a href="{{ url_for('notes.view_note', id='__ID__') }}" class="btn btn-primary mt-auto">Ver</a></div></div>`.replace('__ID__', n.id);
         list.appendChild(div);
       });
     });

--- a/crunevo/templates/notes/list.html
+++ b/crunevo/templates/notes/list.html
@@ -16,7 +16,7 @@
       <div class="card-body d-flex flex-column">
         <h6 class="card-title">{{ note.title }}</h6>
         <p class="card-text flex-grow-1">{{ note.description }}</p>
-        <a href="{{ url_for('notes.detail', note_id=note.id) }}" class="btn btn-primary mt-auto">Ver</a>
+        <a href="{{ url_for('notes.view_note', id=note.id) }}" class="btn btn-primary mt-auto">Ver</a>
       </div>
     </div>
   </div>

--- a/crunevo/templates/perfil_publico.html
+++ b/crunevo/templates/perfil_publico.html
@@ -22,7 +22,7 @@
     <ul class="list-group">
       {% for note in user.notes|sort(attribute='created_at', reverse=True)[:5] %}
       <li class="list-group-item d-flex justify-content-between align-items-start">
-        <a href="{{ url_for('notes.detail', note_id=note.id) }}">{{ note.title }}</a>
+        <a href="{{ url_for('notes.view_note', id=note.id) }}">{{ note.title }}</a>
         <small class="text-muted">{{ note.created_at.strftime('%Y-%m-%d') }}</small>
       </li>
       {% endfor %}

--- a/crunevo/templates/store/product_card.html
+++ b/crunevo/templates/store/product_card.html
@@ -1,0 +1,12 @@
+{% import 'components/button.html' as btn %}
+<article class="card lift h-full flex flex-col">
+  <img src="{{ product.image }}" alt="imagen" class="rounded mb-4">
+  <h6 class="font-semibold mb-1">{{ product.name }}</h6>
+  <p class="font-bold">${{ product.price }}</p>
+  {% if product.stock > 0 %}
+    <span class="badge bg-success mb-2">En stock</span>
+  {% else %}
+    <span class="badge mb-2 bg-[var(--accent)]/10 text-[var(--accent)]">Próximamente</span>
+  {% endif %}
+  {{ btn.button('Agregar al carrito', href=url_for('store.add_to_cart', product_id=product.id), class='mt-auto') }}
+</article>

--- a/crunevo/templates/store/store.html
+++ b/crunevo/templates/store/store.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% import 'components/button.html' as btn %}
 {% block content %}
 <h2 class="mb-4">Tienda</h2>
 <div class="row">
@@ -25,24 +26,12 @@
     <div class="row g-3">
       {% for product in products %}
       <div class="col-sm-6 col-md-4">
-        <div class="card h-100">
-          <img src="{{ product.image }}" class="card-img-top" alt="imagen">
-          <div class="card-body d-flex flex-column">
-            <h6 class="card-title">{{ product.name }}</h6>
-            <p class="fw-bold">${{ product.price }}</p>
-            {% if product.stock > 0 %}
-            <span class="badge bg-success mb-2">En stock</span>
-            {% else %}
-            <span class="badge bg-danger mb-2">Agotado</span>
-            {% endif %}
-            <a href="{{ url_for('store.add_to_cart', product_id=product.id) }}" class="btn btn-primary mt-auto">Agregar al carrito</a>
-          </div>
-        </div>
+        {% include 'store/product_card.html' %}
       </div>
       {% endfor %}
     </div>
     <div class="mt-4 text-end">
-      <a href="{{ url_for('store.view_cart') }}" class="btn btn-success">Ver Carrito</a>
+      {{ btn.button('Ver Carrito', href=url_for('store.view_cart'), variant='secondary') }}
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- add Tailwind-based `button` and `input` components
- refresh note detail layout and integrate new button
- center login and register forms with new components
- overhaul store page with reusable product card
- persist selected theme in `main.js`
- add focus-visible ring styling
- fix NoteCard link to use `notes.view_note()` endpoint

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_684b7a49795c83259aeef499ebce2a90