### PR TITLE
Fix onboarding pending link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,3 +60,4 @@
 - Actualizado `<header>` en `admin/partials/topbar.html` con clase `navbar-light` (PR admin-topbar-light).
 - Navbar ahora usa clase `navbar-crunevo` y `navbar-expand-md`, con iconos en cada enlace (PR navbar-icons).
 - Implementado input rápido en el feed para publicar texto e imagen o PDF, mostrando los últimos posts (PR feed-quick-input).
+- Corregido url_for en pending.html para usar 'feed.index' y evitar BuildError (PR pending-home-link)

--- a/crunevo/templates/onboarding/pending.html
+++ b/crunevo/templates/onboarding/pending.html
@@ -8,6 +8,6 @@
     {{ csrf.csrf_field() }}
     {{ btn.button('Reenviar correo', type='submit') }}
   </form>
-  {{ btn.button('Volver al inicio', href=url_for('index')) }}
+  {{ btn.button('Volver al inicio', href=url_for('feed.index')) }}
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- correct onboarding pending template to link to `feed.index`
- document change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68522fea86c48325b7afe75421d5611c