### PR TITLE
Fix frontend assets and guest experience

### DIFF
--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -25,9 +25,12 @@ def create_app():
     login_manager.init_app(app)
     mail.init_app(app)
     csrf.init_app(app)
+    limiter._storage_uri = app.config.get("RATELIMIT_STORAGE_URI")
     limiter.init_app(app)
     if app.config.get("ENABLE_TALISMAN", True):
-        csp = None if app.config.get("ENABLE_CSP_OVERRIDE") else DEFAULT_CSP
+        csp = app.config.get("TALISMAN_CSP", DEFAULT_CSP)
+        if app.config.get("ENABLE_CSP_OVERRIDE"):
+            csp = None
         Talisman(
             app,
             content_security_policy=csp,

--- a/crunevo/config.py
+++ b/crunevo/config.py
@@ -48,3 +48,11 @@ class Config:
         "true",
         "yes",
     )
+
+    TALISMAN_CSP = {
+        "default-src": ["'self'", "https://cdn.jsdelivr.net"],
+    }
+
+    RATELIMIT_STORAGE_URI = os.getenv(
+        "RATELIMIT_STORAGE_URI", os.getenv("REDIS_URL", "memory://")
+    )

--- a/crunevo/static/css/fix-bootstrap.css
+++ b/crunevo/static/css/fix-bootstrap.css
@@ -1,0 +1,8 @@
+:root,[data-bs-theme="light"] {
+  --bs-body-bg: #fff;
+  --bs-body-color: #212529;
+}
+[data-bs-theme="dark"] {
+  --bs-body-bg: #121212;
+  --bs-body-color: #f8f9fa;
+}

