### PR TITLE
Fix mobile menu overlay stacking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,3 +25,5 @@
 - Se corrige la clase inicial de `#navLinks` para mostrarse horizontal en
   escritorio y se evita abrir el menú móvil en pantallas grandes
   (PR navbar desktop fix).
+- Se establece `z-index: -1` y `position: static` para `#mobileMenuOverlay`
+  en escritorio, previniendo que bloquee el contenido (PR overlay fix 3).

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -112,6 +112,8 @@ body {
     height: 0 !important;
     width: 0 !important;
     background: none !important;
+    z-index: -1 !important;
+    position: static !important;
   }
 }
 


### PR DESCRIPTION
## Summary
- avoid blocking content on desktop by pushing `#mobileMenuOverlay` behind
- document overlay fix 3 in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68508825a0c483259c82c35ebd64f316