### PR TITLE
Full-width layout refactor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,3 +77,4 @@
 - Revalidado enlace a `feed.view_post`; no se reproduce BuildError y se mantiene alias `/posts/<id>` (QA feed-view-post-check 2).
 - Prueba adicional confirma url_for("feed.view_post") genera /post/<id> (QA feed-view-post-check 3).
 - Endpoint `feed.view_post` se define explícitamente en la ruta y se comprueba que la blueprint está registrada (QA feed-view-post-check 4).
+- Layout updated to use `container-fluid px-md-5` and sidebars distributed per page with row/col system (PR full-width-layout).

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -19,28 +19,18 @@
 </head>
 <body class="d-flex flex-column min-vh-100">
     {% include 'components/navbar.html' %}
-    <div class="container">
-        <div class="row gx-4">
-            <aside class="d-none d-lg-block col-lg-3">
-                {% include 'components/sidebar_left.html' %}
-            </aside>
-            <main class="col-lg-6">
-                {% import 'components/toast.html' as toast %}
-                {% with messages = get_flashed_messages() %}
-                  {% if messages %}
-                    <div class="toast-container position-fixed top-0 start-0 end-0 z-50 d-flex flex-column align-items-center gap-2 mt-5">
-                      {% for msg in messages %}
-                        {{ toast.toast(msg) }}
-                      {% endfor %}
-                    </div>
-                  {% endif %}
-                {% endwith %}
-                {% block content %}{% endblock %}
-            </main>
-            <aside class="d-none d-lg-block col-lg-3">
-                {% include 'components/sidebar_right.html' %}
-            </aside>
-        </div>
+    <div class="container-fluid px-md-5">
+        {% import 'components/toast.html' as toast %}
+        {% with messages = get_flashed_messages() %}
+          {% if messages %}
+            <div class="toast-container position-fixed top-0 start-0 end-0 z-50 d-flex flex-column align-items-center gap-2 mt-5">
+              {% for msg in messages %}
+                {{ toast.toast(msg) }}
+              {% endfor %}
+            </div>
+          {% endif %}
+        {% endwith %}
+        {% block content %}{% endblock %}
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>

--- a/crunevo/templates/feed/feed.html
+++ b/crunevo/templates/feed/feed.html
@@ -1,14 +1,22 @@
 {% extends 'base.html' %}
 {% import 'components/csrf.html' as csrf %}
 {% block content %}
-<h5 class="mb-3">Feed</h5>
-<form method="post" enctype="multipart/form-data" class="mb-4">
-  {{ csrf.csrf_field() }}
-  <textarea name="content" class="form-control mb-2" placeholder="Comparte una idea" required></textarea>
-  <input type="file" name="file" accept=".jpg,.png,.pdf" class="form-control mb-2">
-  <button class="btn btn-primary" type="submit">Publicar</button>
-</form>
-<div class="row mb-4 tw-gap-2">
+<div class="row">
+  <!-- Lado izquierdo (menú lateral) -->
+  <div class="col-lg-2 d-none d-lg-block">
+    {% include 'components/sidebar_left.html' %}
+  </div>
+
+  <!-- Contenido central -->
+  <div class="col-lg-7 col-md-12">
+    <h5 class="mb-3">Feed</h5>
+    <form method="post" enctype="multipart/form-data" class="mb-4">
+      {{ csrf.csrf_field() }}
+      <textarea name="content" class="form-control mb-2" placeholder="Comparte una idea" required></textarea>
+      <input type="file" name="file" accept=".jpg,.png,.pdf" class="form-control mb-2">
+      <button class="btn btn-primary" type="submit">Publicar</button>
+    </form>
+    <div class="row mb-4 tw-gap-2">
   <div class="col-md-4">
     <h5>📘 Apuntes más vistos</h5>
     {% for note in top_notes %}
@@ -99,6 +107,11 @@
         {% endfor %}
       </ul>
     </div>
+  </div> <!-- Fin row de publicaciones -->
+  </div> <!-- Fin contenido central -->
+  <!-- Zona derecha (destacados, ranking, etc.) -->
+  <div class="col-lg-3 d-none d-lg-block">
+    {% include 'components/sidebar_right.html' %}
   </div>
 </div>
 {% endblock %}

--- a/crunevo/templates/notes/list.html
+++ b/crunevo/templates/notes/list.html
@@ -1,15 +1,22 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2>Apuntes</h2>
-<div class="row align-items-center mb-3">
-  <div class="col">
-    <input type="text" id="noteSearch" class="form-control" placeholder="Buscar...">
+<div class="row">
+  <!-- Lado izquierdo (menú lateral) -->
+  <div class="col-lg-2 d-none d-lg-block">
+    {% include 'components/sidebar_left.html' %}
   </div>