--- a/crunevo/static/css/tokens.css
+++ b/crunevo/static/css/tokens.css
@@ -21,8 +21,8 @@
 /* typography helpers */
 body {
   font-family: "Inter", system-ui, sans-serif;
-  background: var(--gray-50);
-  color: var(--gray-900);
+  background: var(--bs-body-bg);
+  color: var(--bs-body-color);
 }
 h1, h2, h3, h4, h5, h6 {
   font-family: "Poppins", sans-serif;

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -30,7 +30,7 @@ document.addEventListener('DOMContentLoaded', () => {
           box.innerHTML = '';
           data.forEach((item) => {
             const a = document.createElement('a');
-            a.className = 'block px-2 py-1 hover:bg-gray-100 dark:hover:bg-gray-700';
+            a.className = 'tw-block tw-px-2 tw-py-1 hover:tw-bg-gray-100 dark:hover:tw-bg-gray-700';
             a.href = item.url;
             a.textContent = item.title;
             box.appendChild(a);

--- a/crunevo/static/js/tailwind.config.js
+++ b/crunevo/static/js/tailwind.config.js
@@ -1,0 +1,4 @@
+tailwind.config = {
+  prefix: 'tw-',
+  corePlugins: { preflight: false }
+};

--- a/crunevo/templates/auth/login.html
+++ b/crunevo/templates/auth/login.html
@@ -2,9 +2,9 @@
 {% import 'components/input.html' as forms %}
 {% import 'components/button.html' as btn %}
 {% block content %}
-<div class="max-w-md mx-auto my-16 card">
+<div class="tw-max-w-md tw-mx-auto tw-my-16 card">
   <h2>Iniciar sesión</h2>
-  <form method="post" class="space-y-4">
+  <form method="post" class="tw-space-y-4">
     {{ forms.input('username', placeholder='Usuario') }}
     {{ forms.input('password', type='password', placeholder='Contraseña') }}
     {{ btn.button('Entrar', type='submit') }}

--- a/crunevo/templates/auth/register.html
+++ b/crunevo/templates/auth/register.html
@@ -2,9 +2,9 @@
 {% import 'components/input.html' as forms %}
 {% import 'components/button.html' as btn %}
 {% block content %}
-<div class="max-w-md mx-auto my-16 card">
+<div class="tw-max-w-md tw-mx-auto tw-my-16 card">
   <h2>Registro</h2>
-  <form method="post" class="space-y-4">
+  <form method="post" class="tw-space-y-4">
     {{ forms.input('username', placeholder='Usuario') }}
     {{ forms.input('email', type='email', placeholder='Email') }}
     {{ forms.input('password', type='password', placeholder='Contraseña') }}

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -23,13 +23,12 @@
                 {% include 'components/sidebar_left.html' %}
             </aside>
             <main class="space-y-6">
+                {% import 'components/toast.html' as toast %}
                 {% with messages = get_flashed_messages() %}
                   {% if messages %}
-                    <div class="fixed top-20 inset-x-0 flex justify-center z-50">
+                    <div class="fixed top-20 inset-x-0 z-50 flex flex-col items-center space-y-2">
                       {% for msg in messages %}
-                        <div class="mb-2 w-fit rounded bg-[var(--primary)]/10 px-4 py-2 text-[var(--primary)] shadow">
-                          {{ msg }}
-                        </div>
+                        {{ toast.toast(msg) }}
                       {% endfor %}
                     </div>
                   {% endif %}

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -10,23 +10,25 @@
     <title>Crunevo</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-SdVqqpzI4InENcy9XK6u+YIY7M1bRnwV0w8AV/QXp1S8MaqkOawxjUY8ailqXF/w" crossorigin="anonymous">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+    <script src="{{ url_for('static', filename='js/tailwind.config.js') }}"></script>
     <script src="https://cdn.tailwindcss.com?plugins=forms,typography" defer></script>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/tokens.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/fix-bootstrap.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/navbar.css') }}">
 </head>
 <body class="d-flex flex-column min-vh-100">
     {% include 'components/navbar.html' %}
     <div class="container-fluid mt-5 pt-3">
-        <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
-            <aside class="hidden lg:block">
+        <div class="row gx-4">
+            <aside class="d-none d-lg-block col-lg-3">
                 {% include 'components/sidebar_left.html' %}
             </aside>
-            <main class="space-y-6">
+            <main class="col-lg-6 tw-space-y-6">
                 {% import 'components/toast.html' as toast %}
                 {% with messages = get_flashed_messages() %}
                   {% if messages %}
-                    <div class="fixed top-20 inset-x-0 z-50 flex flex-col items-center space-y-2">
+                    <div class="fixed top-20 inset-x-0 z-50 tw-flex tw-flex-col tw-items-center tw-space-y-2">
                       {% for msg in messages %}
                         {{ toast.toast(msg) }}
                       {% endfor %}
@@ -35,7 +37,7 @@
                 {% endwith %}
                 {% block content %}{% endblock %}
             </main>
-            <aside class="hidden lg:block">
+            <aside class="d-none d-lg-block col-lg-3">
                 {% include 'components/sidebar_right.html' %}
             </aside>
         </div>

--- a/crunevo/templates/components/button.html
+++ b/crunevo/templates/components/button.html
@@ -1,11 +1,11 @@
 {% macro button(text, href=None, type='button', variant='primary', class='') %}
-{% set base = 'inline-flex items-center justify-center rounded-md px-4 py-2 font-medium transition-transform active:scale-[0.98] focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 ' + class %}
+{% set base = 'tw-inline-flex tw-items-center tw-justify-center tw-rounded-md tw-px-4 tw-py-2 tw-font-medium tw-transition-transform active:tw-scale-[0.98] focus-visible:tw-ring-2 focus-visible:tw-ring-[var(--primary)] focus-visible:tw-ring-offset-2 ' + class %}
 {% if variant == 'primary' %}
-  {% set classes = base + ' bg-[var(--primary)] text-white' %}
+  {% set classes = 'btn btn-primary ' + base %}
 {% elif variant == 'secondary' %}
-  {% set classes = base + ' bg-gray-100 text-gray-900' %}
+  {% set classes = 'btn btn-secondary ' + base %}
 {% else %}
-  {% set classes = base + ' text-[var(--primary)]' %}
+  {% set classes = 'btn btn-link tw-text-[var(--primary)] ' + base %}
 {% endif %}
 {% if href %}
 <a href="{{ href }}" class="{{ classes }}">{{ text }}</a>

--- a/crunevo/templates/components/edu_badge.html
+++ b/crunevo/templates/components/edu_badge.html
@@ -1,2 +1,2 @@
 <style>@keyframes shimmer{from{opacity:.6}to{opacity:1}}</style>
-<span class="inline-flex items-center gap-1 rounded-full bg-[var(--success)]/10 px-2 py-0.5 text-xs font-medium text-[var(--success)]" style="animation:shimmer 1.5s ease-in-out 4s infinite"><i class="bi bi-mortarboard-fill"></i> Verificado</span>
+<span class="tw-inline-flex tw-items-center tw-gap-1 tw-rounded-full tw-bg-[var(--success)]/10 tw-px-2 tw-py-0.5 tw-text-xs tw-font-medium tw-text-[var(--success)]" style="animation:shimmer 1.5s ease-in-out 4s infinite"><i class="bi bi-mortarboard-fill"></i> Verificado</span>

--- a/crunevo/templates/components/input.html
+++ b/crunevo/templates/components/input.html
@@ -1,12 +1,12 @@
 {% macro input(name, type='text', value='', placeholder='', error=None) %}
-<div>
+<div class="mb-3">
   {% if type == 'file' %}
   <input name="{{ name }}" type="file" class="form-control" />
   {% else %}
-  <input name="{{ name }}" type="{{ type }}" value="{{ value }}" placeholder="{{ placeholder }}" class="block w-full bg-transparent border-b py-2 outline-none transition-colors {{ 'border-red-500' if error else 'border-gray-300' }} focus:border-[var(--primary)]">
+  <input name="{{ name }}" type="{{ type }}" value="{{ value }}" placeholder="{{ placeholder }}" class="form-control tw-bg-transparent tw-border-b tw-outline-none tw-transition-colors {{ 'tw-border-red-500' if error else 'tw-border-gray-300' }} focus:tw-border-[var(--primary)]">
   {% endif %}
   {% if error %}
-  <p class="mt-1 text-sm text-red-600">{{ error }}</p>
+  <div class="invalid-feedback d-block">{{ error }}</div>
   {% endif %}
 </div>
 {% endmacro %}

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -3,7 +3,7 @@
     <a class="navbar-brand" href="{{ url_for('feed.index') }}">Crunevo</a>
   <form class="d-none d-lg-flex mx-4 flex-grow-1 position-relative" id="globalSearchForm">
       <input class="form-control" type="search" placeholder="Buscar" aria-label="Buscar" id="globalSearchInput" autocomplete="off">
-      <div id="searchSuggestions" class="absolute left-0 z-10 w-full bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded shadow"></div>
+      <div id="searchSuggestions" class="tw-absolute tw-left-0 tw-z-10 tw-w-full tw-bg-white dark:tw-bg-gray-800 tw-border tw-border-gray-200 dark:tw-border-gray-700 tw-rounded tw-shadow"></div>
     </form>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
       <span class="navbar-toggler-icon"></span>
@@ -36,7 +36,7 @@
         {% endif %}
         {% endif %}
           <li class="nav-item">
-            <button id="themeToggle" class="btn btn-sm btn-secondary ml-2 focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2" type="button"><i class="bi bi-moon"></i></button>
+            <button id="themeToggle" class="btn btn-sm btn-secondary ml-2 focus-visible:tw-ring-2 focus-visible:tw-ring-[var(--primary)] focus-visible:tw-ring-offset-2" type="button"><i class="bi bi-moon"></i></button>
           </li>
       </ul>
     </div>

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -24,7 +24,9 @@
         <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.perfil') }}"><i class="bi bi-person-circle"></i></a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.logout') }}"><i class="bi bi-box-arrow-right"></i></a></li>
         {% else %}
-        <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.login') }}"><i class="bi bi-box-arrow-in-right"></i></a></li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('auth.login') }}">Iniciar sesión</a>
+        </li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('onboarding.register') }}">Registrarse</a></li>
         {% endif %}
         {% if current_user.is_authenticated %}

