### PR TITLE
Fix desktop overlay behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,3 +29,6 @@
   en escritorio, previniendo que bloquee el contenido (PR overlay fix 3).
 - Se asegura que `#navLinks` se coloque en `#desktopNavContainer` al cargar la
   página y se oculta `#mobileMenuPanel` en escritorio (PR navbar panel fix).
+- Se fuerzan `display: none` y `pointer-events: none` para `#mobileMenuOverlay`
+  y `#mobileMenuPanel` en escritorio, actualizando `main.js` para aplicar estos
+  estilos al cargar la página y al cerrar el menú (PR overlay hide complete).

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -107,16 +107,23 @@ body {
 @media (min-width: 992px) {
   #mobileMenuOverlay {
     display: none !important;
+    visibility: hidden !important;
     height: 0 !important;
     width: 0 !important;
     pointer-events: none !important;
-    background: none !important;
-    z-index: -1 !important;
+    background: transparent !important;
     position: static !important;
+    z-index: -1 !important;
+    opacity: 0 !important;
   }
 
   #mobileMenuPanel {
     display: none !important;
+    height: 0 !important;
+    width: 0 !important;
+    position: static !important;
+    pointer-events: none !important;
+    z-index: -1 !important;
   }
 }
 

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -87,6 +87,10 @@ document.addEventListener('DOMContentLoaded', () => {
       desktopContainer.appendChild(navLinks);
       navLinks.classList.remove('tw-flex-col', 'tw-space-y-4', 'tw-hidden');
       navLinks.classList.add('tw-flex', 'tw-flex-row', 'tw-space-x-4');
+      panel?.classList.add('tw-hidden');
+      overlay?.classList.add('tw-hidden');
+      overlay?.setAttribute('style', 'display: none; pointer-events: none;');
+      panel?.setAttribute('style', 'display: none; pointer-events: none;');
     }
   });
 
@@ -95,6 +99,10 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!overlay || !panel) return;
     overlay.classList.remove('tw-hidden');
     panel.classList.remove('-tw-translate-x-full');
+    overlay.style.display = 'block';
+    overlay.style.pointerEvents = 'auto';
+    panel.style.display = 'block';
+    panel.style.pointerEvents = 'auto';
     if (navLinks && panel) {
       panel.appendChild(navLinks);
       navLinks.classList.remove('tw-hidden');
@@ -113,6 +121,10 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!overlay || !panel) return;
     overlay.classList.add('tw-hidden');
     panel.classList.add('-tw-translate-x-full');
+    overlay.style.display = 'none';
+    overlay.style.pointerEvents = 'none';
+    panel.style.display = 'none';
+    panel.style.pointerEvents = 'none';
     document.body.style.overflow = 'auto';
     toggleBtn?.setAttribute('aria-expanded', 'false');
     if (navLinks && desktopContainer) {

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -11,7 +11,7 @@
       <div id="searchSuggestions" class="tw-absolute tw-left-0 tw-z-10 tw-w-full tw-bg-white dark:tw-bg-gray-800 tw-border tw-border-gray-200 dark:tw-border-gray-700 tw-rounded tw-shadow"></div>
     </form>
     <div id="desktopNavContainer" class="d-none d-md-flex align-items-center">
-      <ul id="navLinks" class="navbar-nav d-none d-md-flex align-items-center md:tw-flex md:tw-flex-row md:tw-space-x-4">
+      <ul id="navLinks" class="navbar-nav d-none d-md-flex align-items-center tw-flex-row tw-space-x-4">
   <li class="nav-item"><a class="nav-link tw-flex tw-items-center" href="{{ url_for('feed.index') }}"><i class="bi bi-house-door"></i><span class="ms-2 md:tw-hidden">Inicio</span></a></li>
   <li class="nav-item"><a class="nav-link tw-flex tw-items-center" href="{{ url_for('feed.trending') }}"><i class="bi bi-fire"></i><span class="ms-2 md:tw-hidden">Tendencias</span></a></li>
   <li class="nav-item"><a class="nav-link tw-flex tw-items-center" href="{{ url_for('notes.list_notes') }}"><i class="bi bi-journal-text"></i><span class="ms-2 md:tw-hidden">Apuntes</span></a></li>


### PR DESCRIPTION
## Summary
- hide `mobileMenuOverlay` and `mobileMenuPanel` fully on desktop
- keep menu styles hidden via JS when loaded on large screens
- set display and pointer events when opening and closing menu
- update initial classes for `navLinks`
- document changes in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6850b53193408325816616aa7a2f1553