### PR TITLE
Fix admin gunicorn app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,3 +123,5 @@
 - Verificada configuración ADMIN_INSTANCE=1 en fly-admin.toml y wsgi_admin.py; login redirige al dashboard y blueprint admin se registra solo en modo admin (QA admin-config-check).
 - Confirmado FLASK_APP usa "crunevo.wsgi_admin:app" y create_app separa blueprints según ADMIN_INSTANCE (QA admin-env-check).
 - wsgi_admin.py simplificado para importar create_app desde crunevo.app sin variables extra y se verificó FLASK_APP en fly-admin.toml (QA admin-wsgi-cleanup).
+
+- Dockerfile now reads FLASK_APP to run gunicorn, enabling admin instance to use wsgi_admin (PR admin-gunicorn-env).

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,6 @@ COPY migrations /app/migrations
 COPY migrations/versions /app/migrations/versions
 
 # Ejecutar aplicación
-CMD ["gunicorn", "-b", "0.0.0.0:8080", "crunevo.wsgi:app"]
+# Run gunicorn using the FLASK_APP environment variable. Default to the
+# public instance if FLASK_APP is not set (e.g. during local builds).
+CMD ["sh", "-c", "exec gunicorn -b 0.0.0.0:8080 ${FLASK_APP:-crunevo.wsgi:app}"]


### PR DESCRIPTION
## Summary
- make gunicorn use the `FLASK_APP` env var so the admin instance runs `wsgi_admin`
- document the change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6853dd5483a48325a0f5ff5b4ccab90d