### PR TITLE
Add educational feed with posting forms

### DIFF
--- a/crunevo/forms/__init__.py
+++ b/crunevo/forms/__init__.py
@@ -1,0 +1,4 @@
+from .feed_note_form import FeedNoteForm
+from .feed_image_form import FeedImageForm
+
+__all__ = ["FeedNoteForm", "FeedImageForm"]

--- a/crunevo/forms/feed_image_form.py
+++ b/crunevo/forms/feed_image_form.py
@@ -1,0 +1,10 @@
+from flask_wtf import FlaskForm
+from wtforms import StringField, FileField, SubmitField, HiddenField
+from wtforms.validators import Optional
+
+
+class FeedImageForm(FlaskForm):
+    form_type = HiddenField(default="image")
+    title = StringField("Título o descripción", validators=[Optional()])
+    image = FileField("Imagen", validators=[Optional()])
+    submit = SubmitField("Compartir")

--- a/crunevo/forms/feed_note_form.py
+++ b/crunevo/forms/feed_note_form.py
@@ -1,0 +1,12 @@
+from flask_wtf import FlaskForm
+from wtforms import StringField, TextAreaField, FileField, SubmitField, HiddenField
+from wtforms.validators import DataRequired, Optional
+
+
+class FeedNoteForm(FlaskForm):
+    form_type = HiddenField(default="note")
+    title = StringField("Título", validators=[DataRequired()])
+    summary = TextAreaField("Resumen", validators=[Optional()])
+    tags = StringField("Etiquetas", validators=[Optional()])
+    file = FileField("Archivo PDF", validators=[Optional()])
+    submit = SubmitField("Publicar")

--- a/crunevo/routes/feed_routes.py
+++ b/crunevo/routes/feed_routes.py
@@ -15,12 +15,95 @@ from flask_login import current_user
 from crunevo.utils.helpers import activated_required
 from datetime import datetime
 from crunevo.extensions import db, csrf
-from crunevo.models import Post, FeedItem
+from crunevo.models import Post, FeedItem, Note
+from crunevo.forms import FeedNoteForm, FeedImageForm
+from crunevo.utils import create_feed_item_for_all, unlock_achievement
+from crunevo.utils.credits import add_credit
+from crunevo.constants import CreditReasons, AchievementCodes
 import redis
 from crunevo.cache.feed_cache import fetch as cache_fetch, push_items as cache_push
 
 feed_bp = Blueprint("feed", __name__)
 csrf.exempt(feed_bp)
+
+
+@feed_bp.route("/feed", methods=["GET", "POST"])
+@activated_required
+def edu_feed():
+    note_form = FeedNoteForm()
+    image_form = FeedImageForm()
+
+    if note_form.validate_on_submit() and request.form.get("form_type") == "note":
+        f = note_form.file.data
+        filepath = ""
+        if f and f.filename:
+            cloud_url = current_app.config.get("CLOUDINARY_URL")
+            if cloud_url:
+                result = cloudinary.uploader.upload(f)
+                filepath = result["secure_url"]
+            else:
+                filename = secure_filename(f.filename)
+                upload_folder = current_app.config["UPLOAD_FOLDER"]
+                os.makedirs(upload_folder, exist_ok=True)
+                filepath = os.path.join(upload_folder, filename)
+                f.save(filepath)
+
+        note = Note(
+            title=note_form.title.data,
+            description=note_form.summary.data,
+            filename=filepath,
+            tags=note_form.tags.data,
+            author=current_user,
+        )
+        db.session.add(note)
+        current_user.points += 10
+        db.session.commit()
+        create_feed_item_for_all("apunte", note.id)
+        add_credit(current_user, 5, CreditReasons.APUNTE_SUBIDO, related_id=note.id)
+        unlock_achievement(current_user, AchievementCodes.PRIMER_APUNTE)
+        flash("Apunte publicado")
+        return redirect(url_for("feed.edu_feed"))
+
+    if image_form.validate_on_submit() and request.form.get("form_type") == "image":
+        image = image_form.image.data
+        image_url = None
+        if image and image.filename:
+            cloud_url = current_app.config.get("CLOUDINARY_URL")
+            if cloud_url:
+                result = cloudinary.uploader.upload(image)
+                image_url = result["secure_url"]
+            else:
+                filename = secure_filename(image.filename)
+                upload_folder = current_app.config["UPLOAD_FOLDER"]
+                os.makedirs(upload_folder, exist_ok=True)
+                filepath = os.path.join(upload_folder, filename)
+                image.save(filepath)
+                image_url = filepath
+
+        post = Post(
+            content=image_form.title.data or "",
+            image_url=image_url,
+            author=current_user,
+        )
+        db.session.add(post)
+        db.session.commit()
+        create_feed_item_for_all("post", post.id)
+        flash("Publicación creada")
+        return redirect(url_for("feed.edu_feed"))
+
+    page = request.args.get("page", 1, type=int)
+    per_page = 10
+    pagination = Note.query.order_by(Note.created_at.desc()).paginate(
+        page=page, per_page=per_page, error_out=False
+    )
+    notes = pagination.items
+    return render_template(
+        "feed/list.html",
+        notes=notes,
+        pagination=pagination,
+        note_form=note_form,
+        image_form=image_form,
+    )
 
 
 @feed_bp.route("/", methods=["GET", "POST"])

