### PR TITLE
Fix comment form optional listener

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,3 +112,4 @@
 - Added Fly.io troubleshooting steps for Postgres connection errors in README (PR fly-release-troubleshooting).
 - Updated Fly.io docs to reference `crunevo-db.internal` (PR fly-db-internal-fix).
 - Onboarding tokens now use `secrets.token_urlsafe(32)` and no longer encode the email (PR onboarding-token-length).
+- Comment form listener now checks element existence with optional chaining in `detalle.html` (PR comment-form-null-check).

--- a/crunevo/templates/notes/detalle.html
+++ b/crunevo/templates/notes/detalle.html
@@ -62,7 +62,7 @@
 <script>
 
 
-  document.getElementById('commentForm').addEventListener('submit', function(e){
+  document.getElementById('commentForm')?.addEventListener('submit', function(e){
     e.preventDefault();
     const btn = this.querySelector('button');
     btn.disabled = true;


### PR DESCRIPTION
## Summary
- avoid JS error when comment form missing
- document fix in AGENTS

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68539ad8b4288325ba8b7276192fdc37