### PR TITLE
Implement admin dashboard cards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,3 +98,7 @@
 - Implementado filtros rápidos en el feed por query string (PR feed-quick-filters).
 - Lista de apuntes ahora permite filtrar por recientes, más vistos y categorías y muestra tags en cada tarjeta (PR notes-filters).
 - Apuntes admiten comentarios y reacción con likes que se pueden quitar (PR notes-comments-likes).
+- Gestión de usuarios ahora incluye acciones rápidas por fila con dropdown y modal para cambiar rol (PR user-quick-actions).
+- Panel de productos en admin incluye edición visual, eliminación segura y acceso directo a vista pública (PR admin-product-actions).
+
+- Panel de administración muestra tarjetas con métricas de usuarios, apuntes, tienda, créditos y ranking (PR admin-dashboard-cards).

--- a/crunevo/templates/admin/add_edit_product.html
+++ b/crunevo/templates/admin/add_edit_product.html
@@ -4,10 +4,18 @@
 <h2 class="page-title mb-4">Agregar/Editar Producto</h2>
 <form method="post" enctype="multipart/form-data" class="card shadow-sm p-3">
   {{ csrf.csrf_field() }}
-  <div class="mb-3"><input type="text" name="name" class="form-control" placeholder="Nombre" required></div>
-  <div class="mb-3"><textarea name="description" class="form-control" placeholder="Descripción"></textarea></div>
-  <div class="mb-3"><input type="number" step="0.01" name="price" class="form-control" placeholder="Precio" required></div>
-  <div class="mb-3"><input type="number" name="stock" class="form-control" placeholder="Stock" value="0"></div>
+  <div class="mb-3">
+    <input type="text" name="name" class="form-control" placeholder="Nombre" required value="{{ product.name if product else '' }}">
+  </div>
+  <div class="mb-3">
+    <textarea name="description" class="form-control" placeholder="Descripción">{{ product.description if product else '' }}</textarea>
+  </div>
+  <div class="mb-3">
+    <input type="number" step="0.01" name="price" class="form-control" placeholder="Precio" required value="{{ product.price if product else '' }}">
+  </div>
+  <div class="mb-3">
+    <input type="number" name="stock" class="form-control" placeholder="Stock" value="{{ product.stock if product else 0 }}">
+  </div>
   <div class="mb-3"><input type="file" name="image" class="form-control"></div>
   <button class="btn btn-primary" type="submit">Guardar</button>
 </form>

--- a/crunevo/templates/admin/dashboard.html
+++ b/crunevo/templates/admin/dashboard.html
@@ -1,31 +1,64 @@
 {% extends 'admin/base_admin.html' %}
 {% block admin_content %}
-<h2 class="page-title mb-4">Estadísticas</h2>
+<h2 class="page-title mb-4">Panel de Administración</h2>
+
 <div class="row row-cards">
   <div class="col-sm-6 col-lg-3">
-    <div class="card card-sm shadow-sm">
+    <div class="card">
       <div class="card-body">
-        <div class="d-flex align-items-center">
-          <span class="text-secondary"><i class="ti ti-user fs-2"></i></span>
-          <div class="ms-3 lh-sm">
-            <div class="text-muted">Usuarios</div>
-            <div class="h3 m-0">{{ stats.users_total }}</div>
-          </div>
-        </div>
+        <div class="h1 mb-1">{{ users_total }}</div>
+        <div class="text-muted">Usuarios registrados</div>
+      </div>
+    </div>
+  </div>
+  <div class="col-sm-6 col-lg-3">
+    <div class="card">
+      <div class="card-body">
+        <div class="h1 mb-1">{{ notes_total }}</div>
+        <div class="text-muted">Apuntes subidos</div>
+      </div>
+    </div>
+  </div>
+  <div class="col-sm-6 col-lg-3">
+    <div class="card">
+      <div class="card-body">
+        <div class="h1 mb-1">{{ comments_total }}</div>
+        <div class="text-muted">Comentarios</div>
+      </div>
+    </div>
+  </div>
+  <div class="col-sm-6 col-lg-3">
+    <div class="card">
+      <div class="card-body">
+        <div class="h1 mb-1">{{ products_total }}</div>
+        <div class="text-muted">Productos en tienda</div>
+      </div>
+    </div>
+  </div>
+  <div class="col-sm-6 col-lg-3">
+    <div class="card">
+      <div class="card-body">
+        <div class="h1 mb-1">{{ credits_total }}</div>
+        <div class="text-muted">Créditos distribuidos</div>
+      </div>
+    </div>
+  </div>
+  <div class="col-sm-6 col-lg-3">
+    <div class="card">
+      <div class="card-body">
+        <div class="mb-1">Último ranking:</div>
+        <div class="text-muted small">{{ last_ranking.timestamp.strftime('%d %b %Y - %H:%M') if last_ranking else "Aún no calculado" }}</div>
+        <a href="{{ url_for('admin.run_ranking') }}" class="btn btn-outline-primary btn-sm mt-2">Recalcular ranking</a>
+      </div>
+    </div>
+  </div>
+  <div class="col-sm-6 col-lg-3">
+    <div class="card border border-dashed text-center">
+      <div class="card-body">
+        <div class="text-muted">En desarrollo</div>
+        <a href="#" class="btn btn-light btn-sm disabled">Insignias y Misiones</a>
       </div>
     </div>
   </div>
 </div>
-
-<canvas id="chartSubidas" height="80" class="mt-4"></canvas>
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-  const ctx = document.getElementById('chartSubidas');
-  new Chart(ctx, {
-    type: 'line',
-    data: {{ uploads_chart_data|safe }},
-    options: { responsive: true, tension: .4 }
-  });
-});
-</script>
 {% endblock %}

