### PR TITLE
Add featured posts section to feed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,3 +61,4 @@
 - Navbar ahora usa clase `navbar-crunevo` y `navbar-expand-md`, con iconos en cada enlace (PR navbar-icons).
 - Implementado input rápido en el feed para publicar texto e imagen o PDF, mostrando los últimos posts (PR feed-quick-input).
 - Corregido url_for en pending.html para usar 'feed.index' y evitar BuildError (PR pending-home-link)
+- Añadida sección de destacados en el feed con notas más vistas, posts populares y usuarios con logros recientes (PR featured-posts)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,3 +62,4 @@
 - Implementado input rápido en el feed para publicar texto e imagen o PDF, mostrando los últimos posts (PR feed-quick-input).
 - Corregido url_for en pending.html para usar 'feed.index' y evitar BuildError (PR pending-home-link)
 - Añadida sección de destacados en el feed con notas más vistas, posts populares y usuarios con logros recientes (PR featured-posts)
+- Añadido ranking semanal y logros recientes en el feed (PR weekly-ranking)

--- a/crunevo/routes/feed_routes.py
+++ b/crunevo/routes/feed_routes.py
@@ -15,7 +15,7 @@ from flask_login import current_user
 from crunevo.utils.helpers import activated_required
 from datetime import datetime
 from crunevo.extensions import db, csrf
-from crunevo.models import Post, FeedItem, Note
+from crunevo.models import Post, FeedItem, Note, User, UserAchievement
 from crunevo.forms import FeedNoteForm, FeedImageForm
 from crunevo.utils import create_feed_item_for_all, unlock_achievement
 from crunevo.utils.credits import add_credit
@@ -25,6 +25,20 @@ from crunevo.cache.feed_cache import fetch as cache_fetch, push_items as cache_p
 
 feed_bp = Blueprint("feed", __name__)
 csrf.exempt(feed_bp)
+
+
+def get_featured_posts():
+    """Return top notes, posts and users with recent achievements."""
+    top_notes = Note.query.order_by(Note.views.desc()).limit(3).all()
+    top_posts = Post.query.order_by(Post.likes.desc()).limit(3).all()
+    top_users = (
+        User.query.join(UserAchievement)
+        .order_by(UserAchievement.earned_at.desc())
+        .distinct()
+        .limit(3)
+        .all()
+    )
+    return top_notes, top_posts, top_users
 
 
 @feed_bp.route("/feed", methods=["GET", "POST"])
@@ -148,7 +162,14 @@ def index():
         return redirect(url_for("feed.index"))
 
     posts = Post.query.order_by(Post.created_at.desc()).limit(10).all()
-    return render_template("feed/feed.html", posts=posts)
+    top_notes, top_posts, top_users = get_featured_posts()
+    return render_template(
+        "feed/feed.html",
+        posts=posts,
+        top_notes=top_notes,
+        top_posts=top_posts,
+        top_users=top_users,
+    )
 
 
 @feed_bp.route("/trending")

--- a/crunevo/templates/feed/feed.html
+++ b/crunevo/templates/feed/feed.html
@@ -8,6 +8,43 @@
   <input type="file" name="file" accept=".jpg,.png,.pdf" class="form-control mb-2">
   <button class="btn btn-primary" type="submit">Publicar</button>
 </form>
