### PR TITLE
Fix feed template for deleted users

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,3 +65,4 @@
 - Añadido ranking semanal y logros recientes en el feed (PR weekly-ranking)
 - Corregidos formularios del panel de administración: `manage_users` acepta
   POST, `user_actions.html` importa `csrf_field` y envía `user_id` (PR admin-fixes)
+- Fixed feed template to handle posts without an author (PR orphan-posts-fix).

--- a/crunevo/templates/feed/feed.html
+++ b/crunevo/templates/feed/feed.html
@@ -51,10 +51,15 @@
     <div class="card mb-3 shadow-sm">
       <div class="card-body">
         <div class="d-flex align-items-center mb-2">
+          {% if post.author %}
           <img src="{{ post.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
           <a href="{{ url_for('auth.public_profile', user_id=post.author.id) }}" class="me-auto text-decoration-none">
             <strong>{{ post.author.username }}</strong>
           </a>
+          {% else %}
+          <img src="{{ url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
+          <span class="me-auto text-muted">Usuario eliminado</span>
+          {% endif %}
           <small class="text-muted">{{ post.created_at.strftime('%Y-%m-%d') }}</small>
         </div>
         <p class="card-text">{{ post.content }}</p>


### PR DESCRIPTION
## Summary
- handle posts with deleted authors in feed
- document the fix in AGENTS guidelines

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6852369a4c088325b8645051127e791f