### PR TITLE
Enhance mobile menu behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,6 @@
   `csrf_field()` immediately after the `<form>` tag.
 - Nunca hacer CREATE TYPE sin comprobar si el tipo ya existe; usa IF NOT EXISTS o checkfirst=True.
 - Se corrigió la barra de navegación fija añadiendo padding global y mejorando el menú móvil (PR navbar fixes).
+- Se ajustó el padding global mediante CSS en el body y se agregó z-index al navbar para evitar que tape el contenido.
+- Se mejoró el cierre del menú móvil y se fijó la altura del navbar (PR navbar fixes 2).
+- Se cierra el menú móvil al redimensionar la pantalla (PR navbar fixes 3).

--- a/crunevo/static/css/navbar.css
+++ b/crunevo/static/css/navbar.css
@@ -3,6 +3,14 @@
   background-color: rgba(115, 86, 255, 0.75);
   backdrop-filter: blur(6px);
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  z-index: 1030;
+  min-height: 64px;
+}
+
+@media (max-width: 768px) {
+  .navbar-crunevo {
+    min-height: 56px;
+  }
 }
 
 [data-bs-theme="dark"] .navbar-crunevo {

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -125,6 +125,30 @@ document.addEventListener('DOMContentLoaded', () => {
     if (e.target === overlay) closeMenu();
   });
 
+  document.addEventListener('click', (e) => {
+    if (
+      overlay &&
+      !overlay.classList.contains('tw-hidden') &&
+      panel &&
+      !panel.contains(e.target) &&
+      toggleBtn &&
+      !toggleBtn.contains(e.target)
+    ) {
+      closeMenu();
+    }
+  });
+
+  window.addEventListener('pageshow', () => {
+    closeMenu();
+  });
+
+  // Ensure the mobile menu doesn't stay open when resizing to desktop
+  window.addEventListener('resize', () => {
+    if (window.innerWidth >= 768) {
+      closeMenu();
+    }
+  });
+
   document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape' && !overlay?.classList.contains('tw-hidden')) {
       closeMenu();

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -18,7 +18,17 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/navbar.css') }}">
 </head>
-<body class="d-flex flex-column min-vh-100 tw-bg-white dark:tw-bg-black tw-pt-[64px]">
+<body class="d-flex flex-column min-vh-100 tw-bg-white dark:tw-bg-black">
+  <style>
+    body {
+      padding-top: 64px;
+    }
+    @media (max-width: 768px) {
+      body {
+        padding-top: 56px;
+      }
+    }
+  </style>
     {% include 'components/navbar.html' %}
     <div class="tw-container tw-mx-auto tw-px-4 tw-max-w-7xl">
         <div class="row gx-4">

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-dark navbar-crunevo fixed-top">
+<nav class="navbar navbar-dark navbar-crunevo fixed-top" role="navigation" aria-label="Navegaci\u00f3n principal">
   <div class="tw-container tw-mx-auto tw-px-4 tw-max-w-7xl d-flex justify-content-between align-items-center">
     <div class="d-flex align-items-center">
       <button id="mobileMenuToggle" class="btn btn-link text-white tw-md:tw-hidden tw-text-2xl" type="button" aria-label="Menú" aria-controls="mobileMenuPanel" aria-expanded="false">


### PR DESCRIPTION
## Summary
- close mobile menu when resizing to desktop
- document resize behavior in agent guide

## Testing
- `make fmt`
- `make test` *(36 passed, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_685072c632c08325a5372714fce3ed70