### PR TITLE
Fix Fly internal db hostname

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,3 +110,4 @@
 - En el panel de productos se corrigió el enlace a la vista pública usando `store.product_detail` (PR admin-product-link-fix).
 - Eliminada la función `create_tables_once` en app.py para evitar timeouts; las tablas se gestionan con migraciones (PR app-init-fix).
 - Added Fly.io troubleshooting steps for Postgres connection errors in README (PR fly-release-troubleshooting).
+- Updated Fly.io docs to reference `crunevo-db.internal` (PR fly-db-internal-fix).

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ fly postgres attach ...           # genera DATABASE_URL
 fly secrets set SECRET_KEY=...    # etc.
 ```
 
+When connecting from another Fly app, use the internal hostname
+`crunevo-db.internal` (some older docs referenced `db.internal`).
+
 DNS notes:
 * `www.crunevo.com` → CNAME `crunevo2.fly.dev`
 * `crunevo.com` → A `66.241.125.104` (o AAAA si asignas IPv6)


### PR DESCRIPTION
## Summary
- update README to note `crunevo-db.internal`
- log the correction in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68535523eb288325b8e59ccc25340e55