### PR TITLE
Fix Cloudinary PDF URL for iframe view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,3 +45,4 @@
 - Confirmed notes upload uses `resource_type='auto'` for Cloudinary; recommended verifying URL uses '/raw/upload' (answer to resource_type question).
 - Forced Cloudinary URLs for notes to use `resource_type='raw'` when generating
   `secure_url` (PR notes-raw-url).
+- Ajustado el flujo de subida de PDF a Cloudinary para almacenar `resource_type='image'` en la URL principal. Esto permite visualizar correctamente el archivo en un `<iframe>` sin bloqueos por `/raw/upload`.

--- a/crunevo/routes/notes_routes.py
+++ b/crunevo/routes/notes_routes.py
@@ -72,11 +72,14 @@ def upload_note():
                     f,
                     resource_type="auto",
                     public_id=f"notes/{public_id}",
+                    format="pdf",
                 )
-                url, _ = cloudinary.utils.cloudinary_url(
-                    f"notes/{public_id}.pdf", resource_type="raw", secure=True
+                view_url, _ = cloudinary.utils.cloudinary_url(
+                    f"notes/{public_id}.pdf",
+                    resource_type="image",
+                    secure=True,
                 )
-                filepath = url
+                filepath = view_url
             else:
                 filename = secure_filename(f.filename)
                 upload_folder = current_app.config["UPLOAD_FOLDER"]


### PR DESCRIPTION
## Summary
- store Cloudinary view URL using `resource_type='image'`
- document change in AGENTS

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6851bad5df0483259ee91eaa379269cb