### PR TITLE
Add admin dashboard charts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,3 +115,4 @@
 - Comment form listener now checks element existence with optional chaining in `detalle.html` (PR comment-form-null-check).
 - Removed unused today variable from trending route in feed_routes.py (PR trending-today-remove).
 - En `add_product` se castea `price` a float y `stock` a int antes de crear el producto (PR admin-add-product-cast).
+- Dashboard incluye gráficas de usuarios, apuntes, créditos y productos usando Chart.js (PR admin-dashboard-charts)

--- a/crunevo/routes/admin_routes.py
+++ b/crunevo/routes/admin_routes.py
@@ -18,6 +18,12 @@ from crunevo.extensions import db
 from crunevo.models import User, Product, Report, Note, Credit, Comment
 from crunevo.utils.ranking import calculate_weekly_ranking
 from crunevo.utils.audit import record_auth_event
+from crunevo.utils.stats import (
+    user_registrations_last_7_days,
+    notes_last_4_weeks,
+    credits_last_4_weeks,
+    products_last_3_months,
+)
 import cloudinary.uploader
 
 admin_bp = Blueprint("admin", __name__, url_prefix="/admin")
@@ -44,6 +50,12 @@ def dashboard():
         .order_by(Credit.id.desc())
         .first()
     )
+    stats = {
+        "users": user_registrations_last_7_days(),
+        "notes": notes_last_4_weeks(),
+        "credits": credits_last_4_weeks(),
+        "products": products_last_3_months(),
+    }
     return render_template(
         "admin/dashboard.html",
         users_total=users_total,
@@ -52,6 +64,7 @@ def dashboard():
         products_total=products_total,
         credits_total=credits_total,
         last_ranking=last_ranking,
+        stats=stats,
     )
 
 

--- a/crunevo/static/js/admin_stats.js
+++ b/crunevo/static/js/admin_stats.js
@@ -1,0 +1,23 @@
+function initAdminCharts() {
+  document.querySelectorAll('[data-chart]').forEach((el) => {
+    const cfg = JSON.parse(el.dataset.chart || '{}');
+    if (!cfg.labels) return;
+    new Chart(el, {
+      type: 'line',
+      data: {
+        labels: cfg.labels,
+        datasets: [
+          {
+            label: cfg.label || '',
+            data: cfg.values,
+            tension: 0.4,
+            fill: true,
+            backgroundColor: 'rgba(32,107,196,0.2)',
+            borderColor: '#206bc4',
+          },
+        ],
+      },
+      options: { scales: { y: { beginAtZero: true } }, plugins: { legend: { display: false } } },
+    });
+  });
+}

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -88,6 +88,10 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  if (typeof initAdminCharts === 'function') {
+    initAdminCharts();
+  }
+
   // Bootstrap collapse handles the mobile menu
 
 });

--- a/crunevo/templates/admin/base_admin.html
+++ b/crunevo/templates/admin/base_admin.html
@@ -2,6 +2,7 @@
 {% block head_extra %}
   <link href="https://unpkg.com/@tabler/core@1.3.2/dist/css/tabler.min.css" rel="stylesheet">
   <script src="https://unpkg.com/@tabler/core@1.3.2/dist/js/tabler.min.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" defer></script>
   <link rel="stylesheet" href="{{ url_for('static', filename='admin/custom.css') }}">
 {% endblock %}
 {% block content %}
@@ -19,4 +20,9 @@
     </main>
   </div>
 </div>
+{% endblock %}
+
+{% block body_end %}
+  {{ super() }}
+  <script src="{{ url_for('static', filename='js/admin_stats.js') }}" defer></script>
 {% endblock %}

--- a/crunevo/templates/admin/dashboard.html
+++ b/crunevo/templates/admin/dashboard.html
@@ -61,4 +61,39 @@
     </div>
   </div>
 </div>
