### PR TITLE
Admin panel subdomain setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,3 +117,4 @@
 - En `add_product` se castea `price` a float y `stock` a int antes de crear el producto (PR admin-add-product-cast).
 - Dashboard incluye gráficas de usuarios, apuntes, créditos y productos usando Chart.js (PR admin-dashboard-charts)
 - Corregido _fill_series en products_last_3_months pasando 'rows' (PR admin-stats-bugfix)
+- Admin panel moved to subdomain burrito.crunevo.com with dedicated Fly app (PR admin-subdomain).

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository contains the Crunevo2 Flask application. The project is configured to run on Fly.io using Docker and PostgreSQL.
 
+The administration panel is served from the dedicated subdomain `https://burrito.crunevo.com`.
+
 ## Deploying to Fly.io
 
 If you encounter the error below when attempting to deploy:

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -53,16 +53,24 @@ def create_app():
     from .routes.errors import errors_bp
     from .routes.health_routes import health_bp
 
-    app.register_blueprint(onboarding_bp)
-    app.register_blueprint(auth_bp)
-    app.register_blueprint(notes_bp)
-    app.register_blueprint(feed_bp)
-    app.register_blueprint(store_bp)
-    app.register_blueprint(chat_bp)
-    app.register_blueprint(admin_bp)
-    app.register_blueprint(ranking_bp)
-    app.register_blueprint(errors_bp)
-    app.register_blueprint(health_bp)
+    admin_only = os.environ.get("ADMIN_INSTANCE") == "1"
+
+    if admin_only:
+        app.register_blueprint(auth_bp)
+        app.register_blueprint(admin_bp)
+        app.register_blueprint(errors_bp)
+        app.register_blueprint(health_bp)
+    else:
+        app.register_blueprint(onboarding_bp)
+        app.register_blueprint(auth_bp)
+        app.register_blueprint(notes_bp)
+        app.register_blueprint(feed_bp)
+        app.register_blueprint(store_bp)
+        app.register_blueprint(chat_bp)
+        app.register_blueprint(admin_bp)
+        app.register_blueprint(ranking_bp)
+        app.register_blueprint(errors_bp)
+        app.register_blueprint(health_bp)
 
     @app.errorhandler(CSRFError)
     def handle_csrf_error(e):

--- a/crunevo/routes/admin_routes.py
+++ b/crunevo/routes/admin_routes.py
@@ -8,6 +8,7 @@ from flask import (
     request,
     current_app,
     Response,
+    abort,
 )
 from flask_login import login_required
 from crunevo.utils.helpers import activated_required, admin_required
@@ -27,6 +28,17 @@ from crunevo.utils.stats import (
 import cloudinary.uploader
 
 admin_bp = Blueprint("admin", __name__, url_prefix="/admin")
+
+
+@admin_bp.before_request
+def restrict_to_subdomain():
+    if current_app.config.get("TESTING"):
+        return
+    host = request.host.split(":")[0]
+    if not host.startswith("burrito."):
+        if host.endswith("crunevo.com"):
+            return redirect("https://burrito.crunevo.com" + request.full_path, code=302)
+        abort(403)
 
 
 @admin_bp.before_request

--- a/crunevo/wsgi_admin.py
+++ b/crunevo/wsgi_admin.py
@@ -1,0 +1,6 @@
+import os
+from crunevo import create_app
+
+os.environ.setdefault("ADMIN_INSTANCE", "1")
+
+app = create_app()

--- a/fly-admin.toml
+++ b/fly-admin.toml
@@ -1,0 +1,42 @@
+app = "crunevo-admin"
+primary_region = "bog"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[deploy]
+  release_command = "flask db upgrade"
+
+[env]
+  FLASK_APP = "crunevo.wsgi_admin"
+  FLASK_ENV = "production"
+  ADMIN_INSTANCE = "1"
+  PORT = "8080"
+
+[experimental]
+  auto_rollback = true
+
+[[services]]
+  protocol = "tcp"
+  internal_port = 8080
+
+  [[services.ports]]
+    port = 80
+    handlers = ["http"]
+
+  [[services.ports]]
+    port = 443
+    handlers = ["tls", "http"]
+
+  [[services.http_checks]]
+    interval     = 10000
+    timeout      = 2000
+    grace_period = "30s"
+    method       = "get"
+    path         = "/healthz"
+    protocol     = "https"
+
+[[vm]]
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 1


### PR DESCRIPTION
## Summary
- create `wsgi_admin.py` to launch admin-only instance
- restrict admin blueprint to `burrito.crunevo.com`
- allow admin-only mode in `create_app`
- add Fly.io config for admin app
- document new subdomain in README
- log update in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6853b4b24eb483259b906adba22002fe