### PR TITLE
Fix navbar desktop layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,3 +22,6 @@
   listener de redimensionado a 992px (PR overlay fix).
 - Se establece `height` y `width` en 0 para `#mobileMenuOverlay` en
   escritorio y se asegura que `closeMenu()` añada `tw-hidden` (PR overlay fix 2).
+- Se corrige la clase inicial de `#navLinks` para mostrarse horizontal en
+  escritorio y se evita abrir el menú móvil en pantallas grandes
+  (PR navbar desktop fix).

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -111,6 +111,7 @@ body {
     pointer-events: none !important;
     height: 0 !important;
     width: 0 !important;
+    background: none !important;
   }
 }
 

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -82,7 +82,17 @@ document.addEventListener('DOMContentLoaded', () => {
   const navLinks = document.getElementById('navLinks');
   const desktopContainer = document.getElementById('desktopNavContainer');
 
+  window.addEventListener('load', () => {
+    if (window.innerWidth >= 992 && navLinks) {
+      navLinks.classList.remove('tw-flex-col', 'tw-space-y-4');
+      navLinks.classList.add('md:tw-flex', 'md:tw-flex-row', 'md:tw-space-x-4');
+      navLinks.classList.remove('tw-hidden');
+      desktopContainer?.appendChild(navLinks);
+    }
+  });
+
   function openMenu() {
+    if (window.innerWidth >= 992) return;
     if (!overlay || !panel) return;
     overlay.classList.remove('tw-hidden');
     panel.classList.remove('-tw-translate-x-full');

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -11,7 +11,7 @@
       <div id="searchSuggestions" class="tw-absolute tw-left-0 tw-z-10 tw-w-full tw-bg-white dark:tw-bg-gray-800 tw-border tw-border-gray-200 dark:tw-border-gray-700 tw-rounded tw-shadow"></div>
     </form>
     <div id="desktopNavContainer" class="d-none d-md-flex align-items-center">
-      <ul id="navLinks" class="navbar-nav tw-flex tw-flex-col tw-space-y-4 md:tw-flex-row md:tw-space-y-0 md:tw-space-x-4 align-items-center tw-hidden md:tw-flex">
+      <ul id="navLinks" class="navbar-nav d-none d-md-flex align-items-center md:tw-flex md:tw-flex-row md:tw-space-x-4">
   <li class="nav-item"><a class="nav-link tw-flex tw-items-center" href="{{ url_for('feed.index') }}"><i class="bi bi-house-door"></i><span class="ms-2 md:tw-hidden">Inicio</span></a></li>
   <li class="nav-item"><a class="nav-link tw-flex tw-items-center" href="{{ url_for('feed.trending') }}"><i class="bi bi-fire"></i><span class="ms-2 md:tw-hidden">Tendencias</span></a></li>
   <li class="nav-item"><a class="nav-link tw-flex tw-items-center" href="{{ url_for('notes.list_notes') }}"><i class="bi bi-journal-text"></i><span class="ms-2 md:tw-hidden">Apuntes</span></a></li>


### PR DESCRIPTION
## Summary
- fix navLinks classes for desktop view
- ensure navLinks starts horizontal on load
- prevent opening the mobile menu on desktops
- hide mobile overlay background on desktop
- document navbar desktop fix in AGENTS guidelines

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6850853313908325bed9b001425ef5f3