### PR TITLE
Bootstrap-only navbar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,3 +34,4 @@
   estilos al cargar la página y al cerrar el menú (PR overlay hide complete).
 
 - Se agregó "navbar_crunevo_fixed.html" como ejemplo de navbar fijo con menú móvil.
+- Navbar migrado completamente a Bootstrap sin Tailwind ni overlay. Se eliminó el script de Tailwind y se simplificó main.js (PR bootstrap-only navbar).

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -104,26 +104,4 @@ body {
   transition: .15s ease;
 }
 
-@media (min-width: 992px) {
-  #mobileMenuOverlay {
-    display: none !important;
-    visibility: hidden !important;
-    height: 0 !important;
-    width: 0 !important;
-    pointer-events: none !important;
-    background: transparent !important;
-    position: static !important;
-    z-index: -1 !important;
-    opacity: 0 !important;
-  }
-
-  #mobileMenuPanel {
-    display: none !important;
-    height: 0 !important;
-    width: 0 !important;
-    position: static !important;
-    pointer-events: none !important;
-    z-index: -1 !important;
-  }
-}
 

--- a/crunevo/static/js/feed_toggle.js
+++ b/crunevo/static/js/feed_toggle.js
@@ -6,12 +6,12 @@ function initFeedToggle() {
   if (!noteBtn || !imageBtn) return;
 
   noteBtn.addEventListener('click', () => {
-    noteForm.classList.remove('tw-hidden');
-    imageForm.classList.add('tw-hidden');
+    noteForm.classList.remove('d-none');
+    imageForm.classList.add('d-none');
   });
 
   imageBtn.addEventListener('click', () => {
-    imageForm.classList.remove('tw-hidden');
-    noteForm.classList.add('tw-hidden');
+    imageForm.classList.remove('d-none');
+    noteForm.classList.add('d-none');
   });
 }

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -11,10 +11,10 @@ function csrfFetch(url, options = {}) {
 }
 
 function showToast(message) {
-  const box = document.querySelector('.fixed.top-20');
+  const box = document.querySelector('.toast-container');
   if (!box) return;
   const div = document.createElement('div');
-  div.className = 'tw-rounded tw-bg-[var(--primary)]/10 tw-px-4 tw-py-2 tw-text-[var(--primary)] tw-shadow';
+  div.className = 'alert alert-primary';
   div.textContent = message;
   box.appendChild(div);
   setTimeout(() => div.remove(), 3000);
@@ -59,7 +59,7 @@ document.addEventListener('DOMContentLoaded', () => {
           box.innerHTML = '';
           data.forEach((item) => {
             const a = document.createElement('a');
-            a.className = 'tw-block tw-px-2 tw-py-1 hover:tw-bg-gray-100 dark:hover:tw-bg-gray-700';
+            a.className = 'dropdown-item';
             a.href = item.url;
             a.textContent = item.title;
             box.appendChild(a);
@@ -75,106 +75,6 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  const overlay = document.getElementById('mobileMenuOverlay');
-  const panel = document.getElementById('mobileMenuPanel');
-  const toggleBtn = document.getElementById('mobileMenuToggle');
-  const closeBtn = document.getElementById('closeMobileMenu');
-  const navLinks = document.getElementById('navLinks');
-  const desktopContainer = document.getElementById('desktopNavContainer');
-
-  window.addEventListener('load', () => {
-    if (window.innerWidth >= 992 && navLinks && desktopContainer) {
-      desktopContainer.appendChild(navLinks);
-      navLinks.classList.remove('tw-flex-col', 'tw-space-y-4', 'tw-hidden');
-      navLinks.classList.add('tw-flex', 'tw-flex-row', 'tw-space-x-4');
-      panel?.classList.add('tw-hidden');
-      overlay?.classList.add('tw-hidden');
-      overlay?.setAttribute('style', 'display: none; pointer-events: none;');
-      panel?.setAttribute('style', 'display: none; pointer-events: none;');
-    }
-  });
-
-  function openMenu() {
-    if (window.innerWidth >= 992) return;
-    if (!overlay || !panel) return;
-    overlay.classList.remove('tw-hidden');
-    panel.classList.remove('-tw-translate-x-full');
-    overlay.style.display = 'block';
-    overlay.style.pointerEvents = 'auto';
-    panel.style.display = 'block';
-    panel.style.pointerEvents = 'auto';
-    if (navLinks && panel) {
-      panel.appendChild(navLinks);
-      navLinks.classList.remove('tw-hidden');
-      navLinks.classList.add('tw-flex-col', 'tw-space-y-4');
-      navLinks.classList.remove(
-        'md:tw-flex',
-        'md:tw-flex-row',
-        'md:tw-space-x-4',
-      );
-    }
-    document.body.style.overflow = 'hidden';
-    toggleBtn?.setAttribute('aria-expanded', 'true');
-  }
-
-  function closeMenu() {
-    if (!overlay || !panel) return;
-    overlay.classList.add('tw-hidden');
-    panel.classList.add('-tw-translate-x-full');
-    overlay.style.display = 'none';
-    overlay.style.pointerEvents = 'none';
-    panel.style.display = 'none';
-    panel.style.pointerEvents = 'none';
-    document.body.style.overflow = 'auto';
-    toggleBtn?.setAttribute('aria-expanded', 'false');
-    if (navLinks && desktopContainer) {
-      desktopContainer.appendChild(navLinks);
-      navLinks.classList.remove('tw-flex-col', 'tw-space-y-4');
-      navLinks.classList.add('md:tw-flex', 'md:tw-flex-row', 'md:tw-space-x-4');
-      navLinks.classList.add('tw-hidden');
-    }
-    const onEnd = () => {
-      overlay.classList.add('tw-hidden');
-      panel.removeEventListener('transitionend', onEnd);
-    };
-    panel.addEventListener('transitionend', onEnd);
-  }
-
-  toggleBtn?.addEventListener('click', openMenu);
-  closeBtn?.addEventListener('click', closeMenu);
-
-  overlay?.addEventListener('click', (e) => {
-    if (e.target === overlay) closeMenu();
-  });
-
-  document.addEventListener('click', (e) => {
-    if (
-      overlay &&
-      !overlay.classList.contains('tw-hidden') &&
-      panel &&
-      !panel.contains(e.target) &&
-      toggleBtn &&
-      !toggleBtn.contains(e.target)
-    ) {
-      closeMenu();
-    }
-  });
-
-  window.addEventListener('pageshow', () => {
-    closeMenu();
-  });
-
-  // Ensure the mobile menu doesn't stay open when resizing to desktop
-  window.addEventListener('resize', () => {
-    if (window.innerWidth >= 992) {
-      closeMenu();
-    }
-  });
-
-  document.addEventListener('keydown', (e) => {
-    if (e.key === 'Escape' && !overlay?.classList.contains('tw-hidden')) {
-      closeMenu();
-    }
-  });
+  // Bootstrap collapse handles the mobile menu
 
 });

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -11,25 +11,23 @@
     <title>Crunevo</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='vendor/bootstrap.min.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='vendor/bootstrap-icons.css') }}">
-    <script src="{{ url_for('static', filename='js/tailwind.config.js') }}"></script>
-    <script src="https://cdn.tailwindcss.com?plugins=forms,typography" defer></script>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/tokens.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/fix-bootstrap.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/navbar.css') }}">
 </head>
-<body class="d-flex flex-column min-vh-100 tw-bg-white dark:tw-bg-black">
+<body class="d-flex flex-column min-vh-100">
     {% include 'components/navbar.html' %}
-    <div class="tw-container tw-mx-auto tw-px-4 tw-max-w-7xl">
+    <div class="container">
         <div class="row gx-4">
             <aside class="d-none d-lg-block col-lg-3">
                 {% include 'components/sidebar_left.html' %}
             </aside>
-            <main class="col-lg-6 tw-space-y-6">
+            <main class="col-lg-6">
                 {% import 'components/toast.html' as toast %}
                 {% with messages = get_flashed_messages() %}
                   {% if messages %}
-                    <div class="fixed top-20 inset-x-0 z-50 tw-flex tw-flex-col tw-items-center tw-space-y-2">
+                    <div class="toast-container position-fixed top-0 start-0 end-0 z-50 d-flex flex-column align-items-center gap-2 mt-5">
                       {% for msg in messages %}
                         {{ toast.toast(msg) }}
                       {% endfor %}
@@ -44,7 +42,7 @@
         </div>
     </div>
 
-    <script src="{{ url_for('static', filename='vendor/bootstrap.bundle.min.js') }}" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="{{ url_for('static', filename='js/feed_toggle.js') }}" defer></script>
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>
 </body>

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -1,49 +1,38 @@
-<nav class="navbar navbar-dark navbar-crunevo fixed-top" role="navigation" aria-label="Navegaci\u00f3n principal">
-  <div class="tw-container tw-mx-auto tw-px-4 tw-max-w-7xl d-flex justify-content-between align-items-center">
-    <div class="d-flex align-items-center">
-      <button id="mobileMenuToggle" class="btn btn-link text-white tw-md:tw-hidden tw-text-2xl" type="button" aria-label="Menú" aria-controls="mobileMenuPanel" aria-expanded="false">
-        <i class="bi bi-list"></i>
-      </button>
-      <a class="navbar-brand ms-2" href="{{ url_for('feed.index') }}">Crunevo</a>
-    </div>
-    <form class="d-none d-md-flex mx-4 flex-grow-1 position-relative" id="globalSearchForm">
+<nav class="navbar navbar-dark bg-primary fixed-top">
+  <div class="container-fluid">
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCrunevo" aria-controls="navbarCrunevo" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <a class="navbar-brand ms-2" href="{{ url_for('feed.index') }}">Crunevo</a>
+    <form class="d-none d-md-flex mx-3 flex-grow-1 position-relative" id="globalSearchForm">
       <input class="form-control" type="search" placeholder="Buscar" aria-label="Buscar" id="globalSearchInput" autocomplete="off">
-      <div id="searchSuggestions" class="tw-absolute tw-left-0 tw-z-10 tw-w-full tw-bg-white dark:tw-bg-gray-800 tw-border tw-border-gray-200 dark:tw-border-gray-700 tw-rounded tw-shadow"></div>
+      <div id="searchSuggestions" class="position-absolute start-0 w-100 bg-white border rounded shadow"></div>
     </form>
-    <div id="desktopNavContainer" class="d-none d-md-flex align-items-center">
-      <ul id="navLinks" class="navbar-nav d-none d-md-flex align-items-center tw-flex-row tw-space-x-4">
-  <li class="nav-item"><a class="nav-link tw-flex tw-items-center" href="{{ url_for('feed.index') }}"><i class="bi bi-house-door"></i><span class="ms-2 md:tw-hidden">Inicio</span></a></li>
-  <li class="nav-item"><a class="nav-link tw-flex tw-items-center" href="{{ url_for('feed.trending') }}"><i class="bi bi-fire"></i><span class="ms-2 md:tw-hidden">Tendencias</span></a></li>
-  <li class="nav-item"><a class="nav-link tw-flex tw-items-center" href="{{ url_for('notes.list_notes') }}"><i class="bi bi-journal-text"></i><span class="ms-2 md:tw-hidden">Apuntes</span></a></li>
-  <li class="nav-item"><a class="nav-link tw-flex tw-items-center" href="{{ url_for('store.store_index') }}"><i class="bi bi-bag"></i><span class="ms-2 md:tw-hidden">Tienda</span></a></li>
-  <li class="nav-item"><a class="nav-link tw-flex tw-items-center" href="{{ url_for('chat.chat_index') }}"><i class="bi bi-chat-dots"></i><span class="ms-2 md:tw-hidden">Chat</span></a></li>
-  {% if current_user.is_authenticated and current_user.role == 'admin' %}
-  <li class="nav-item"><a class="nav-link tw-flex tw-items-center" href="{{ url_for('admin.dashboard') }}"><i class="bi bi-speedometer2"></i><span class="ms-2 md:tw-hidden">Admin</span></a></li>
-  {% endif %}
-  {% if current_user.is_authenticated %}
-  <li class="nav-item"><a class="nav-link tw-flex tw-items-center" href="{{ url_for('auth.perfil') }}"><i class="bi bi-person-circle"></i><span class="ms-2 md:tw-hidden">Perfil</span></a></li>
-  <li class="nav-item"><a class="nav-link tw-flex tw-items-center" href="{{ url_for('auth.logout') }}"><i class="bi bi-box-arrow-right"></i><span class="ms-2 md:tw-hidden">Salir</span></a></li>
-  {% else %}
-  <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.login') }}">Iniciar sesión</a></li>
-  <li class="nav-item"><a class="nav-link" href="{{ url_for('onboarding.register') }}">Registrarse</a></li>
-  {% endif %}
-  {% if current_user.is_authenticated %}
-  <li class="nav-item text-white mx-2"><i class="bi bi-coin"></i> {{ current_user.credits }}</li>
-  {% if current_user.verification_level >= 2 %}
-  {% include 'components/edu_badge.html' %}
-  {% endif %}
-  {% endif %}
-  <li class="nav-item">
-    <button id="themeToggle" class="btn btn-sm btn-secondary ml-2 focus-visible:tw-ring-2 focus-visible:tw-ring-[var(--primary)] focus-visible:tw-ring-offset-2" type="button"><i class="bi bi-moon"></i><span class="ms-2 md:tw-hidden">Tema</span></button>
-  </li>
+    <div class="collapse navbar-collapse" id="navbarCrunevo">
+      <ul class="navbar-nav ms-auto d-flex flex-column flex-md-row align-items-center gap-2">
+        <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('feed.index') }}">Inicio</a></li>
+        <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('feed.trending') }}">Tendencias</a></li>
+        <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('notes.list_notes') }}">Apuntes</a></li>
+        <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('store.store_index') }}">Tienda</a></li>
+        <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('chat.chat_index') }}">Chat</a></li>
+        {% if current_user.is_authenticated and current_user.role == 'admin' %}
+        <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('admin.dashboard') }}">Admin</a></li>
+        {% endif %}
+        {% if current_user.is_authenticated %}
+        <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('auth.perfil') }}">Perfil</a></li>
+        <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('auth.logout') }}">Salir</a></li>
+        <li class="nav-item text-white mx-2"><i class="bi bi-coin"></i> {{ current_user.credits }}</li>
+        {% if current_user.verification_level >= 2 %}
+          {% include 'components/edu_badge.html' %}
+        {% endif %}
+        {% else %}
+        <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('auth.login') }}">Iniciar sesión</a></li>
+        <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('onboarding.register') }}">Registrarse</a></li>
+        {% endif %}
+        <li class="nav-item">
+          <button id="themeToggle" class="btn btn-sm btn-secondary" type="button"><i class="bi bi-moon"></i></button>
+        </li>
       </ul>
     </div>
   </div>
 </nav>
