### PR TITLE
Add PDF.js viewer for notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,3 +47,4 @@
   `secure_url` (PR notes-raw-url).
 - Ajustado el flujo de subida de PDF a Cloudinary para almacenar `resource_type='image'` en la URL principal. Esto permite visualizar correctamente el archivo en un `<iframe>` sin bloqueos por `/raw/upload`.
 - Reemplazado iframe de detalle de nota para usar Google gview y permitir visualización embebida (PR gview-iframe).
+- Se integró PDF.js como visor en `detalle.html`, cargando el primer canvas con el PDF y manteniendo enlace de descarga. (PR pdfjs-viewer)

--- a/crunevo/templates/notes/detalle.html
+++ b/crunevo/templates/notes/detalle.html
@@ -33,9 +33,7 @@
       </form>
       {% endif %}
       <p><strong>Likes:</strong> <span id="likeCount">{{ note.likes }}</span></p>
-    <div class="ratio ratio-16x9 mb-4">
-      <iframe src="https://docs.google.com/gview?url={{ note.filename }}&embedded=true" width="100%" height="600px" frameborder="0"></iframe>
-    </div>
+    <canvas id="pdfViewer" class="w-100 border rounded shadow-sm mb-3" style="max-height: 600px;"></canvas>
     <p class="text-muted small">¿No puedes visualizar el PDF? <a href="{{ note.filename }}" target="_blank">Haz clic aquí para descargarlo</a>.</p>
     <h5 class="mb-3">Comentarios</h5>
     <div id="comments">
@@ -97,6 +95,38 @@
     csrfFetch(this.action, {method:'POST'}).then(() => {
       showToast('Gracias por compartir');
     }).finally(() => { btn.disabled = false; });
+  });
+</script>
+{% endblock %}
+
+{% block body_end %}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
+<script>
+  const url = "{{ note.filename }}";
+
+  const loadingTask = pdfjsLib.getDocument(url);
+  loadingTask.promise.then(pdf => {
+    pdf.getPage(1).then(page => {
+      const scale = 1.5;
+      const viewport = page.getViewport({ scale });
+
+      const canvas = document.getElementById('pdfViewer');
+      const context = canvas.getContext('2d');
+      canvas.height = viewport.height;
+      canvas.width = viewport.width;
+
+      const renderContext = {
+        canvasContext: context,
+        viewport: viewport
+      };
+      page.render(renderContext);
+    });
+  }).catch(error => {
+    console.error("Error al cargar el PDF:", error);
+    const fallback = document.createElement("p");
+    fallback.className = "text-danger";
+    fallback.textContent = "No se pudo cargar el PDF. Puedes descargarlo abajo.";
+    document.getElementById("pdfViewer").replaceWith(fallback);
   });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- embed PDFs with a canvas using PDF.js
- keep download link as fallback
- document change in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6851d7a5b3ec8325a53c2921b84dda44