### PR TITLE
Add admin credit history panel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,3 +103,4 @@
 
 - Panel de administración muestra tarjetas con métricas de usuarios, apuntes, tienda, créditos y ranking (PR admin-dashboard-cards).
 - Panel de administración ahora incluye vista detallada de movimientos de créditos con tabla y razón (PR admin-credits-history).
+- Panel de administración permite exportar usuarios, créditos y productos a CSV (PR admin-exports).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,3 +102,4 @@
 - Panel de productos en admin incluye edición visual, eliminación segura y acceso directo a vista pública (PR admin-product-actions).
 
 - Panel de administración muestra tarjetas con métricas de usuarios, apuntes, tienda, créditos y ranking (PR admin-dashboard-cards).
+- Panel de administración ahora incluye vista detallada de movimientos de créditos con tabla y razón (PR admin-credits-history).

--- a/crunevo/routes/admin_routes.py
+++ b/crunevo/routes/admin_routes.py
@@ -215,3 +215,15 @@ def toggle_user_status(user_id):
 def user_activity(user_id):
     user = User.query.get_or_404(user_id)
     return render_template("admin/user_activity.html", user=user)
+
+
+@admin_bp.route("/credits")
+@admin_required
+def manage_credits():
+    credits = (
+        db.session.query(Credit, User)
+        .join(User, Credit.user_id == User.id)
+        .order_by(Credit.timestamp.desc())
+        .all()
+    )
+    return render_template("admin/manage_credits.html", credits=credits)

--- a/crunevo/templates/admin/manage_credits.html
+++ b/crunevo/templates/admin/manage_credits.html
@@ -1,0 +1,36 @@
+{% extends 'admin/base_admin.html' %}
+{% block admin_content %}
+<h2 class="page-title mb-4">Historial de Créditos</h2>
+<div class="card shadow-sm">
+  <div class="card-body p-0">
+    <div class="table-responsive">
+      <table id="tablaCreditos" class="table table-vcenter card-table">
+        <thead>
+          <tr>
+            <th>Usuario</th><th>Email</th><th>Monto</th><th>Razón</th><th>Fecha</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for credit, user in credits %}
+          <tr>
+            <td>{{ user.username }}</td>
+            <td>{{ user.email }}</td>
+            <td class="fw-bold text-{{ 'success' if credit.amount >= 0 else 'danger' }}">
+              {{ '+' if credit.amount >= 0 else '' }}{{ credit.amount }}
+            </td>
+            <td>{{ credit.reason }}</td>
+            <td>{{ credit.timestamp.strftime('%d/%m/%Y %H:%M') }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  new simpleDatatables.DataTable('#tablaCreditos');
+});
+</script>
+{% endblock %}

--- a/crunevo/templates/admin/manage_credits.html
+++ b/crunevo/templates/admin/manage_credits.html
@@ -1,6 +1,7 @@
 {% extends 'admin/base_admin.html' %}
 {% block admin_content %}
 <h2 class="page-title mb-4">Historial de Créditos</h2>
+<a href="{{ url_for('admin.export_credits') }}" class="btn btn-outline-primary btn-sm mb-3">Exportar a CSV</a>
 <div class="card shadow-sm">
   <div class="card-body p-0">
     <div class="table-responsive">

--- a/crunevo/templates/admin/manage_store.html
+++ b/crunevo/templates/admin/manage_store.html
@@ -1,7 +1,8 @@
 {% extends 'admin/base_admin.html' %}
 {% block admin_content %}
 <h2 class="page-title mb-4">Administrar Tienda</h2>
-<a href="{{ url_for('admin.add_product') }}" class="btn btn-success mb-3">Nuevo producto</a>
+<a href="{{ url_for('admin.add_product') }}" class="btn btn-success mb-3 me-2">Nuevo producto</a>
+<a href="{{ url_for('admin.export_products') }}" class="btn btn-outline-primary btn-sm mb-3">Exportar a CSV</a>
 <div class="card shadow-sm">
   <div class="card-body p-0">
     <div class="table-responsive">

--- a/crunevo/templates/admin/manage_users.html
+++ b/crunevo/templates/admin/manage_users.html
@@ -1,6 +1,7 @@
 {% extends 'admin/base_admin.html' %}
 {% block admin_content %}
 <h2 class="page-title mb-4">Gestión de usuarios</h2>
+<a href="{{ url_for('admin.export_users') }}" class="btn btn-outline-primary btn-sm mb-3">Exportar a CSV</a>
 <div class="card shadow-sm">
   <div class="card-body p-0">
     <div class="table-responsive">

--- a/crunevo/templates/admin/partials/sidebar.html
+++ b/crunevo/templates/admin/partials/sidebar.html
@@ -12,6 +12,9 @@
   <a class="nav-link {% if request.endpoint == 'admin.manage_store' %}active{% endif %}" href="{{ url_for('admin.manage_store') }}">
     <i class="ti ti-building-store me-2"></i> Tienda
   </a>
+  <a class="nav-link {% if request.endpoint == 'admin.manage_credits' %}active{% endif %}" href="{{ url_for('admin.manage_credits') }}">
+    <i class="ti ti-coin me-2"></i> Créditos
+  </a>
 
   <span class="text-muted fw-bold small mt-4 mb-2">🏅 Comunidad</span>
   <a class="nav-link disabled"><i class="ti ti-check me-2"></i> Verificaciones</a>


### PR DESCRIPTION
## Summary
- add `/admin/credits` route to list credit movements
- create `manage_credits.html` to display credit history
- link credit panel from admin sidebar
- document new feature in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685327b7aacc8325aba2b837f0c4ffc6