### PR TITLE
Fix mobile nav placement on desktop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,3 +27,5 @@
   (PR navbar desktop fix).
 - Se establece `z-index: -1` y `position: static` para `#mobileMenuOverlay`
   en escritorio, previniendo que bloquee el contenido (PR overlay fix 3).
+- Se asegura que `#navLinks` se coloque en `#desktopNavContainer` al cargar la
+  página y se oculta `#mobileMenuPanel` en escritorio (PR navbar panel fix).

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -107,13 +107,16 @@ body {
 @media (min-width: 992px) {
   #mobileMenuOverlay {
     display: none !important;
-    visibility: hidden !important;
-    pointer-events: none !important;
     height: 0 !important;
     width: 0 !important;
+    pointer-events: none !important;
     background: none !important;
     z-index: -1 !important;
     position: static !important;
+  }
+
+  #mobileMenuPanel {
+    display: none !important;
   }
 }
 

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -83,11 +83,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const desktopContainer = document.getElementById('desktopNavContainer');
 
   window.addEventListener('load', () => {
-    if (window.innerWidth >= 992 && navLinks) {
-      navLinks.classList.remove('tw-flex-col', 'tw-space-y-4');
-      navLinks.classList.add('md:tw-flex', 'md:tw-flex-row', 'md:tw-space-x-4');
-      navLinks.classList.remove('tw-hidden');
-      desktopContainer?.appendChild(navLinks);
+    if (window.innerWidth >= 992 && navLinks && desktopContainer) {
+      desktopContainer.appendChild(navLinks);
+      navLinks.classList.remove('tw-flex-col', 'tw-space-y-4', 'tw-hidden');
+      navLinks.classList.add('tw-flex', 'tw-flex-row', 'tw-space-x-4');
     }
   });
 


### PR DESCRIPTION
## Summary
- ensure navLinks attach to the desktop container once the page loads
- hide the mobile menu overlay and panel on desktop
- document the fix in AGENTS guidelines

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68508a3495548325bd18aa6965f44b83