### PR TITLE
Add CSRF helper and enable tokens in forms

### DIFF
--- a/crunevo/templates/admin/add_edit_product.html
+++ b/crunevo/templates/admin/add_edit_product.html
@@ -1,7 +1,9 @@
 {% extends 'base.html' %}
+{% import 'components/csrf.html' as csrf %}
 {% block content %}
 <h2>Agregar/Editar Producto</h2>
 <form method="post" enctype="multipart/form-data">
+  {{ csrf.csrf_field() }}
   <div class="mb-3"><input type="text" name="name" class="form-control" placeholder="Nombre" required></div>
   <div class="mb-3"><textarea name="description" class="form-control" placeholder="Descripción"></textarea></div>
   <div class="mb-3"><input type="number" step="0.01" name="price" class="form-control" placeholder="Precio" required></div>

--- a/crunevo/templates/admin/verifications.html
+++ b/crunevo/templates/admin/verifications.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% import 'components/csrf.html' as csrf %}
 {% block content %}
 <h2>Verificaciones pendientes</h2>
 <table class="table">
@@ -11,7 +12,7 @@
     <td>{{ u.email }}</td>
     <td>
       <form action="{{ url_for('admin.approve_user', user_id=u.id) }}" method="post" class="d-inline">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        {{ csrf.csrf_field() }}
         <button class="btn btn-success btn-sm" type="submit">&#x2705;</button>
       </form>
     </td>

--- a/crunevo/templates/auth/login.html
+++ b/crunevo/templates/auth/login.html
@@ -1,10 +1,12 @@
 {% extends 'base.html' %}
 {% import 'components/input.html' as forms %}
 {% import 'components/button.html' as btn %}
+{% import 'components/csrf.html' as csrf %}
 {% block content %}
 <div class="tw-max-w-md tw-mx-auto tw-my-16 card">
   <h2>Iniciar sesión</h2>
   <form method="post" class="tw-space-y-4">
+    {{ csrf.csrf_field() }}
     {{ forms.input('username', placeholder='Usuario') }}
     {{ forms.input('password', type='password', placeholder='Contraseña') }}
     {{ btn.button('Entrar', type='submit') }}

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% import 'components/csrf.html' as csrf %}
 {% block content %}
 <h2>Mi perfil</h2>
 <div class="mb-3 text-center">
@@ -7,6 +8,7 @@
   <p>💰 Créditos: {{ current_user.credits }}</p>
 </div>
 <form method="post">
+  {{ csrf.csrf_field() }}
   <div class="mb-3">
     <textarea class="form-control" name="about" placeholder="Sobre mí">{{ current_user.about }}</textarea>
   </div>

--- a/crunevo/templates/auth/register.html
+++ b/crunevo/templates/auth/register.html
@@ -1,10 +1,12 @@
 {% extends 'base.html' %}
 {% import 'components/input.html' as forms %}
 {% import 'components/button.html' as btn %}
+{% import 'components/csrf.html' as csrf %}
 {% block content %}
 <div class="tw-max-w-md tw-mx-auto tw-my-16 card">
   <h2>Registro</h2>
   <form method="post" class="tw-space-y-4">
+    {{ csrf.csrf_field() }}
     {{ forms.input('username', placeholder='Usuario') }}
     {{ forms.input('email', type='email', placeholder='Email') }}
     {{ forms.input('password', type='password', placeholder='Contraseña') }}

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
     <!-- Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/crunevo/templates/chat/chat.html
+++ b/crunevo/templates/chat/chat.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% import 'components/csrf.html' as csrf %}
 {% block content %}
 <h2 class="mb-3">Chat</h2>
 <div class="row">
@@ -12,6 +13,7 @@
   <div class="col-lg-8">
     <div id="chatBox" class="border rounded p-2 mb-2 chat-container"></div>
     <form id="chatForm">
+      {{ csrf.csrf_field() }}
       <input type="hidden" name="receiver_id" id="receiver_id">
       <div class="input-group">
         <input type="text" name="content" class="form-control" placeholder="Mensaje">
