### PR TITLE
feat(postgres): Fly.io PG + uniqueness guard

### DIFF
--- a/crunevo/routes/auth_routes.py
+++ b/crunevo/routes/auth_routes.py
@@ -10,6 +10,7 @@ from crunevo.extensions import db
 from crunevo.models import User
 from crunevo.utils import spend_credit, record_login
 from crunevo.constants import CreditReasons
+from sqlalchemy.exc import IntegrityError
 
 auth_bp = Blueprint("auth", __name__)
 
@@ -26,7 +27,12 @@ def register():
         user = User(username=username, email=email)
         user.set_password(password)
         db.session.add(user)
-        db.session.commit()
+        try:
+            db.session.commit()
+        except IntegrityError:
+            db.session.rollback()
+            flash("Usuario o correo ya registrado", "danger")
+            return render_template("auth/register.html"), 400
         flash("Registro exitoso. Inicia sesión")
         return redirect(url_for("auth.login"))
     return render_template("auth/register.html")

--- a/fly.toml
+++ b/fly.toml
@@ -11,6 +11,7 @@ primary_region = 'bog'
 
 [env]
   FLASK_APP = 'crunevo.wsgi'
+  FLASK_ENV = 'production'
   PORT = "8080"
 
 [experimental]

--- a/tests/test_register_uniqueness.py
+++ b/tests/test_register_uniqueness.py
@@ -1,0 +1,33 @@
+from crunevo.models import User
+
+
+def test_onboarding_register_duplicate_email(client, db_session):
+    user = User(username="dup", email="dup@example.com")
+    user.set_password("StrongPassw0rd!")
+    db_session.add(user)
+    db_session.commit()
+
+    resp = client.post(
+        "/onboarding/register",
+        data={"email": "dup@example.com", "password": "StrongPassw0rd!"},
+    )
+    assert resp.status_code == 400
+    assert User.query.filter_by(email="dup@example.com").count() == 1
+
+
+def test_auth_register_duplicate_username(client, db_session):
+    user = User(username="dupuser", email="dupuser@example.com", activated=True)
+    user.set_password("StrongPassw0rd!")
+    db_session.add(user)
+    db_session.commit()
+
+    resp = client.post(
+        "/register",
+        data={
+            "username": "dupuser",
+            "email": "other@example.com",
+            "password": "StrongPassw0rd!",
+        },
+    )
+    assert resp.status_code == 400
+    assert User.query.filter_by(username="dupuser").count() == 1


### PR DESCRIPTION
## Summary
- add `FLASK_ENV` to `fly.toml`
- handle IntegrityError in register routes
- test registering users with duplicate credentials

## Testing
- `make fmt`
- `make test`
- `fly deploy --app crunevo2-alt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c627849e48325ba4e2596a415b8f8