### PR TITLE
Implement mixed feed for notes and posts

### DIFF
--- a/crunevo/routes/feed_routes.py
+++ b/crunevo/routes/feed_routes.py
@@ -91,16 +91,21 @@ def edu_feed():
         flash("Publicación creada")
         return redirect(url_for("feed.edu_feed"))
 
-    page = request.args.get("page", 1, type=int)
-    per_page = 10
-    pagination = Note.query.order_by(Note.created_at.desc()).paginate(
-        page=page, per_page=per_page, error_out=False
-    )
-    notes = pagination.items
+    feed_items_raw = FeedItem.query.order_by(FeedItem.created_at.desc()).limit(20).all()
+    feed_items = []
+    for item in feed_items_raw:
+        if item.item_type == "apunte":
+            note = Note.query.get(item.ref_id)
+            if note:
+                feed_items.append({"type": "note", "data": note})
+        elif item.item_type == "post":
+            post = Post.query.get(item.ref_id)
+            if post:
+                feed_items.append({"type": "post", "data": post})
+
     return render_template(
         "feed/list.html",
-        notes=notes,
-        pagination=pagination,
+        feed_items=feed_items,
         note_form=note_form,
         image_form=image_form,
     )

--- a/crunevo/templates/components/post_card.html
+++ b/crunevo/templates/components/post_card.html
@@ -1,7 +1,7 @@
-<article class="card lift mb-6">
+<article class="card lift tw-space-y-2">
   {% if post.image_url %}
-    <img src="{{ post.image_url }}" alt="imagen" class="tw-rounded mb-4 tw-w-full">
+    <img src="{{ post.image_url }}" alt="imagen" class="tw-rounded tw-w-full">
   {% endif %}
-  <p class="mb-4">{{ post.content }}</p>
-  <a href="#comentarios" class="tw-inline-block tw-bg-[var(--primary)] tw-text-white tw-px-3 tw-py-1 tw-rounded">Comentar</a>
+  <p class="tw-text-base">{{ post.content }}</p>
+  <div class="tw-text-xs tw-text-gray-500">{{ post.author.username }} · {{ post.created_at.strftime('%Y-%m-%d') }}</div>
 </article>

--- a/crunevo/templates/feed/list.html
+++ b/crunevo/templates/feed/list.html
@@ -27,21 +27,21 @@
 </div>
 
 <div id="feed" class="tw-mt-6 tw-grid tw-gap-6 md:tw-grid-cols-2">
-  {% for note in notes %}
-    {% include 'components/feed_card.html' with context %}
+  {% for item in feed_items %}
+    {% if item.type == 'note' %}
+      {% set note = item.data %}
+      {% include 'components/feed_card.html' %}
+    {% elif item.type == 'post' %}
+      {% set post = item.data %}
+      {% include 'components/post_card.html' %}
+    {% endif %}
   {% endfor %}
 </div>
 
-{% if not notes %}
+{% if not feed_items %}
   <div class="tw-text-center tw-my-10">
     <i class="bi bi-journal-text tw-text-4xl tw-text-gray-400"></i>
     <p>Aún no hay apuntes... ¿quieres ser el primero en compartir?</p>
-  </div>
-{% endif %}
-
-{% if pagination.pages > 1 %}
-  <div class="tw-text-center tw-my-4">
-    <a href="{{ url_for('feed.edu_feed', page=pagination.next_num) }}" class="btn btn-secondary" id="loadMore">Ver más</a>
   </div>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- fetch recent `FeedItem` entries instead of just notes
- display notes and posts dynamically in the feed
- add `post_card.html` component for posts

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_684fe9da4a548325ba3c8a327807c0b5