-  <div class="col-auto">
-    <a href="{{ url_for('notes.upload_note') }}" class="btn btn-success">Subir nuevo</a>
-  </div>
-</div>
-<div class="row row-cols-1 row-cols-md-2 g-3" id="notesList">
+  <!-- Contenido central -->
+  <div class="col-lg-7 col-md-12">
+    <h2>Apuntes</h2>
+    <div class="row align-items-center mb-3 d-flex justify-content-between">
+      <div class="col">
+        <input type="text" id="noteSearch" class="form-control" placeholder="Buscar...">
+      </div>
+      <div class="col-auto">
+        <a href="{{ url_for('notes.upload_note') }}" class="btn btn-success">Subir nuevo</a>
+      </div>
+    </div>
+    <div class="row row-cols-1 row-cols-md-2 g-3" id="notesList">
 {% for note in notes %}
   <div class="col">
     <div class="card h-100 shadow-sm">
@@ -66,4 +73,9 @@ function createNoteCard(n) {
   return col;
 }
 </script>
+  </div> <!-- Fin contenido central -->
+  <div class="col-lg-3 d-none d-lg-block">
+    {% include 'components/sidebar_right.html' %}
+  </div>
+</div>
 {% endblock %}

--- a/crunevo/templates/store/store.html
+++ b/crunevo/templates/store/store.html
@@ -1,36 +1,51 @@
 {% extends 'base.html' %}
 {% import 'components/button.html' as btn %}
 {% block content %}
-<h2 class="mb-4">Tienda</h2>
 <div class="row">
-  <aside class="col-lg-3 mb-3">
-    <div class="tw-rounded-2xl tw-shadow-sm tw-bg-white dark:tw-bg-gray-900 tw-p-4">
-        <h6 class="card-title">Filtros</h6>
-        <hr>
-        <div class="mb-3">
-          <strong>Categorías</strong>
-          <div class="form-check">
-            <input class="form-check-input" type="checkbox" id="cat1">
-            <label class="form-check-label" for="cat1">General</label>
+  <!-- Lado izquierdo (menú lateral) -->
+  <div class="col-lg-2 d-none d-lg-block">
+    {% include 'components/sidebar_left.html' %}
+  </div>
+
+  <!-- Contenido central -->
+  <div class="col-lg-7 col-md-12">
+    <h2 class="mb-4">Tienda</h2>
+    <div class="row d-flex justify-content-between">
+      <aside class="col-md-4 col-lg-3 mb-3 d-none d-md-block">
+        <div class="tw-rounded-2xl tw-shadow-sm tw-bg-white dark:tw-bg-gray-900 tw-p-4">
+            <h6 class="card-title">Filtros</h6>
+            <hr>
+            <div class="mb-3">
+              <strong>Categorías</strong>
+              <div class="form-check">
+                <input class="form-check-input" type="checkbox" id="cat1">
+                <label class="form-check-label" for="cat1">General</label>
+              </div>
+            </div>
+            <div class="mb-3">
+              <strong>Precio</strong>
+              <input type="range" class="form-range" min="0" max="100">
+            </div>
           </div>
+      </aside>
+      <div class="col-md-8 col-lg-9">
+        <div class="row g-3">
+          {% for product in products %}
+          <div class="col-sm-6 col-md-4">
+            {% include 'store/product_card.html' %}
+          </div>
+          {% endfor %}
         </div>
-        <div class="mb-3">
-          <strong>Precio</strong>
-          <input type="range" class="form-range" min="0" max="100">
+        <div class="mt-4 text-end">
+          {{ btn.button('Ver Carrito', href=url_for('store.view_cart'), variant='secondary') }}
         </div>
       </div>
-  </aside>
-  <div class="col-lg-9">
-    <div class="row g-3">
-      {% for product in products %}
-      <div class="col-sm-6 col-md-4">
-        {% include 'store/product_card.html' %}
-      </div>
-      {% endfor %}
     </div>
-    <div class="mt-4 text-end">
-      {{ btn.button('Ver Carrito', href=url_for('store.view_cart'), variant='secondary') }}
-    </div>
+  </div>
+
+  <!-- Zona derecha (destacados, ranking, etc.) -->
+  <div class="col-lg-3 d-none d-lg-block">
+    {% include 'components/sidebar_right.html' %}
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- convert base layout to use `container-fluid`
- move sidebars into feed, notes list and store pages with new row/col layout
- enhance store layout with responsive filter sidebar
- document change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685250a9b8908325b804c1b236d200cb