-
-<div id="mobileMenuOverlay" class="tw-fixed tw-inset-0 tw-bg-black/60 tw-z-50 tw-hidden md:tw-hidden tw-transition-opacity" aria-hidden="true">
-  <div id="mobileMenuPanel" class="tw-fixed tw-top-0 tw-left-0 tw-h-full tw-w-64 tw-bg-white dark:tw-bg-gray-900 tw-transform -tw-translate-x-full tw-transition-transform tw-duration-300 tw-py-4 tw-px-6" role="dialog" aria-modal="true" aria-label="Menú móvil">
-    <button id="closeMobileMenu" class="tw-absolute tw-top-2 tw-right-2 tw-text-2xl" type="button" aria-label="Cerrar menú">&times;</button>
-  </div>
-</div>
-

--- a/crunevo/templates/components/navbar_crunevo_fixed.html
+++ b/crunevo/templates/components/navbar_crunevo_fixed.html
@@ -33,22 +33,3 @@
     </ul>
   </div>
 </nav>
-
-<!-- overlay only for mobile -->
-<div id="mobileMenuOverlay" class="d-md-none position-fixed top-0 start-0 w-100 h-100 bg-dark bg-opacity-50 d-none z-50">
-  <div id="mobileMenuPanel" class="bg-white p-4 h-100 w-75 position-absolute">
-    <button id="closeMobileMenu" class="btn-close float-end" type="button" aria-label="Cerrar menú"></button>
-    <ul class="mt-5 list-unstyled">
-      <li><a href="{{ url_for('feed.index') }}" class="d-block py-2"><i class="bi bi-house-door"></i> Inicio</a></li>
-      <li><a href="{{ url_for('notes.list_notes') }}" class="d-block py-2"><i class="bi bi-journal-text"></i> Apuntes</a></li>
-      <li><a href="{{ url_for('store.store_index') }}" class="d-block py-2"><i class="bi bi-bag"></i> Tienda</a></li>
-      <li><a href="{{ url_for('chat.chat_index') }}" class="d-block py-2"><i class="bi bi-chat-dots"></i> Chat</a></li>
-      {% if current_user.is_authenticated %}
-      <li><a href="{{ url_for('auth.logout') }}" class="d-block py-2">Salir</a></li>
-      {% else %}
-      <li><a href="{{ url_for('auth.login') }}" class="d-block py-2">Iniciar sesión</a></li>
-      <li><a href="{{ url_for('onboarding.register') }}" class="d-block py-2">Registrarse</a></li>
-      {% endif %}
-    </ul>
-  </div>
-</div>

--- a/crunevo/templates/components/toast.html
+++ b/crunevo/templates/components/toast.html
@@ -1,5 +1,3 @@
 {% macro toast(message) %}
-<div class="tw-rounded tw-bg-[var(--primary)]/10 tw-px-4 tw-py-2 tw-text-[var(--primary)] tw-shadow">
-  {{ message }}
-</div>
+<div class="alert alert-primary">{{ message }}</div>
 {% endmacro %}


### PR DESCRIPTION
## Summary
- drop Tailwind CDN and config
- rebuild navbar with only Bootstrap classes
- simplify toast layout and JS helpers
- remove obsolete overlay code and styles
- document navbar migration in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6850bad3291483259dabfd72fb631026