### PR TITLE
Fix PDF upload and download

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,3 +36,4 @@
 - Se agregó "navbar_crunevo_fixed.html" como ejemplo de navbar fijo con menú móvil.
 - Navbar migrado completamente a Bootstrap sin Tailwind ni overlay. Se eliminó el script de Tailwind y se simplificó main.js (PR bootstrap-only navbar).
 - Implemented Tabler-based admin dashboard with new templates and blueprint enforcement.
+- Fixed PDF upload to Cloudinary storing URL and adjusted templates (PR pdf-upload-fix).

--- a/crunevo/routes/notes_routes.py
+++ b/crunevo/routes/notes_routes.py
@@ -48,9 +48,18 @@ def search_notes():
 def upload_note():
     if request.method == "POST":
         f = request.files["file"]
+        if not f or not f.filename:
+            flash("Selecciona un archivo", "danger")
+            return redirect(url_for("notes.upload_note"))
+
+        ext = os.path.splitext(f.filename)[1].lower()
+        if ext != ".pdf":
+            flash("El archivo debe ser un PDF", "danger")
+            return redirect(url_for("notes.upload_note"))
+
         cloud_url = current_app.config.get("CLOUDINARY_URL")
         if cloud_url:
-            result = cloudinary.uploader.upload(f)
+            result = cloudinary.uploader.upload(f, resource_type="raw")
             filepath = result["secure_url"]
         else:
             filename = secure_filename(f.filename)
@@ -157,4 +166,4 @@ def download_note(note_id):
     if note.downloads >= 100:
         unlock_achievement(note.author, AchievementCodes.DESCARGA_100)
 
-    return redirect(f"/{note.filename}")
+    return redirect(note.filename)

--- a/crunevo/templates/notes/detalle.html
+++ b/crunevo/templates/notes/detalle.html
@@ -34,8 +34,8 @@
       {% endif %}
       <p><strong>Likes:</strong> <span id="likeCount">{{ note.likes }}</span></p>
     <div class="ratio ratio-16x9 mb-4">
-      <object data="/{{ note.filename or '' }}" type="application/pdf" width="100%" height="100%">
-        {{ note.filename }}
+      <object data="{{ note.filename }}" type="application/pdf" width="100%" height="100%">
+        <a href="{{ note.filename }}" target="_blank">Descargar</a>
       </object>
     </div>
     <h5 class="mb-3">Comentarios</h5>


### PR DESCRIPTION
## Summary
- validate PDF extension when uploading notes
- upload PDFs to Cloudinary as raw files and store secure URL
- remove leading slash in download redirect
- link to PDF in note detail
- document change in AGENTS guidelines

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6850f75a0260832583ba832a7ddc132c