### PR TITLE
Fix overlay visibility on desktop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,3 +18,7 @@
   mayores (PR navbar fixes 5).
 - Se agregó margen superior al `main` solo en escritorio con CSS
   (`@media (min-width: 992px)`)
+- Se oculta `#mobileMenuOverlay` en escritorio y se ajusta el
+  listener de redimensionado a 992px (PR overlay fix).
+- Se establece `height` y `width` en 0 para `#mobileMenuOverlay` en
+  escritorio y se asegura que `closeMenu()` añada `tw-hidden` (PR overlay fix 2).

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -104,3 +104,13 @@ body {
   transition: .15s ease;
 }
 
+@media (min-width: 992px) {
+  #mobileMenuOverlay {
+    display: none !important;
+    visibility: hidden !important;
+    pointer-events: none !important;
+    height: 0 !important;
+    width: 0 !important;
+  }
+}
+

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -102,6 +102,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function closeMenu() {
     if (!overlay || !panel) return;
+    overlay.classList.add('tw-hidden');
     panel.classList.add('-tw-translate-x-full');
     document.body.style.overflow = 'auto';
     toggleBtn?.setAttribute('aria-expanded', 'false');
@@ -144,7 +145,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Ensure the mobile menu doesn't stay open when resizing to desktop
   window.addEventListener('resize', () => {
-    if (window.innerWidth >= 768) {
+    if (window.innerWidth >= 992) {
       closeMenu();
     }
   });


### PR DESCRIPTION
## Summary
- hide `#mobileMenuOverlay` completely on desktop
- close the mobile menu when resizing beyond 992px
- ensure closing the menu hides the overlay immediately
- record overlay fix follow-up in AGENTS guidelines

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685081ded608832580e6fe30353a4171