### PR TITLE
Switch onboarding tokens to secrets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,3 +111,4 @@
 - Eliminada la función `create_tables_once` en app.py para evitar timeouts; las tablas se gestionan con migraciones (PR app-init-fix).
 - Added Fly.io troubleshooting steps for Postgres connection errors in README (PR fly-release-troubleshooting).
 - Updated Fly.io docs to reference `crunevo-db.internal` (PR fly-db-internal-fix).
+- Onboarding tokens now use `secrets.token_urlsafe(32)` and no longer encode the email (PR onboarding-token-length).

--- a/crunevo/routes/onboarding_routes.py
+++ b/crunevo/routes/onboarding_routes.py
@@ -9,7 +9,7 @@ from flask import (
     current_app,
 )
 from flask_login import login_user, current_user, login_required
-from itsdangerous import URLSafeTimedSerializer
+import secrets
 
 from crunevo.extensions import db, limiter, csrf
 from flask_limiter.util import get_remote_address
@@ -22,13 +22,12 @@ from sqlalchemy.exc import IntegrityError
 bp = Blueprint("onboarding", __name__, url_prefix="/onboarding")
 
 
-def generate_token(email):
-    s = URLSafeTimedSerializer(current_app.config["SECRET_KEY"])
-    return s.dumps(email)
+def generate_token():
+    return secrets.token_urlsafe(32)
 
 
 def send_confirmation_email(user):
-    token = generate_token(user.email)
+    token = generate_token()
     db.session.add(EmailToken(token=token, email=user.email, user_id=user.id))
     db.session.commit()
     html = render_template("emails/confirm.html", token=token)

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -72,3 +72,16 @@ def test_token_expires(client, db_session):
         resp = client.get(f"/onboarding/confirm/{token.token}")
     assert resp.status_code == 302
     assert not user.activated
+
+
+def test_generated_token_length_and_confirm(client):
+    with mail.record_messages():
+        client.post(
+            "/onboarding/register",
+            data={"email": "tok@test.com", "password": "StrongPassw0rd!"},
+        )
+    user = User.query.filter_by(email="tok@test.com").first()
+    token = EmailToken.query.filter_by(user_id=user.id).first()
+    assert len(token.token) < 64
+    client.get(f"/onboarding/confirm/{token.token}")
+    assert user.activated


### PR DESCRIPTION
## Summary
- simplify `generate_token` to use `secrets.token_urlsafe`
- remove email argument from onboarding token logic
- check new token length and confirmation in tests
- document token change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685384d470288325a3f0f236022f4e8f