@@ -28,7 +30,14 @@
   });
   document.getElementById('chatForm').addEventListener('submit', e=>{
     e.preventDefault();
-    fetch('{{ url_for('chat.send_message') }}', {method:'POST', body:new FormData(e.target)})
+    fetch('{{ url_for('chat.send_message') }}', {
+      method:'POST',
+      body:new FormData(e.target),
+      headers: {
+        'X-Requested-With': 'XMLHttpRequest',
+        'X-CSRFToken': document.querySelector('input[name="csrf_token"]').value
+      }
+    })
       .then(r=>r.json()).then(()=>{
         const box = document.getElementById('chatBox');
         const div = document.createElement('div');

--- a/crunevo/templates/components/csrf.html
+++ b/crunevo/templates/components/csrf.html
@@ -1,0 +1,3 @@
+{% macro csrf_field() -%}
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+{%- endmacro %}

--- a/crunevo/templates/feed/feed.html
+++ b/crunevo/templates/feed/feed.html
@@ -1,7 +1,9 @@
 {% extends 'base.html' %}
+{% import 'components/csrf.html' as csrf %}
 {% block content %}
 <h5 class="mb-3">Feed</h5>
 <form method="post" enctype="multipart/form-data" class="mb-4">
+  {{ csrf.csrf_field() }}
   <textarea name="content" class="form-control mb-2" placeholder="Comparte una idea" required></textarea>
   <input type="file" name="image" class="form-control mb-2">
   <button class="btn btn-primary" type="submit">Publicar</button>

--- a/crunevo/templates/notes/detalle.html
+++ b/crunevo/templates/notes/detalle.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% import 'components/button.html' as btn %}
+{% import 'components/csrf.html' as csrf %}
 {% block content %}
 <article class="prose lg:prose-lg mx-auto card">
     <div class="d-flex align-items-center mb-3">
@@ -22,10 +23,12 @@
     </div>
       {{ btn.button('Descargar', href=url_for('notes.download_note', note_id=note.id), class='mb-3') }}
       <form action="{{ url_for('notes.share_note', note_id=note.id) }}" method="post" style="display:inline;">
+        {{ csrf.csrf_field() }}
         <button class="btn btn-outline-primary btn-sm" type="submit">🔗 Compartir</button>
       </form>
       {% if current_user.id != note.author.id %}
       <form method="post" action="{{ url_for('notes.like_note', note_id=note.id) }}" style="display:inline;">
+        {{ csrf.csrf_field() }}
         <button class="btn btn-outline-success btn-sm">👍 Me gusta</button>
       </form>
       {% endif %}
@@ -48,6 +51,7 @@
       {% endfor %}
     </div>
     <form id="commentForm" class="mt-3">
+      {{ csrf.csrf_field() }}
       <div class="input-group">
         <input type="text" name="body" class="form-control" placeholder="Añadir comentario" required>
         <button class="btn btn-primary" type="submit">Enviar</button>
@@ -61,7 +65,10 @@
     fetch('{{ url_for('notes.add_comment', note_id=note.id) }}', {
       method: 'POST',
       body: data,
-      headers: {'X-Requested-With': 'XMLHttpRequest'}
+      headers: {
+        'X-Requested-With': 'XMLHttpRequest',
+        'X-CSRFToken': document.querySelector('input[name="csrf_token"]').value
+      }
     }).then(r => r.json()).then(c => {
       const div = document.createElement('div');
       div.className = 'd-flex mb-3 comment';

--- a/crunevo/templates/notes/upload.html
+++ b/crunevo/templates/notes/upload.html
@@ -1,10 +1,12 @@
 {% extends 'base.html' %}
 {% import 'components/input.html' as forms %}
 {% import 'components/button.html' as btn %}
+{% import 'components/csrf.html' as csrf %}
 {% block content %}
 <div class="tw-max-w-lg tw-mx-auto tw-my-16 card">
   <h2>Subir Apunte</h2>
   <form method="post" enctype="multipart/form-data" class="tw-space-y-4">
+    {{ csrf.csrf_field() }}
     {{ forms.input('title', placeholder='Título') }}
     <div>
       <textarea name="description" class="form-control" placeholder="Descripción"></textarea>

--- a/crunevo/templates/onboarding/finish.html
+++ b/crunevo/templates/onboarding/finish.html
@@ -1,10 +1,12 @@
 {% extends 'base.html' %}
 {% import 'components/input.html' as forms %}
 {% import 'components/button.html' as btn %}
+{% import 'components/csrf.html' as csrf %}
 {% block content %}
 <div class="tw-max-w-lg tw-mx-auto tw-my-16 card">
   <h2>Completa tu perfil</h2>
   <form method="post" class="tw-space-y-4">
+    {{ csrf.csrf_field() }}
     {{ forms.input('alias', placeholder='Alias') }}
     {{ forms.input('avatar', placeholder='URL del avatar') }}
     <div>

--- a/crunevo/templates/onboarding/pending.html
+++ b/crunevo/templates/onboarding/pending.html
@@ -1,9 +1,11 @@
 {% extends 'base.html' %}
 {% import 'components/button.html' as btn %}
+{% import 'components/csrf.html' as csrf %}
 {% block content %}
 <div class="tw-max-w-lg tw-mx-auto tw-my-16 card tw-space-y-4 tw-text-center">
   <p>Confirma tu correo para continuar.</p>
   <form method="post" action="{{ url_for('onboarding.resend') }}" class="tw-space-y-4">
+    {{ csrf.csrf_field() }}
     {{ btn.button('Reenviar correo', type='submit') }}
   </form>
   {{ btn.button('Volver al inicio', href=url_for('index')) }}

--- a/crunevo/templates/onboarding/register.html
+++ b/crunevo/templates/onboarding/register.html
@@ -1,10 +1,12 @@
 {% extends 'base.html' %}
 {% import 'components/input.html' as forms %}
 {% import 'components/button.html' as btn %}
+{% import 'components/csrf.html' as csrf %}
 {% block content %}
 <div class="tw-max-w-md tw-mx-auto tw-my-16 card">
   <h2>Registro</h2>
   <form method="post" class="tw-space-y-4">
+    {{ csrf.csrf_field() }}
     {{ forms.input('email', type='email', placeholder='Email') }}
     {{ forms.input('password', type='password', placeholder='Contraseña') }}
     {{ btn.button('Crear cuenta', type='submit') }}

--- a/crunevo/templates/perfil_publico.html
+++ b/crunevo/templates/perfil_publico.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% import 'components/csrf.html' as csrf %}
 {% block content %}
 <div class="row g-4">
   <div class="col-md-4 text-center">
@@ -6,6 +7,7 @@
     {% if current_user.is_authenticated and current_user.id != user.id %}
     <button class="btn btn-primary btn-sm">Seguir</button>
     <form method="post" action="{{ url_for('auth.agradecer', user_id=user.id) }}" class="d-inline">
+      {{ csrf.csrf_field() }}
       <button class="btn btn-success btn-sm" type="submit">Agradecer con 1 crédito</button>
     </form>
     {% endif %}

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -1,0 +1,19 @@
+from bs4 import BeautifulSoup
+from crunevo.models import User
+
+
+def test_login_csrf(app, db_session):
+    app.config["WTF_CSRF_ENABLED"] = True
+    client = app.test_client()
+    user = User(username="csrf", email="c@example.com", activated=True)
+    user.set_password("secret")
+    db_session.add(user)
+    db_session.commit()
+    resp = client.get("/login")
+    soup = BeautifulSoup(resp.data, "html.parser")
+    token = soup.find("input", {"name": "csrf_token"})["value"]
+    resp = client.post(
+        "/login",
+        data={"username": user.username, "password": "secret", "csrf_token": token},
+    )
+    assert resp.status_code == 302


### PR DESCRIPTION
## Summary
- add reusable csrf_field macro
- include CSRF hidden inputs for all POST forms
- send CSRF token on AJAX requests
- expose token in meta tag
- add regression test for login with CSRF enabled

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684bd377141083258a95564604dcfec4