### PR TITLE
Fix store link BuildError

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,3 +104,4 @@
 - Panel de administración muestra tarjetas con métricas de usuarios, apuntes, tienda, créditos y ranking (PR admin-dashboard-cards).
 - Corregido url_for en manage_store.html para usar 'store.product_detail' (PR admin-product-link-fix).
 - Se añadió alias 'store.view_product' en store_routes para mantener compatibilidad (PR store-product-alias).
+- Se cambió el enlace de manage_store.html a 'store.view_product' para evitar BuildError (PR store-link-alias-fix).

--- a/crunevo/templates/admin/manage_store.html
+++ b/crunevo/templates/admin/manage_store.html
@@ -21,7 +21,7 @@
           <div class="dropdown">
             <button class="btn btn-sm btn-light dropdown-toggle" data-bs-toggle="dropdown">⋮</button>
             <ul class="dropdown-menu shadow-sm">
-              <li><a class="dropdown-item" href="{{ url_for('store.product_detail', product_id=product.id) }}" target="_blank">Ver en tienda</a></li>
+              <li><a class="dropdown-item" href="{{ url_for('store.view_product', product_id=product.id) }}" target="_blank">Ver en tienda</a></li>
               <li><a class="dropdown-item" href="{{ url_for('admin.edit_product', product_id=product.id) }}">Editar</a></li>
               <li><button class="dropdown-item text-danger" data-bs-toggle="modal" data-bs-target="#deleteProductModal{{ product.id }}">Eliminar</button></li>
             </ul>


### PR DESCRIPTION
## Summary
- fix product URL in admin templates
- document store link alias in AGENTS

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68533dfe9fe88325992c02654ebaddd3