### PR TITLE
Fix Cloudinary raw URL for notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,3 +43,5 @@
 - Updated notes detail template to embed PDFs with an `<iframe>` wrapped in `.ratio`, added fallback download link and removed duplicate buttons (PR pdf-viewer-fix).
 
 - Confirmed notes upload uses `resource_type='auto'` for Cloudinary; recommended verifying URL uses '/raw/upload' (answer to resource_type question).
+- Forced Cloudinary URLs for notes to use `resource_type='raw'` when generating
+  `secure_url` (PR notes-raw-url).

--- a/crunevo/routes/notes_routes.py
+++ b/crunevo/routes/notes_routes.py
@@ -68,12 +68,15 @@ def upload_note():
             if cloud_url:
                 filename = secure_filename(f.filename)
                 public_id = os.path.splitext(filename)[0]
-                result = cloudinary.uploader.upload(
+                _ = cloudinary.uploader.upload(
                     f,
                     resource_type="auto",
                     public_id=f"notes/{public_id}",
                 )
-                filepath = result["secure_url"]
+                url, _ = cloudinary.utils.cloudinary_url(
+                    f"notes/{public_id}.pdf", resource_type="raw", secure=True
+                )
+                filepath = url
             else:
                 filename = secure_filename(f.filename)
                 upload_folder = current_app.config["UPLOAD_FOLDER"]


### PR DESCRIPTION
## Summary
- update Cloudinary upload logic to build `resource_type='raw'` URL
- document new behavior in AGENTS guidelines

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68511e87d17883258f9f27d66881f436