### PR TITLE
Fix admin spacing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,3 +82,5 @@
 - Se ajustó 'feed.html' corrigiendo clases y confirmando las columnas de destacados (PR feed-layout-fix2).
 - Ajustado el layout de destacados para distribuir correctamente las tarjetas en tres columnas (PR feed-layout-fix3).
 - Verificada CSS global sin conflictos y la fila de destacados usa `row-cols-md-3` para asegurar las tres columnas (PR feed-layout-fix4).
+- Ajustado layout de admin para separar navbar fijo y añadir padding al contenido (PR admin-spacing-fix).
+- Mejorado `base_admin.html` con padding horizontal en el main y sidebar con enlaces actualizados (PR admin-spacing-fix2).

--- a/crunevo/templates/admin/add_edit_product.html
+++ b/crunevo/templates/admin/add_edit_product.html
@@ -1,6 +1,6 @@
 {% extends 'admin/base_admin.html' %}
 {% import 'components/csrf.html' as csrf %}
-{% block content %}
+{% block admin_content %}
 <h2 class="page-title">Agregar/Editar Producto</h2>
 <form method="post" enctype="multipart/form-data" class="card p-3">
   {{ csrf.csrf_field() }}

--- a/crunevo/templates/admin/base_admin.html
+++ b/crunevo/templates/admin/base_admin.html
@@ -7,16 +7,16 @@
   <script src="https://cdn.jsdelivr.net/npm/simple-datatables@latest" defer></script>
   <link rel="stylesheet" href="{{ url_for('static', filename='admin/custom.css') }}">
 {% endblock %}
-{% block body %}
-<body class="layout-fluid {% if current_user.pref_dark %}theme-dark{% endif %}">
-  <div class="page">
-    {% include "admin/partials/topbar.html" %}
-    {% include "admin/partials/sidebar.html" %}
-    <div class="page-wrapper">
-      <div class="container-xl">
-        {% block content %}{% endblock %}
-      </div>
+{% block content %}
+  {% include "admin/partials/topbar.html" %}
+  <div class="container-fluid mt-5">
+    <div class="row">
+      <aside class="col-lg-3 d-none d-lg-block">
+        {% include "admin/partials/sidebar.html" %}
+      </aside>
+      <main class="col-lg-9 px-md-4 pt-4">
+        {% block admin_content %}{% endblock %}
+      </main>
     </div>
   </div>
-</body>
 {% endblock %}

--- a/crunevo/templates/admin/dashboard.html
+++ b/crunevo/templates/admin/dashboard.html
@@ -1,5 +1,5 @@
 {% extends 'admin/base_admin.html' %}
-{% block content %}
+{% block admin_content %}
 <div class="row row-cards">
   <div class="col-sm-6 col-lg-3">
     <div class="card card-sm">

--- a/crunevo/templates/admin/manage_reports.html
+++ b/crunevo/templates/admin/manage_reports.html
@@ -1,5 +1,5 @@
 {% extends 'admin/base_admin.html' %}
-{% block content %}
+{% block admin_content %}
 <h2 class="page-title">Reportes</h2>
 <div class="card">
   <div class="table-responsive">

--- a/crunevo/templates/admin/manage_store.html
+++ b/crunevo/templates/admin/manage_store.html
@@ -1,5 +1,5 @@
 {% extends 'admin/base_admin.html' %}
-{% block content %}
+{% block admin_content %}
 <h2 class="page-title">Administrar Tienda</h2>
 <a href="{{ url_for('admin.add_product') }}" class="btn btn-success mb-3">Nuevo producto</a>
 <div class="card">

--- a/crunevo/templates/admin/manage_users.html
+++ b/crunevo/templates/admin/manage_users.html
@@ -1,5 +1,5 @@
 {% extends 'admin/base_admin.html' %}
-{% block content %}
+{% block admin_content %}
 <h2 class="page-title">Gestión de usuarios</h2>
 
 <div class="card">

--- a/crunevo/templates/admin/partials/sidebar.html
+++ b/crunevo/templates/admin/partials/sidebar.html
@@ -2,9 +2,9 @@
   <div class="collapse navbar-collapse" id="sidebar-menu">
     <ul class="navbar-nav pt-lg-3">
       <li class="nav-item"><a class="nav-link" href="{{ url_for('admin.dashboard') }}"><i class="ti ti-home"></i> Dashboard</a></li>
-      <li class="nav-item"><a class="nav-link" href="{{ url_for('admin.manage_users') }}"><i class="ti ti-users"></i> Usuarios</a></li>
-      <li class="nav-item"><a class="nav-link" href="{{ url_for('admin.manage_store') }}"><i class="ti ti-credit-card"></i> Créditos</a></li>
+      <li class="nav-item"><a class="nav-link" href="{{ url_for('admin.manage_users') }}"><i class="ti ti-users"></i> Gestionar usuarios</a></li>
       <li class="nav-item"><a class="nav-link" href="{{ url_for('admin.manage_reports') }}"><i class="ti ti-flag"></i> Reportes</a></li>
+      <li class="nav-item"><a class="nav-link" href="{{ url_for('admin.manage_store') }}"><i class="ti ti-building-store"></i> Tienda</a></li>
     </ul>
   </div>
 </div>

--- a/crunevo/templates/admin/verifications.html
+++ b/crunevo/templates/admin/verifications.html
@@ -1,6 +1,6 @@
 {% extends 'admin/base_admin.html' %}
 {% import 'components/csrf.html' as csrf %}
-{% block content %}
+{% block admin_content %}
 <h2 class="page-title">Verificaciones pendientes</h2>
 <div class="card">
   <div class="table-responsive">


### PR DESCRIPTION
## Summary
- restructure `base_admin.html` to add container-fluid layout and sidebar column
- rename admin blocks to `admin_content`
- document admin layout update in AGENTS guidelines
- add horizontal padding in admin main content and update sidebar links

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68525c9245748325b9fd93ba5106b616