### PR TITLE
Hide main navbar on admin pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,3 +94,4 @@
 - Añadido sistema de navegación de secciones por botones en el feed (PR feed-section-buttons).
 - Estructura de admin modernizada con Tabler 1.3.x: sidebar fijo, topbar simplificada y soporte de tema oscuro (PR admin-modern-layout).
 - Fixed like_post to initialize likes when null (PR post-like-null-fix).
+- Navbar principal se oculta en /admin usando un condicional en base.html (PR admin-navbar-hide).

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -18,7 +18,9 @@
     {% block head_extra %}{% endblock %}
 </head>
 <body class="d-flex flex-column min-vh-100">
-    {% include 'components/navbar.html' %}
+    {% if not request.path.startswith('/admin') %}
+      {% include 'components/navbar.html' %}
+    {% endif %}
     <div class="container-fluid px-md-5">
         {% import 'components/toast.html' as toast %}
         {% with messages = get_flashed_messages() %}


### PR DESCRIPTION
## Summary
- avoid including the purple navbar when visiting admin URLs
- document change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68527bf62ff0832585c6b1f3b5b99bd4