+
+<div class="row mt-4" id="chartsRow">
+  <div class="col-md-6 col-xl-3 mb-4">
+    <div class="card">
+      <div class="card-header"><h3 class="card-title">Usuarios / día</h3></div>
+      <div class="card-body">
+        <canvas id="usersChart" height="200" data-chart='{{ stats.users | tojson }}'></canvas>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-6 col-xl-3 mb-4">
+    <div class="card">
+      <div class="card-header"><h3 class="card-title">Apuntes / semana</h3></div>
+      <div class="card-body">
+        <canvas id="notesChart" height="200" data-chart='{{ stats.notes | tojson }}'></canvas>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-6 col-xl-3 mb-4">
+    <div class="card">
+      <div class="card-header"><h3 class="card-title">Créditos / semana</h3></div>
+      <div class="card-body">
+        <canvas id="creditsChart" height="200" data-chart='{{ stats.credits | tojson }}'></canvas>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-6 col-xl-3 mb-4">
+    <div class="card">
+      <div class="card-header"><h3 class="card-title">Productos / mes</h3></div>
+      <div class="card-body">
+        <canvas id="productsChart" height="200" data-chart='{{ stats.products | tojson }}'></canvas>
+      </div>
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/crunevo/utils/stats.py
+++ b/crunevo/utils/stats.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, date
+from collections import OrderedDict
+from sqlalchemy import func
+
+from crunevo.extensions import db
+from crunevo.models import EmailToken, Note, Credit, Product
+
+
+def _fill_series(start: date, periods: int, step: timedelta, rows):
+    data = OrderedDict(
+        ((start + step * i).strftime("%Y-%m-%d"), 0) for i in range(periods)
+    )
+    for dt, count in rows:
+        key = dt.strftime("%Y-%m-%d")
+        data[key] = int(count)
+    labels = list(data.keys())
+    values = list(data.values())
+    return labels, values
+
+
+def user_registrations_last_7_days():
+    today = datetime.utcnow().date()
+    start = today - timedelta(days=6)
+    rows = (
+        db.session.query(func.date(EmailToken.created_at), func.count())
+        .filter(EmailToken.created_at >= start)
+        .group_by(func.date(EmailToken.created_at))
+        .order_by(func.date(EmailToken.created_at))
+        .all()
+    )
+    labels, values = _fill_series(start, 7, timedelta(days=1), rows)
+    return {"label": "Usuarios", "labels": labels, "values": values}
+
+
+def notes_last_4_weeks():
+    today = datetime.utcnow().date()
+    start = today - timedelta(weeks=3)
+    start -= timedelta(days=start.weekday())
+    rows = (
+        db.session.query(func.date_trunc("week", Note.created_at), func.count())
+        .filter(Note.created_at >= start)
+        .group_by(func.date_trunc("week", Note.created_at))
+        .order_by(func.date_trunc("week", Note.created_at))
+        .all()
+    )
+    labels, values = _fill_series(start, 4, timedelta(weeks=1), rows)
+    return {"label": "Apuntes", "labels": labels, "values": values}
+
+
+def credits_last_4_weeks():
+    today = datetime.utcnow().date()
+    start = today - timedelta(weeks=3)
+    start -= timedelta(days=start.weekday())
+    rows = (
+        db.session.query(
+            func.date_trunc("week", Credit.timestamp), func.sum(Credit.amount)
+        )
+        .filter(Credit.timestamp >= start)
+        .group_by(func.date_trunc("week", Credit.timestamp))
+        .order_by(func.date_trunc("week", Credit.timestamp))
+        .all()
+    )
+    labels, values = _fill_series(start, 4, timedelta(weeks=1), rows)
+    values = [float(v) for v in values]
+    return {"label": "Créditos", "labels": labels, "values": values}
+
+
+def _month_add(dt: date, months: int) -> date:
+    year = dt.year + (dt.month - 1 + months) // 12
+    month = (dt.month - 1 + months) % 12 + 1
+    return date(year, month, 1)
+
+
+def products_last_3_months():
+    today = datetime.utcnow().date()
+    first = date(today.year, today.month, 1)
+    start = _month_add(first, -2)
+    if hasattr(Product, "created_at"):
+        rows = (
+            db.session.query(func.date_trunc("month", Product.created_at), func.count())
+            .filter(Product.created_at >= start)
+            .group_by(func.date_trunc("month", Product.created_at))
+            .order_by(func.date_trunc("month", Product.created_at))
+            .all()
+        )
+    else:
+        rows = []
+    labels, values = _fill_series(start, 3, timedelta(days=31))
+    # adjust labels to first day of month
+    labels = [_month_add(start, i).strftime("%Y-%m") for i in range(3)]
+    mapping = {dt.strftime("%Y-%m"): int(count) for dt, count in rows}
+    values = [mapping.get(label, 0) for label in labels]
+    return {"label": "Productos", "labels": labels, "values": values}


### PR DESCRIPTION
## Summary
- display admin dashboard charts using Chart.js
- compute statistics in new `utils/stats.py`
- load Chart.js in admin layout and initialize in `admin_stats.js`
- render new charts row in dashboard
- update AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6853a02beb308325ad8496b127a58546