### PR TITLE
Fix price casting in add_product

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,3 +114,4 @@
 - Onboarding tokens now use `secrets.token_urlsafe(32)` and no longer encode the email (PR onboarding-token-length).
 - Comment form listener now checks element existence with optional chaining in `detalle.html` (PR comment-form-null-check).
 - Removed unused today variable from trending route in feed_routes.py (PR trending-today-remove).
+- En `add_product` se castea `price` a float y `stock` a int antes de crear el producto (PR admin-add-product-cast).

--- a/crunevo/routes/admin_routes.py
+++ b/crunevo/routes/admin_routes.py
@@ -90,8 +90,8 @@ def add_product():
     if request.method == "POST":
         name = request.form["name"]
         description = request.form.get("description")
-        price = request.form["price"]
-        stock = request.form.get("stock", 0)
+        price = float(request.form["price"])
+        stock = int(request.form.get("stock", 0))
         file = request.files.get("image")
         image_url = None
         if file and file.filename:


### PR DESCRIPTION
## Summary
- parse `price` as float and `stock` as int when adding a product
- record change in AGENTS notes

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68539f7cdc388325bf6f63f06c25da9f