### PR TITLE
Add Fly.io deployment troubleshooting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,3 +109,4 @@
 - Panel de administración permite exportar usuarios, créditos y productos a CSV (PR admin-exports).
 - En el panel de productos se corrigió el enlace a la vista pública usando `store.product_detail` (PR admin-product-link-fix).
 - Eliminada la función `create_tables_once` en app.py para evitar timeouts; las tablas se gestionan con migraciones (PR app-init-fix).
+- Added Fly.io troubleshooting steps for Postgres connection errors in README (PR fly-release-troubleshooting).

--- a/README.md
+++ b/README.md
@@ -51,6 +51,22 @@ It usually means Fly.io detected an outdated manifest from a previous deployment
    fly deploy
    ```
 
+## Troubleshooting deployment failures
+
+If `fly deploy` fails with `release_command failed` and the logs show an
+`OperationalError` when connecting to `crunevo-db.flycast`, the app could not
+reach the PostgreSQL instance. Make sure a Fly Postgres cluster exists and is
+attached to your application:
+
+```bash
+fly postgres create --name crunevo-db       # creates the database
+fly postgres attach --postgres-app crunevo-db -a crunevo2
+```
+
+This command sets the `DATABASE_URL` secret automatically. Verify it with
+`fly secrets list -a crunevo2`. If the database is stopped, restart it with
+`fly pg restart -a crunevo-db` and then run `fly deploy` again.
+
 If you want to run the application locally but use a PostgreSQL
 database hosted on Fly.io:
 ```bash


### PR DESCRIPTION
## Summary
- document how to solve release failures when Fly cannot connect to Postgres
- track this new guidance in AGENTS.md

## Testing
- `make fmt`
- `make test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68534c4f46248325833697d09501c34c