+<div class="row mb-4 tw-gap-2">
+  <div class="col-md-4">
+    <h5>📘 Apuntes más vistos</h5>
+    {% for note in top_notes %}
+    <div class="card mb-2 tw-shadow-sm">
+      <div class="card-body">
+        <h6 class="card-title">{{ note.title }}</h6>
+        <a href="{{ url_for('notes.detail', note_id=note.id) }}" class="btn btn-sm btn-primary">Ver</a>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+
+  <div class="col-md-4">
+    <h5>🔥 Publicaciones populares</h5>
+    {% for post in top_posts %}
+    <div class="card mb-2 tw-shadow-sm">
+      <div class="card-body">
+        <p>{{ post.content[:100] }}...</p>
+        <a href="{{ url_for('feed.view_post', post_id=post.id) }}" class="btn btn-sm btn-outline-primary">Ver más</a>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+
+  <div class="col-md-4">
+    <h5>🏅 Usuarios destacados</h5>
+    {% for user in top_users %}
+    <div class="card mb-2 tw-shadow-sm">
+      <div class="card-body">
+        <strong>{{ user.username }}</strong><br>
+        <span class="badge bg-info">Logros recientes</span>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+</div>
 {% for post in posts %}
   <div class="card mb-3 shadow-sm">
     <div class="card-body">

--- a/crunevo/templates/feed/feed.html
+++ b/crunevo/templates/feed/feed.html
@@ -45,26 +45,54 @@
     {% endfor %}
   </div>
 </div>
-{% for post in posts %}
-  <div class="card mb-3 shadow-sm">
-    <div class="card-body">
-      <div class="d-flex align-items-center mb-2">
-        <img src="{{ post.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
-        <a href="{{ url_for('auth.public_profile', user_id=post.author.id) }}" class="me-auto text-decoration-none">
-          <strong>{{ post.author.username }}</strong>
-        </a>
-        <small class="text-muted">{{ post.created_at.strftime('%Y-%m-%d') }}</small>
-      </div>
-      <p class="card-text">{{ post.content }}</p>
-      {% if post.file_url %}
-        {% if post.file_url.endswith('.pdf') %}
-        <a href="{{ post.file_url }}" target="_blank" class="btn btn-sm btn-outline-primary mb-2">Ver PDF</a>
-        {% else %}
-        <img src="{{ post.file_url }}" class="img-fluid rounded mb-2">
+<div class="row">
+  <div class="col-lg-8">
+    {% for post in posts %}
+    <div class="card mb-3 shadow-sm">
+      <div class="card-body">
+        <div class="d-flex align-items-center mb-2">
+          <img src="{{ post.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
+          <a href="{{ url_for('auth.public_profile', user_id=post.author.id) }}" class="me-auto text-decoration-none">
+            <strong>{{ post.author.username }}</strong>
+          </a>
+          <small class="text-muted">{{ post.created_at.strftime('%Y-%m-%d') }}</small>
+        </div>
+        <p class="card-text">{{ post.content }}</p>
+        {% if post.file_url %}
+          {% if post.file_url.endswith('.pdf') %}
+          <a href="{{ post.file_url }}" target="_blank" class="btn btn-sm btn-outline-primary mb-2">Ver PDF</a>
+          {% else %}
+          <img src="{{ post.file_url }}" class="img-fluid rounded mb-2">
+          {% endif %}
         {% endif %}
-      {% endif %}
-      <div class="text-muted small">{{ post.likes }} likes</div>
+        <div class="text-muted small">{{ post.likes }} likes</div>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+  <div class="col-lg-4 mt-4 mt-lg-0">
+    <div class="card mb-3">
+      <div class="card-header bg-success text-white">🏆 Top de la semana</div>
+      <ul class="list-group list-group-flush">
+        {% for user in top_ranked %}
+        <li class="list-group-item">
+          <strong>{{ user.username }}</strong><br>
+          Créditos: {{ user.credits }}
+        </li>
+        {% endfor %}
+      </ul>
+    </div>
+
+    <div class="card">
+      <div class="card-header bg-info text-white">🧩 Logros recientes</div>
+      <ul class="list-group list-group-flush">
+        {% for user, logros in recent_achievements %}
+        <li class="list-group-item">
+          <strong>{{ user }}</strong>: {{ logros }}
+        </li>
+        {% endfor %}
+      </ul>
     </div>
   </div>
-{% endfor %}
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- create `get_featured_posts` helper to fetch top notes, posts and users with recent achievements
- display the featured posts section in the feed template
- document the new feature in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6852310ae7ec8325b641c04f5538b32e