--- a/crunevo/templates/components/note_card.html
+++ b/crunevo/templates/components/note_card.html
@@ -1,14 +1,14 @@
 <article class="card lift mb-6">
   {% if note.thumbnail_url %}
-    <img src="{{ note.thumbnail_url }}" alt="preview" class="rounded mb-4 w-full">
+    <img src="{{ note.thumbnail_url }}" alt="preview" class="tw-rounded mb-4 tw-w-full">
   {% else %}
-    <img src="{{ url_for('static', filename='img/placeholder.svg') }}" alt="preview" class="rounded mb-4 w-full">
+    <img src="{{ url_for('static', filename='img/placeholder.svg') }}" alt="preview" class="tw-rounded mb-4 tw-w-full">
   {% endif %}
-  <h3 class="text-lg font-semibold mb-2">{{ note.title }}</h3>
-  <ul class="flex flex-wrap gap-1 text-sm text-gray-500 mb-4">
+  <h3 class="tw-text-lg tw-font-semibold mb-2">{{ note.title }}</h3>
+  <ul class="tw-flex tw-flex-wrap tw-gap-1 tw-text-sm tw-text-gray-500 mb-4">
     {% for tag in note.tags.split(',') if note.tags %}
       <li>#{{ tag }}</li>
     {% endfor %}
   </ul>
