### PR TITLE
Improve DB and email handling

### DIFF
--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -98,6 +98,7 @@ def create_app():
     from .routes.admin_routes import admin_bp
     from .routes.ranking_routes import ranking_bp
     from .routes.errors import errors_bp
+    from .routes.health_routes import health_bp
 
     app.register_blueprint(onboarding_bp)
     app.register_blueprint(auth_bp)
@@ -108,6 +109,7 @@ def create_app():
     app.register_blueprint(admin_bp)
     app.register_blueprint(ranking_bp)
     app.register_blueprint(errors_bp)
+    app.register_blueprint(health_bp)
 
     @app.errorhandler(CSRFError)
     def handle_csrf_error(e):

--- a/crunevo/config.py
+++ b/crunevo/config.py
@@ -8,10 +8,13 @@ load_dotenv()
 class Config:
     SECRET_KEY = os.getenv("SECRET_KEY", "devkey")
 
-    _db_uri = os.getenv("DATABASE_URL", "sqlite:///crunevo.db")
-    if _db_uri.startswith("postgres://"):
-        _db_uri = _db_uri.replace("postgres://", "postgresql://", 1)
-    SQLALCHEMY_DATABASE_URI = _db_uri
+    DEBUG = os.getenv("FLASK_DEBUG", "0").lower() in ("1", "true", "yes")
+
+    SQLALCHEMY_DATABASE_URI = os.getenv("DATABASE_URL", "sqlite:///data.db").replace(
+        "postgres://", "postgresql://"
+    )
+    if DEBUG:
+        print("DB:", SQLALCHEMY_DATABASE_URI)
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     UPLOAD_FOLDER = os.getenv("UPLOAD_FOLDER", "static/uploads")
@@ -31,6 +34,10 @@ class Config:
     MAIL_USERNAME = os.getenv("MAIL_USERNAME")
     MAIL_PASSWORD = os.getenv("MAIL_PASSWORD")
     MAIL_DEFAULT_SENDER = os.getenv("MAIL_SENDER", "Crunevo <no-reply@crunevo.io>")
+    if not (MAIL_SERVER and MAIL_USERNAME and MAIL_PASSWORD):
+        MAIL_SUPPRESS_SEND = True
+    else:
+        MAIL_SUPPRESS_SEND = False
 
     ONBOARDING_TOKEN_EXP_H = int(os.getenv("ONBOARDING_TOKEN_EXP_H", 1))
 

--- a/crunevo/routes/auth_routes.py
+++ b/crunevo/routes/auth_routes.py
@@ -1,4 +1,12 @@
-from flask import Blueprint, render_template, redirect, url_for, flash, request
+from flask import (
+    Blueprint,
+    render_template,
+    redirect,
+    url_for,
+    flash,
+    request,
+    current_app,
+)
 from flask_login import login_user, logout_user, current_user
 from crunevo.utils.helpers import activated_required
 from crunevo.extensions import limiter
@@ -29,8 +37,9 @@ def register():
         db.session.add(user)
         try:
             db.session.commit()
-        except IntegrityError:
+        except IntegrityError as e:
             db.session.rollback()
+            current_app.logger.warning("IntegrityError: %s", e)
             flash("Usuario o correo ya registrado", "danger")
             return render_template("auth/register.html"), 400
         flash("Registro exitoso. Inicia sesión")

--- a/crunevo/routes/health_routes.py
+++ b/crunevo/routes/health_routes.py
@@ -1,0 +1,14 @@
+from flask import Blueprint, current_app
+from crunevo.extensions import db
+
+health_bp = Blueprint("health", __name__)
+
+
+@health_bp.route("/healthz")
+def healthz():
+    try:
+        db.session.execute("SELECT 1")
+        return "ok"
+    except Exception as e:
+        current_app.logger.error("Healthz DB error: %s", e)
+        return "error", 500

--- a/crunevo/routes/onboarding_routes.py
+++ b/crunevo/routes/onboarding_routes.py
@@ -53,8 +53,9 @@ def register():
         db.session.add(user)
         try:
             db.session.commit()
-        except IntegrityError:
+        except IntegrityError as e:
             db.session.rollback()
+            current_app.logger.warning("IntegrityError: %s", e)
             flash("Usuario o correo ya registrado", "danger")
             return render_template("onboarding/register.html"), 400
         send_confirmation_email(user)

--- a/crunevo/utils/mailer.py
+++ b/crunevo/utils/mailer.py
@@ -1,7 +1,15 @@
 from flask_mail import Message
+from flask import current_app, flash
 from crunevo.extensions import mail
 
 
 def send_email(to, subject, html):
     msg = Message(subject=subject, recipients=[to], html=html)
-    mail.send(msg)
+    try:
+        mail.send(msg)
+    except Exception as e:
+        current_app.logger.error("Email error: %s", e)
+        flash(
+            "No se pudo enviar el correo de confirmación. Inténtalo más tarde.",
+            "danger",
+        )

--- a/fly.toml
+++ b/fly.toml
@@ -13,6 +13,7 @@ primary_region = 'bog'
   FLASK_APP = 'crunevo.wsgi'
   FLASK_ENV = 'production'
   PORT = "8080"
+  DATABASE_URL = "postgresql://<user>:<pass>@<host>:<port>/<db>"
 
 [experimental]
   auto_rollback = true


### PR DESCRIPTION
## Summary
- configure database url via `DATABASE_URL` and log it in debug mode
- suppress email sending if SMTP env vars are missing
- log duplicate registration errors with rollback
- handle email errors gracefully
- add `/healthz` endpoint and register new blueprint
- include `DATABASE_URL` in Fly configuration

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_684cadc92894832591060ec6e9604f04