### PR TITLE
Enable Resend email support and health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ It usually means Fly.io detected an outdated manifest from a previous deployment
    fly deploy
    ```
 
+If you want to run the application locally but use a PostgreSQL
+database hosted on Fly.io:
+```bash
+fly postgres create ...           # crea cluster
+fly postgres attach ...           # genera DATABASE_URL
+fly secrets set SECRET_KEY=...    # etc.
+```
+
+DNS notes:
+* `www.crunevo.com` → CNAME `crunevo2-alt.fly.dev`
+* `crunevo.com` → A `66.241.124.8` (o AAAA si asignas IPv6)
+
 `CLOUDINARY_URL` and `DATABASE_URL` are already supported in `config.py`, and `flask db upgrade` runs automatically as the release command. The feed cache uses Redis, so set `REDIS_URL` (default `redis://localhost:6379/0`) and make sure a Redis instance is available when deploying or running locally.
 * Si Redis no está disponible el feed funcionará en modo "degradado"
   (lee directamente de la base de datos) y repoblará el cache

--- a/crunevo/config.py
+++ b/crunevo/config.py
@@ -34,10 +34,12 @@ class Config:
     MAIL_USERNAME = os.getenv("MAIL_USERNAME")
     MAIL_PASSWORD = os.getenv("MAIL_PASSWORD")
     MAIL_DEFAULT_SENDER = os.getenv("MAIL_SENDER", "Crunevo <no-reply@crunevo.io>")
-    if not (MAIL_SERVER and MAIL_USERNAME and MAIL_PASSWORD):
-        MAIL_SUPPRESS_SEND = True
-    else:
-        MAIL_SUPPRESS_SEND = False
+
+    RESEND_API_KEY = os.getenv("RESEND_API_KEY")
+    USE_RESEND = RESEND_API_KEY is not None
+    MAIL_SUPPRESS_SEND = (
+        not (MAIL_SERVER and MAIL_USERNAME and MAIL_PASSWORD) and not USE_RESEND
+    )
 
     ONBOARDING_TOKEN_EXP_H = int(os.getenv("ONBOARDING_TOKEN_EXP_H", 1))
 

--- a/crunevo/routes/health_routes.py
+++ b/crunevo/routes/health_routes.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, current_app
+from sqlalchemy import text
 from crunevo.extensions import db
 
 health_bp = Blueprint("health", __name__)
@@ -7,7 +8,7 @@ health_bp = Blueprint("health", __name__)
 @health_bp.route("/healthz")
 def healthz():
     try:
-        db.session.execute("SELECT 1")
+        db.session.execute(text("SELECT 1"))
         return "ok"
     except Exception as e:
         current_app.logger.error("Healthz DB error: %s", e)

--- a/crunevo/utils/mailer.py
+++ b/crunevo/utils/mailer.py
@@ -1,9 +1,41 @@
+import os
+import requests
 from flask_mail import Message
 from flask import current_app, flash
 from crunevo.extensions import mail
 
 
+RESEND_API_KEY = os.getenv("RESEND_API_KEY")
+
+
 def send_email(to, subject, html):
+    if RESEND_API_KEY:
+        try:
+            resp = requests.post(
+                "https://api.resend.com/emails",
+                headers={
+                    "Authorization": f"Bearer {RESEND_API_KEY}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "from": current_app.config.get("MAIL_DEFAULT_SENDER"),
+                    "to": [to],
+                    "subject": subject,
+                    "html": html,
+                },
+                timeout=5,
+            )
+            current_app.logger.info("Resend response: %s", resp.text)
+            resp.raise_for_status()
+            return
+        except Exception as e:
+            current_app.logger.error("Email error: %s", e)
+            flash(
+                "No se pudo enviar el correo de confirmación. Inténtalo más tarde.",
+                "danger",
+            )
+            return
+
     msg = Message(subject=subject, recipients=[to], html=html)
     try:
         mail.send(msg)

--- a/fly.toml
+++ b/fly.toml
@@ -13,7 +13,6 @@ primary_region = 'bog'
   FLASK_APP = 'crunevo.wsgi'
   FLASK_ENV = 'production'
   PORT = "8080"
-  DATABASE_URL = "postgresql://<user>:<pass>@<host>:<port>/<db>"
 
 [experimental]
   auto_rollback = true
@@ -34,7 +33,18 @@ primary_region = 'bog'
     interval = '10s'
     timeout = '2s'
 
+  [[services.http_checks]]
+    interval     = '10s'
+    timeout      = '2s'
+    grace_period = '5s'
+    method       = 'get'
+    path         = '/healthz'
+    protocol     = 'http'
+
 [[vm]]
   memory = '1gb'
   cpu_kind = 'shared'
   cpus = 1
+
+# If using shared IPv4, point the root domain (crunevo.com)
+# to 66.241.124.8 with an A record.

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ Werkzeug==3.1.3
 WTForms==3.2.1
 cloudinary==1.40.0
 redis==5.0.1
+requests==2.31.0
 fakeredis==2.23.2
 ruff==0.4.4
 black==24.4.2

--- a/tests/test_healthz.py
+++ b/tests/test_healthz.py
@@ -1,0 +1,3 @@
+def test_healthz_endpoint(client):
+    resp = client.get("/healthz")
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- clean `fly.toml` DATABASE_URL placeholder
- add HTTP health check configuration with a note about the root domain A record
- support Resend API in config and mailer
- document Fly Postgres workflow and DNS in README
- include a regression test for `/healthz`
- add `requests` to dependencies
- fix SQLAlchemy text usage in the healthz route

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684cbf54d8d08325adc3c7d392d2b62c