### PR TITLE
Fix PDF viewer and download

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,4 +38,5 @@
 - Implemented Tabler-based admin dashboard with new templates and blueprint enforcement.
 - Fixed PDF upload to Cloudinary storing URL and adjusted templates (PR pdf-upload-fix).
 - Restored Cloudinary upload logic in `notes_routes.py` to fix undefined variable error (PR notes-upload-fix).
+- Improved PDF handling in notes: use `resource_type='auto'`, display inline with `<iframe>` and direct download link (PR notes-pdf-view).
 

--- a/crunevo/routes/notes_routes.py
+++ b/crunevo/routes/notes_routes.py
@@ -62,10 +62,7 @@ def upload_note():
             filename = secure_filename(f.filename)
             public_id = os.path.splitext(filename)[0]
             result = cloudinary.uploader.upload(
-                f,
-                resource_type="raw",
-                public_id=f"notes/{public_id}.pdf",
-                format="pdf",
+                f, resource_type="auto", public_id=f"notes/{public_id}"
             )
             filepath = result["secure_url"]
         else:

--- a/crunevo/templates/notes/detalle.html
+++ b/crunevo/templates/notes/detalle.html
@@ -21,7 +21,7 @@
       <span class="badge bg-secondary me-1">{{ tag }}</span>
       {% endfor %}
     </div>
-      {{ btn.button('Descargar', href=url_for('notes.download_note', note_id=note.id), class='mb-3') }}
+      <a class="btn btn-primary mb-3" href="{{ note.filename }}" target="_blank">Descargar</a>
       <form id="shareForm" action="{{ url_for('notes.share_note', note_id=note.id) }}" method="post" style="display:inline;">
         {{ csrf.csrf_field() }}
         <button class="btn btn-outline-primary btn-sm" type="submit">🔗 Compartir</button>
@@ -34,9 +34,7 @@
       {% endif %}
       <p><strong>Likes:</strong> <span id="likeCount">{{ note.likes }}</span></p>
     <div class="ratio ratio-16x9 mb-4">
-      <object data="{{ note.filename }}" type="application/pdf" width="100%" height="100%">
-        <a href="{{ note.filename }}" target="_blank">Descargar</a>
-      </object>
+      <iframe src="{{ note.filename }}" width="100%" height="500px" frameborder="0"></iframe>
     </div>
     <h5 class="mb-3">Comentarios</h5>
     <div id="comments">

--- a/crunevo/templates/notes/upload.html
+++ b/crunevo/templates/notes/upload.html
@@ -13,7 +13,9 @@
     </div>
     {{ forms.input('tags', placeholder='Etiquetas') }}
     {{ forms.input('category', placeholder='Categoría') }}
-    {{ forms.input('file', type='file') }}
+    <div class="tw-space-y-1">
+      <input name="file" type="file" accept="application/pdf" required class="tw-rounded tw-border tw-border-gray-300 dark:tw-border-gray-700 tw-w-full tw-px-3 tw-py-2 focus:tw-ring-2 focus:tw-ring-[var(--primary)] focus:tw-outline-none" />
+    </div>
     {{ btn.button('Subir', type='submit') }}
   </form>
 </div>


### PR DESCRIPTION
## Summary
- improve Cloudinary upload for notes by using `resource_type="auto"`
- show a single download button on note detail page
- embed PDF using `<iframe>`
- restrict note upload form to accept PDFs only
- document PDF handling fix in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6851055bde788325b103952aace9a223