### PR TITLE
Increase registration limit per hour

### DIFF
--- a/crunevo/routes/onboarding_routes.py
+++ b/crunevo/routes/onboarding_routes.py
@@ -39,7 +39,7 @@ def _user_key():
 
 
 @bp.route("/register", methods=["GET", "POST"])
-@limiter.limit("3 per hour")
+@limiter.limit("15 per hour")
 def register():
     if request.method == "POST":
         email = request.form["email"]

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -9,7 +9,7 @@ def test_login_rate_limit(client):
 
 
 def test_register_rate_limit(client):
-    for i in range(3):
+    for i in range(15):
         client.post(
             "/onboarding/register",
             data={"email": f"a{i}@ex.com", "password": "StrongPassw0rd!"},


### PR DESCRIPTION
## Summary
- bump the rate limit for `/onboarding/register` to 15 per hour
- update test to match new rate limit

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684bae6f1d5c8325a55bd771872527dd