-  <a href="{{ url_for('notes.view_note', id=note.id) }}" class="inline-block bg-[var(--primary)] text-white px-3 py-1 rounded">Ver apunte</a>
+  <a href="{{ url_for('notes.view_note', id=note.id) }}" class="tw-inline-block tw-bg-[var(--primary)] tw-text-white tw-px-3 tw-py-1 tw-rounded">Ver apunte</a>
 </article>

--- a/crunevo/templates/components/post_card.html
+++ b/crunevo/templates/components/post_card.html
@@ -1,7 +1,7 @@
 <article class="card lift mb-6">
   {% if post.image_url %}
-    <img src="{{ post.image_url }}" alt="imagen" class="rounded mb-4 w-full">
+    <img src="{{ post.image_url }}" alt="imagen" class="tw-rounded mb-4 tw-w-full">
   {% endif %}
   <p class="mb-4">{{ post.content }}</p>
-  <a href="#comentarios" class="inline-block bg-[var(--primary)] text-white px-3 py-1 rounded">Comentar</a>
+  <a href="#comentarios" class="tw-inline-block tw-bg-[var(--primary)] tw-text-white tw-px-3 tw-py-1 tw-rounded">Comentar</a>
 </article>

--- a/crunevo/templates/components/toast.html
+++ b/crunevo/templates/components/toast.html
@@ -1,3 +1,5 @@
-<div class="toast" role="alert">
-  <div class="toast-body">{{ message }}</div>
+{% macro toast(message) %}
+<div class="rounded bg-[var(--primary)]/10 px-4 py-2 text-[var(--primary)] shadow">
+  {{ message }}
 </div>
+{% endmacro %}

--- a/crunevo/templates/components/toast.html
+++ b/crunevo/templates/components/toast.html
@@ -1,5 +1,5 @@
 {% macro toast(message) %}
-<div class="rounded bg-[var(--primary)]/10 px-4 py-2 text-[var(--primary)] shadow">
+<div class="tw-rounded tw-bg-[var(--primary)]/10 tw-px-4 tw-py-2 tw-text-[var(--primary)] tw-shadow">
   {{ message }}
 </div>
 {% endmacro %}

--- a/crunevo/templates/notes/upload.html
+++ b/crunevo/templates/notes/upload.html
@@ -2,9 +2,9 @@
 {% import 'components/input.html' as forms %}
 {% import 'components/button.html' as btn %}
 {% block content %}
-<div class="max-w-lg mx-auto my-16 card">
+<div class="tw-max-w-lg tw-mx-auto tw-my-16 card">
   <h2>Subir Apunte</h2>
-  <form method="post" enctype="multipart/form-data" class="space-y-4">
+  <form method="post" enctype="multipart/form-data" class="tw-space-y-4">
     {{ forms.input('title', placeholder='Título') }}
     <div>
       <textarea name="description" class="form-control" placeholder="Descripción"></textarea>

--- a/crunevo/templates/onboarding/finish.html
+++ b/crunevo/templates/onboarding/finish.html
@@ -2,9 +2,9 @@
 {% import 'components/input.html' as forms %}
 {% import 'components/button.html' as btn %}
 {% block content %}
-<div class="max-w-lg mx-auto my-16 card">
+<div class="tw-max-w-lg tw-mx-auto tw-my-16 card">
   <h2>Completa tu perfil</h2>
-  <form method="post" class="space-y-4">
+  <form method="post" class="tw-space-y-4">
     {{ forms.input('alias', placeholder='Alias') }}
     {{ forms.input('avatar', placeholder='URL del avatar') }}
     <div>

--- a/crunevo/templates/onboarding/pending.html
+++ b/crunevo/templates/onboarding/pending.html
@@ -1,9 +1,9 @@
 {% extends 'base.html' %}
 {% import 'components/button.html' as btn %}
 {% block content %}
-<div class="max-w-lg mx-auto my-16 card space-y-4 text-center">
+<div class="tw-max-w-lg tw-mx-auto tw-my-16 card tw-space-y-4 tw-text-center">
   <p>Confirma tu correo para continuar.</p>
-  <form method="post" action="{{ url_for('onboarding.resend') }}" class="space-y-4">
+  <form method="post" action="{{ url_for('onboarding.resend') }}" class="tw-space-y-4">
     {{ btn.button('Reenviar correo', type='submit') }}
   </form>
   {{ btn.button('Volver al inicio', href=url_for('index')) }}

