### PR TITLE
Fix like_post with null likes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,3 +93,4 @@
 - Layout de admin en dos columnas con sidebar fijo y topbar dentro de main. Sidebar usa `nav flex-column` (PR admin-sidebar-col-fix).
 - Añadido sistema de navegación de secciones por botones en el feed (PR feed-section-buttons).
 - Estructura de admin modernizada con Tabler 1.3.x: sidebar fijo, topbar simplificada y soporte de tema oscuro (PR admin-modern-layout).
+- Fixed like_post to initialize likes when null (PR post-like-null-fix).

--- a/crunevo/routes/feed_routes.py
+++ b/crunevo/routes/feed_routes.py
@@ -234,6 +234,8 @@ feed_bp.add_url_rule("/posts/<int:post_id>", endpoint="view_post", view_func=vie
 @activated_required
 def like_post(post_id):
     post = Post.query.get_or_404(post_id)
+    if post.likes is None:
+        post.likes = 0
     post.likes += 1
     db.session.commit()
     return jsonify({"likes": post.likes})

--- a/tests/test_post_likes.py
+++ b/tests/test_post_likes.py
@@ -1,0 +1,19 @@
+from crunevo.models import Post
+
+
+def login(client, username, password):
+    return client.post("/login", data={"username": username, "password": password})
+
+
+def test_like_post_handles_null_likes(client, db_session, test_user, another_user):
+    post = Post(content="hello", author=another_user, likes=None)
+    db_session.add(post)
+    db_session.commit()
+
+    login(client, test_user.username, "secret")
+    resp = client.post(f"/like/{post.id}")
+    assert resp.status_code == 200
+    assert resp.get_json()["likes"] == 1
+
+    db_session.refresh(post)
+    assert post.likes == 1


### PR DESCRIPTION
## Summary
- handle NULL `post.likes` in feed route
- test liking a post when likes is NULL
- document the fix in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68527a27d8ac832595d498486ea66e93