### PR TITLE
Add CSRF helper and regression checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,5 @@
 - Do not modify models or database migrations unless explicitly requested.
 - The notes blueprint exposes both `notes.detail` and `notes.view_note` for `/notes/<id>`.
 - Merge duplicated `DOMContentLoaded` listeners into a single entry point in `main.js`.
+- All `<form method="post">` must import `components/csrf.html` and call
+  `csrf_field()` immediately after the `<form>` tag.

--- a/README.md
+++ b/README.md
@@ -131,3 +131,14 @@ código automáticamente antes de cada commit:
 pre-commit install
 ```
 
+## Configuración
+
+La clave CSRF (`FLASK_WTF_SECRET_KEY`) suele ser la misma que `SECRET_KEY`.
+En producción la protección CSRF está siempre habilitada.
+
+Si necesitas el token desde JavaScript puedes leerlo con:
+
+```javascript
+document.querySelector('meta[name="csrf-token"]').content;
+```
+

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -1,10 +1,11 @@
-from flask import Flask
+from flask import Flask, request, redirect, url_for, flash
 import logging
 from logging.handlers import RotatingFileHandler
 import os
 
 from .extensions import db, login_manager, migrate, mail, csrf, limiter
 from flask_talisman import Talisman
+from flask_wtf.csrf import CSRFError
 
 DEFAULT_CSP = {
     "default-src": "'self'",
@@ -107,6 +108,11 @@ def create_app():
     app.register_blueprint(admin_bp)
     app.register_blueprint(ranking_bp)
     app.register_blueprint(errors_bp)
+
+    @app.errorhandler(CSRFError)
+    def handle_csrf_error(e):
+        flash("La sesión expiró, vuelve a intentarlo.", "danger")
+        return redirect(request.referrer or url_for("feed.index")), 302
 
     if os.getenv("SCHEDULER") == "1":
         from apscheduler.schedulers.background import BackgroundScheduler

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -1,5 +1,15 @@
 // Main entry point
 
+function csrfFetch(url, options = {}) {
+  const token = document.querySelector('meta[name="csrf-token"]').content;
+  const headers = {
+    'X-CSRFToken': token,
+    'X-Requested-With': 'XMLHttpRequest',
+    ...(options.headers || {}),
+  };
+  return fetch(url, { ...options, headers });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   // theme persistence
   const saved = localStorage.getItem('theme');

--- a/crunevo/templates/chat/chat.html
+++ b/crunevo/templates/chat/chat.html
@@ -30,13 +30,9 @@
   });
   document.getElementById('chatForm').addEventListener('submit', e=>{
     e.preventDefault();
-    fetch('{{ url_for('chat.send_message') }}', {
+    csrfFetch('{{ url_for('chat.send_message') }}', {
       method:'POST',
-      body:new FormData(e.target),
-      headers: {
-        'X-Requested-With': 'XMLHttpRequest',
-        'X-CSRFToken': document.querySelector('input[name="csrf_token"]').value
-      }
+      body:new FormData(e.target)
     })
       .then(r=>r.json()).then(()=>{
         const box = document.getElementById('chatBox');

--- a/crunevo/templates/notes/detalle.html
+++ b/crunevo/templates/notes/detalle.html
@@ -62,13 +62,9 @@
   document.getElementById('commentForm').addEventListener('submit', function(e){
     e.preventDefault();
     const data = new FormData(this);
-    fetch('{{ url_for('notes.add_comment', note_id=note.id) }}', {
+    csrfFetch('{{ url_for('notes.add_comment', note_id=note.id) }}', {
       method: 'POST',
-      body: data,
-      headers: {
-        'X-Requested-With': 'XMLHttpRequest',
-        'X-CSRFToken': document.querySelector('input[name="csrf_token"]').value
-      }
+      body: data
     }).then(r => r.json()).then(c => {
       const div = document.createElement('div');
       div.className = 'd-flex mb-3 comment';

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -1,19 +1,29 @@
 from bs4 import BeautifulSoup
-from crunevo.models import User
+from pathlib import Path
+import re
 
 
-def test_login_csrf(app, db_session):
+def test_login_csrf(app, db_session, client, test_user):
     app.config["WTF_CSRF_ENABLED"] = True
-    client = app.test_client()
-    user = User(username="csrf", email="c@example.com", activated=True)
-    user.set_password("secret")
-    db_session.add(user)
-    db_session.commit()
     resp = client.get("/login")
     soup = BeautifulSoup(resp.data, "html.parser")
     token = soup.find("input", {"name": "csrf_token"})["value"]
     resp = client.post(
         "/login",
-        data={"username": user.username, "password": "secret", "csrf_token": token},
+        data={
+            "username": test_user.username,
+            "password": "secret",
+            "csrf_token": token,
+        },
     )
     assert resp.status_code == 302
+
+
+def test_post_forms_have_csrf_macro():
+    pattern = re.compile(r'<form[^>]*method=["\']post["\'][^>]*>', re.IGNORECASE)
+    missing = []
+    for path in Path("crunevo/templates").rglob("*.html"):
+        text = path.read_text()
+        if pattern.search(text) and "{{ csrf.csrf_field() }}" not in text:
+            missing.append(str(path))
+    assert not missing, "Missing csrf_field in: " + ", ".join(missing)

--- a/tests/test_user_verification.py
+++ b/tests/test_user_verification.py
@@ -104,7 +104,7 @@ def test_admin_verification_csrf(client, db_session):
         token = _get_csrf_token(page)
 
         assert (
-            client.post(f"/admin/verificaciones/{user.id}/approve").status_code == 400
+            client.post(f"/admin/verificaciones/{user.id}/approve").status_code == 302
         )
 
         resp = client.post(


### PR DESCRIPTION
## Summary
- add CSRF macro rule in AGENTS
- include CSRF docs in README
- handle CSRFError gracefully
- centralize AJAX calls with `csrfFetch`
- update chat and note comment forms
- enforce CSRF macro presence via test
- adjust admin CSRF test

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684bde2dd1408325b4a3ff991a65c403