### PR TITLE
Add health check root route

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,1 @@
+migrations/alembic.ini

--- a/crunevo/__init__.py
+++ b/crunevo/__init__.py
@@ -1,1 +1,10 @@
 """Application package initializer."""
+
+from .app import create_app as _create_app
+from .routes import main_routes
+
+
+def create_app():
+    app = _create_app()
+    app.register_blueprint(main_routes.main_bp)
+    return app

--- a/crunevo/routes/main_routes.py
+++ b/crunevo/routes/main_routes.py
@@ -1,0 +1,8 @@
+from flask import Blueprint
+
+main_bp = Blueprint("main", __name__)
+
+
+@main_bp.route("/")
+def index():
+    return "CRUNEVO est\u00e1 en l\u00ednea \ud83d\ude80", 200

--- a/crunevo/wsgi.py
+++ b/crunevo/wsgi.py
@@ -1,3 +1,3 @@
-from crunevo.app import create_app
+from crunevo import create_app
 
 app = create_app()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import pytest
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from crunevo.app import create_app
+from crunevo import create_app
 from crunevo.extensions import db, mail
 from crunevo.models import User
 from crunevo.cache import feed_cache

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,6 +1,6 @@
 from alembic.command import upgrade
 from alembic.config import Config
-from crunevo.app import create_app
+from crunevo import create_app
 
 
 def test_alembic_upgrade():


### PR DESCRIPTION
## Summary
- add `main_routes` with a public `/` endpoint
- expose `create_app` from `crunevo` package and register the new blueprint
- update tests and WSGI to use the new factory
- include symlink to `alembic.ini` for tests

## Testing
- `make fmt`
- `make test` *(fails: 6 files would be reformatted)*

------
https://chatgpt.com/codex/tasks/task_e_684e41fccc6483258af39a1ea0c00e65