### PR TITLE
Answer user question about Cloudinary PDF upload

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,3 +42,4 @@
 - Enhanced notes upload error handling and download route: validate title, catch Cloudinary errors and serve local files with `send_file` (PR notes-error-handling).
 - Updated notes detail template to embed PDFs with an `<iframe>` wrapped in `.ratio`, added fallback download link and removed duplicate buttons (PR pdf-viewer-fix).
 
+- Confirmed notes upload uses `resource_type='auto'` for Cloudinary; recommended verifying URL uses '/raw/upload' (answer to resource_type question).


### PR DESCRIPTION
## Summary
- document that Cloudinary uploads for PDFs already use `resource_type='auto'`

## Testing
- `ruff check .`
- `black . --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68511ad35c708325a2cb9b36a7da3f04