--- a/crunevo/static/js/feed_toggle.js
+++ b/crunevo/static/js/feed_toggle.js
@@ -1,0 +1,17 @@
+function initFeedToggle() {
+  const noteBtn = document.getElementById('toggleNote');
+  const imageBtn = document.getElementById('toggleImage');
+  const noteForm = document.getElementById('noteForm');
+  const imageForm = document.getElementById('imageForm');
+  if (!noteBtn || !imageBtn) return;
+
+  noteBtn.addEventListener('click', () => {
+    noteForm.classList.remove('tw-hidden');
+    imageForm.classList.add('tw-hidden');
+  });
+
+  imageBtn.addEventListener('click', () => {
+    imageForm.classList.remove('tw-hidden');
+    noteForm.classList.add('tw-hidden');
+  });
+}

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -39,6 +39,10 @@ document.addEventListener('DOMContentLoaded', () => {
     loadFeed();
   }
 
+  if (typeof initFeedToggle === 'function') {
+    initFeedToggle();
+  }
+
   // simple AJAX search suggestions
   const input = document.getElementById('globalSearchInput');
   const box = document.getElementById('searchSuggestions');

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -45,6 +45,7 @@
     </div>
 
     <script src="{{ url_for('static', filename='vendor/bootstrap.bundle.min.js') }}" defer></script>
+    <script src="{{ url_for('static', filename='js/feed_toggle.js') }}" defer></script>
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>
 </body>
 </html>

--- a/crunevo/templates/components/feed_card.html
+++ b/crunevo/templates/components/feed_card.html
@@ -1,0 +1,18 @@
+<article class="card lift tw-space-y-2">
+  {% if note.thumbnail_url %}
+  <img src="{{ note.thumbnail_url }}" alt="vista previa" class="tw-rounded tw-w-full">
+  {% else %}
+  <div class="tw-flex tw-items-center tw-justify-center tw-h-40 tw-bg-gray-100 dark:tw-bg-gray-800">
+    <i class="bi bi-file-earmark-text tw-text-4xl tw-text-gray-400"></i>
+  </div>
+  {% endif %}
+  <h3 class="tw-text-lg tw-font-semibold">{{ note.title }}</h3>
+  <p class="tw-text-sm tw-text-gray-600 dark:tw-text-gray-400">{{ note.description }}</p>
+  <ul class="tw-flex tw-flex-wrap tw-gap-1 tw-text-xs tw-text-gray-500">
+    {% for tag in (note.tags or '').split(',') if tag %}
+    <li>#{{ tag }}</li>
+    {% endfor %}
+  </ul>
+  <div class="tw-text-xs tw-text-gray-500">{{ note.author.username }} · {{ note.created_at.strftime('%Y-%m-%d') }}</div>
+  <a href="{{ url_for('notes.view_note', id=note.id) }}" class="btn btn-sm btn-primary">Ver detalle</a>
+</article>

--- a/crunevo/templates/feed/list.html
+++ b/crunevo/templates/feed/list.html
@@ -1,0 +1,47 @@
+{% extends 'base.html' %}
+{% import 'components/csrf.html' as csrf %}
+
+{% block content %}
+<div class="card tw-space-y-4">
+  <input type="text" class="form-control" placeholder="¿Qué deseas compartir hoy?" readonly>
+  <div class="tw-flex tw-gap-2">
+    <button id="toggleNote" type="button" class="btn btn-outline-primary btn-sm">Subir Apunte</button>
+    <button id="toggleImage" type="button" class="btn btn-outline-secondary btn-sm">Compartir Imagen</button>
+  </div>
+  <form id="noteForm" method="post" enctype="multipart/form-data" class="tw-space-y-2 tw-hidden">
+    {{ csrf.csrf_field() }}
+    <input type="hidden" name="form_type" value="note">
+    <input type="text" name="title" class="form-control" placeholder="Título" required>
+    <textarea name="summary" class="form-control" placeholder="Resumen"></textarea>
+    <input type="text" name="tags" class="form-control" placeholder="Etiquetas">
+    <input type="file" name="file" class="form-control">
+    <button type="submit" class="btn btn-primary">Publicar</button>
+  </form>
+  <form id="imageForm" method="post" enctype="multipart/form-data" class="tw-space-y-2 tw-hidden">
+    {{ csrf.csrf_field() }}
+    <input type="hidden" name="form_type" value="image">
+    <input type="text" name="title" class="form-control" placeholder="Descripción">
+    <input type="file" name="image" class="form-control">
+    <button type="submit" class="btn btn-primary">Compartir</button>
+  </form>
+</div>
+
+<div id="feed" class="tw-mt-6 tw-grid tw-gap-6 md:tw-grid-cols-2">
+  {% for note in notes %}
+    {% include 'components/feed_card.html' with context %}
+  {% endfor %}
+</div>
+
+{% if not notes %}
+  <div class="tw-text-center tw-my-10">
+    <i class="bi bi-journal-text tw-text-4xl tw-text-gray-400"></i>
+    <p>Aún no hay apuntes... ¿quieres ser el primero en compartir?</p>
+  </div>
+{% endif %}
+
+{% if pagination.pages > 1 %}
+  <div class="tw-text-center tw-my-4">
+    <a href="{{ url_for('feed.edu_feed', page=pagination.next_num) }}" class="btn btn-secondary" id="loadMore">Ver más</a>
+  </div>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- build new feed page with note and image posting forms
- add JS toggle handler
- hook toggle initializer in main.js
- include script in base template

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684fe6efe6dc8325a88f857a17e8a836