--- a/crunevo/templates/onboarding/register.html
+++ b/crunevo/templates/onboarding/register.html
@@ -1,13 +1,17 @@
 {% extends 'base.html' %}
+{% import 'components/input.html' as forms %}
+{% import 'components/button.html' as btn %}
 {% block content %}
-<h2>Registro</h2>
-<form method="post">
-  <div class="mb-3">
-    <input type="email" name="email" class="form-control" placeholder="Email" required>
-  </div>
-  <div class="mb-3">
-    <input type="password" name="password" class="form-control" placeholder="Contraseña" required>
-  </div>
-  <button class="btn btn-primary" type="submit">Crear cuenta</button>
-</form>
+<div class="max-w-md mx-auto my-16 card">
+  <h2>Registro</h2>
+  <form method="post" class="space-y-4">
+    {{ forms.input('email', type='email', placeholder='Email') }}
+    {{ forms.input('password', type='password', placeholder='Contraseña') }}
+    {{ btn.button('Crear cuenta', type='submit') }}
+  </form>
+  <p class="mt-4 text-center text-sm">
+    ¿Ya tienes cuenta?
+    <a href="{{ url_for('auth.login') }}" class="text-[var(--primary)] underline">Inicia sesión</a>
+  </p>
+</div>
 {% endblock %}

--- a/crunevo/templates/onboarding/register.html
+++ b/crunevo/templates/onboarding/register.html
@@ -2,16 +2,16 @@
 {% import 'components/input.html' as forms %}
 {% import 'components/button.html' as btn %}
 {% block content %}
-<div class="max-w-md mx-auto my-16 card">
+<div class="tw-max-w-md tw-mx-auto tw-my-16 card">
   <h2>Registro</h2>
-  <form method="post" class="space-y-4">
+  <form method="post" class="tw-space-y-4">
     {{ forms.input('email', type='email', placeholder='Email') }}
     {{ forms.input('password', type='password', placeholder='Contraseña') }}
     {{ btn.button('Crear cuenta', type='submit') }}
   </form>
-  <p class="mt-4 text-center text-sm">
+  <p class="mt-4 tw-text-center tw-text-sm">
     ¿Ya tienes cuenta?
-    <a href="{{ url_for('auth.login') }}" class="text-[var(--primary)] underline">Inicia sesión</a>
+    <a href="{{ url_for('auth.login') }}" class="tw-text-[var(--primary)] tw-underline">Inicia sesión</a>
   </p>
 </div>
 {% endblock %}

--- a/crunevo/templates/store/product_card.html
+++ b/crunevo/templates/store/product_card.html
@@ -1,12 +1,12 @@
 {% import 'components/button.html' as btn %}
-<article class="card lift h-full flex flex-col">
-  <img src="{{ product.image }}" alt="imagen" class="rounded mb-4">
-  <h6 class="font-semibold mb-1">{{ product.name }}</h6>
+<article class="card lift h-full tw-flex tw-flex-col">
+  <img src="{{ product.image }}" alt="imagen" class="tw-rounded mb-4">
+  <h6 class="tw-font-semibold mb-1">{{ product.name }}</h6>
   <p class="font-bold">${{ product.price }}</p>
   {% if product.stock > 0 %}
     <span class="badge bg-success mb-2">En stock</span>
   {% else %}
-    <span class="badge mb-2 bg-[var(--accent)]/10 text-[var(--accent)]">Próximamente</span>
+    <span class="badge mb-2 tw-bg-[var(--accent)]/10 tw-text-[var(--accent)]">Próximamente</span>
   {% endif %}
   {{ btn.button('Agregar al carrito', href=url_for('store.add_to_cart', product_id=product.id), class='mt-auto') }}
 </article>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ import fakeredis
 def app():
     os.environ["DATABASE_URL"] = "sqlite:///:memory:"
     os.environ["ENABLE_TALISMAN"] = "0"
+    os.environ["RATELIMIT_STORAGE_URI"] = "memory://"
     app = create_app()
     app.config["TESTING"] = True
     app.config["MAIL_SUPPRESS_SEND"] = True


### PR DESCRIPTION
## Summary
- relax CSP to allow CDN for jsDelivr
- improve navbar guest link and toast container
- modernize onboarding register form
- configure Limiter storage via RATELIMIT_STORAGE_URI
- extract toast component and link register → login

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_684bbec76fe48325a5db666bd12fe402