### PR TITLE
Remove unused today variable from trending route

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,3 +113,4 @@
 - Updated Fly.io docs to reference `crunevo-db.internal` (PR fly-db-internal-fix).
 - Onboarding tokens now use `secrets.token_urlsafe(32)` and no longer encode the email (PR onboarding-token-length).
 - Comment form listener now checks element existence with optional chaining in `detalle.html` (PR comment-form-null-check).
+- Removed unused today variable from trending route in feed_routes.py (PR trending-today-remove).

--- a/crunevo/routes/feed_routes.py
+++ b/crunevo/routes/feed_routes.py
@@ -13,7 +13,6 @@ from flask import (
 )
 from flask_login import current_user
 from crunevo.utils.helpers import activated_required
-from datetime import datetime
 from sqlalchemy import func
 from crunevo.extensions import db, csrf
 from crunevo.models import (
@@ -223,8 +222,7 @@ def index():
 @activated_required
 def trending():
     posts = Post.query.order_by(Post.created_at.desc()).limit(10).all()
-    today = datetime.utcnow().date()
-    return render_template("feed/feed.html", posts=posts, trending=True, today=today)
+    return render_template("feed/feed.html", posts=posts, trending=True)
 
 
 @feed_bp.route("/post/<int:post_id>", endpoint="view_post")


### PR DESCRIPTION
## Summary
- tidy up `feed_routes.trending` by removing the unused `today` variable
- document this change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68539e7435308325a33ed9927309a108