--- a/crunevo/templates/admin/manage_store.html
+++ b/crunevo/templates/admin/manage_store.html
@@ -6,10 +6,29 @@
   <div class="card-body p-0">
     <div class="table-responsive">
       <table id="tablaProductos" class="table table-vcenter card-table">
-      <thead><tr><th>ID</th><th>Nombre</th><th>Stock</th></tr></thead>
+      <thead>
+        <tr>
+          <th>ID</th><th>Nombre</th><th>Stock</th><th></th>
+        </tr>
+      </thead>
       <tbody>
-      {% for p in products %}
-      <tr><td>{{ p.id }}</td><td>{{ p.name }}</td><td>{{ p.stock }}</td></tr>
+      {% for product in products %}
+      <tr>
+        <td>{{ product.id }}</td>
+        <td>{{ product.name }}</td>
+        <td>{{ product.stock }}</td>
+        <td class="text-end">
+          <div class="dropdown">
+            <button class="btn btn-sm btn-light dropdown-toggle" data-bs-toggle="dropdown">⋮</button>
+            <ul class="dropdown-menu shadow-sm">
+              <li><a class="dropdown-item" href="{{ url_for('store.view_product', product_id=product.id) }}" target="_blank">Ver en tienda</a></li>
+              <li><a class="dropdown-item" href="{{ url_for('admin.edit_product', product_id=product.id) }}">Editar</a></li>
+              <li><button class="dropdown-item text-danger" data-bs-toggle="modal" data-bs-target="#deleteProductModal{{ product.id }}">Eliminar</button></li>
+            </ul>
+          </div>
+        </td>
+      </tr>
+      {% include 'admin/modals/delete_product.html' %}
       {% endfor %}
       </tbody>
       </table>

--- a/crunevo/templates/admin/manage_users.html
+++ b/crunevo/templates/admin/manage_users.html
@@ -22,12 +22,21 @@
             <span class="status-dot status-dot-{{ 'green' if user.activated else 'red' }}"></span>
           </td>
           <td class="text-end">
-            <a href="#" data-bs-toggle="modal" data-bs-target="#modal-{{ user.id }}" class="btn btn-sm">
-              <i class="ti ti-settings"></i>
-            </a>
+            <div class="dropdown">
+              <button class="btn btn-sm btn-light dropdown-toggle" data-bs-toggle="dropdown">
+                ⋮
+              </button>
+              <ul class="dropdown-menu shadow-sm">
+                <li><a class="dropdown-item" href="{{ url_for('auth.public_profile', user_id=user.id) }}" target="_blank">Ver perfil público</a></li>
+                <li><button class="dropdown-item" data-bs-toggle="modal" data-bs-target="#editRoleModal{{ user.id }}">Cambiar rol</button></li>
+                <li><a class="dropdown-item text-warning" href="{{ url_for('admin.toggle_user_status', user_id=user.id) }}">Suspender / Reactivar</a></li>
+                <li><a class="dropdown-item text-muted" href="{{ url_for('admin.user_activity', user_id=user.id) }}">Ver actividad</a></li>
+              </ul>
+            </div>
           </td>
         </tr>
         {% include 'admin/modals/user_actions.html' %}
+        {% include 'admin/modals/edit_role.html' %}
         {% endfor %}
       </tbody>
       </table>

--- a/crunevo/templates/admin/modals/delete_product.html
+++ b/crunevo/templates/admin/modals/delete_product.html
@@ -1,0 +1,21 @@
+{% import 'components/csrf.html' as csrf %}
+<div class="modal fade" id="deleteProductModal{{ product.id }}" tabindex="-1">
+  <div class="modal-dialog modal-dialog-centered">
+    <form method="POST" action="{{ url_for('admin.delete_product', product_id=product.id) }}">
+      {{ csrf.csrf_field() }}
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Confirmar eliminación</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body">
+          ¿Seguro que deseas eliminar el producto <strong>{{ product.name }}</strong>?
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+          <button type="submit" class="btn btn-danger">Eliminar</button>
+        </div>
+      </div>
+    </form>
+  </div>
+</div>

--- a/crunevo/templates/admin/modals/edit_role.html
+++ b/crunevo/templates/admin/modals/edit_role.html
@@ -1,0 +1,23 @@
+{% import 'components/csrf.html' as csrf %}
+<div class="modal fade" id="editRoleModal{{ user.id }}" tabindex="-1">
+  <div class="modal-dialog">
+    <form method="POST" action="{{ url_for('admin.update_user_role', user_id=user.id) }}">
+      {{ csrf.csrf_field() }}
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Cambiar rol</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body">
+          <select name="role" class="form-select">
+            <option value="student" {% if user.role == 'student' %}selected{% endif %}>Estudiante</option>
+            <option value="admin" {% if user.role == 'admin' %}selected{% endif %}>Administrador</option>
+          </select>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-primary" type="submit">Guardar cambios</button>
+        </div>
+      </div>
+    </form>
+  </div>
+</div>

--- a/crunevo/templates/admin/user_activity.html
+++ b/crunevo/templates/admin/user_activity.html
@@ -1,0 +1,9 @@
+{% extends "admin/base_admin.html" %}
+{% block admin_content %}
+<h3>Actividad reciente de {{ user.username }}</h3>
+<ul>
+  <li>Último login: {{ user.last_login or "Desconocido" }}</li>
+  <li>Apuntes subidos: {{ user.notes|length }}</li>
+  <li>Comentarios hechos: {{ user.comments|length }}</li>
+</ul>
+{% endblock %}


### PR DESCRIPTION
## Summary
- modernize `/admin` dashboard route to aggregate metrics
- redesign dashboard with Tabler cards showing key counts
- record update in AGENTS guidelines

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68531079a3008325b56591b91f0ebdc6