### PR TITLE
Improve mobile navigation

### DIFF
--- a/crunevo/static/css/navbar.css
+++ b/crunevo/static/css/navbar.css
@@ -1,20 +1,31 @@
 /* Modern educational navbar */
 .navbar-crunevo {
-  background-color: rgba(103, 58, 183, 0.85);
+  background-color: rgba(115, 86, 255, 0.75);
   backdrop-filter: blur(6px);
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+[data-bs-theme="dark"] .navbar-crunevo {
+  background-color: rgba(115, 86, 255, 0.4);
 }
 
 @media (max-width: 991.98px) {
   .navbar-crunevo .navbar-collapse {
     position: fixed;
     inset: 0;
+    z-index: 1040;
     padding-top: 4rem;
-    background-color: rgba(103, 58, 183, 0.95);
+    background-color: rgba(115, 86, 255, 0.95);
     backdrop-filter: blur(6px);
   }
   .navbar-crunevo .navbar-nav .nav-link {
     padding: 1rem 2rem;
     font-size: 1.25rem;
+  }
+
+  .navbar-crunevo .btn-close {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
   }
 }

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -79,4 +79,23 @@ document.addEventListener('DOMContentLoaded', () => {
       if (bsCollapse) bsCollapse.hide();
     });
   });
+
+  const collapse = document.getElementById('navbarNav');
+  if (collapse) {
+    collapse.addEventListener('shown.bs.collapse', () => {
+      document.body.classList.add('tw-overflow-hidden');
+      const back = document.createElement('div');
+      back.id = 'menuBackdrop';
+      back.className = 'tw-fixed tw-inset-0 tw-bg-black/50 tw-z-[1030]';
+      back.addEventListener('click', () => {
+        const inst = bootstrap.Collapse.getInstance(collapse);
+        inst.hide();
+      });
+      document.body.appendChild(back);
+    });
+    collapse.addEventListener('hidden.bs.collapse', () => {
+      document.body.classList.remove('tw-overflow-hidden');
+      document.getElementById('menuBackdrop')?.remove();
+    });
+  }
 });

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -5,10 +5,11 @@
       <input class="form-control" type="search" placeholder="Buscar" aria-label="Buscar" id="globalSearchInput" autocomplete="off">
       <div id="searchSuggestions" class="tw-absolute tw-left-0 tw-z-10 tw-w-full tw-bg-white dark:tw-bg-gray-800 tw-border tw-border-gray-200 dark:tw-border-gray-700 tw-rounded tw-shadow"></div>
     </form>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-label="Menú">
       <span class="navbar-toggler-icon"></span>
     </button>
   <div class="collapse navbar-collapse" id="navbarNav">
+    <button class="btn-close btn-close-white d-lg-none ms-auto me-3" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-label="Cerrar"></button>
     <ul class="navbar-nav mr-auto mb-2 lg:mb-0">
         <li class="nav-item"><a class="nav-link" href="{{ url_for('feed.index') }}"><i class="bi bi-house-door"></i></a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('feed.trending') }}"><i class="bi bi-fire"></i></a></li>


### PR DESCRIPTION
## Summary
- style navbar with dynamic theme and overlay support
- add close button to mobile menu
- darken background and disable scroll when mobile menu opens

## Testing
- `make fmt`
- `make test` *(fails: KeyError: 'formatters')*

------
https://chatgpt.com/codex/tasks/task_e_684f77fbd2e88325a2a61cdcbede0e5a