### PR TITLE
Fix top users ordering error

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,3 +67,4 @@
   POST, `user_actions.html` importa `csrf_field` y envía `user_id` (PR admin-fixes)
 - Fixed feed template to handle posts without an author (PR orphan-posts-fix).
 - Simplified author checks in feed template using a local variable (PR feed-author-var).
+- Corregido el query de usuarios destacados para agrupar por usuario y ordenar por el logro más reciente (PR top-users-orderby-fix).

--- a/crunevo/routes/feed_routes.py
+++ b/crunevo/routes/feed_routes.py
@@ -14,6 +14,7 @@ from flask import (
 from flask_login import current_user
 from crunevo.utils.helpers import activated_required
 from datetime import datetime
+from sqlalchemy import func
 from crunevo.extensions import db, csrf
 from crunevo.models import (
     Post,
@@ -39,9 +40,10 @@ def get_featured_posts():
     top_notes = Note.query.order_by(Note.views.desc()).limit(3).all()
     top_posts = Post.query.order_by(Post.likes.desc()).limit(3).all()
     top_users = (
-        User.query.join(UserAchievement)
-        .order_by(UserAchievement.earned_at.desc())
-        .distinct()
+        db.session.query(User)
+        .join(UserAchievement)
+        .group_by(User.id)
+        .order_by(func.max(UserAchievement.earned_at).desc())
         .limit(3)
         .all()
     )


### PR DESCRIPTION
## Summary
- group top users by User.id and sort by latest achievement
- document fix in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68523bf6ce508325b6804f1e3eb25aca