### PR TITLE
Fix admin instance blueprint handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,3 +125,4 @@
 - wsgi_admin.py simplificado para importar create_app desde crunevo.app sin variables extra y se verificó FLASK_APP en fly-admin.toml (QA admin-wsgi-cleanup).
 
 - Dockerfile now reads FLASK_APP to run gunicorn, enabling admin instance to use wsgi_admin (PR admin-gunicorn-env).
+- Updated create_app to use `is_admin` flag and ensure admin blueprints load only when ADMIN_INSTANCE=1. wsgi_admin.py now sets this variable explicitly (PR admin-blueprint-filter).

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -54,11 +54,11 @@ def create_app():
     from .routes.errors import errors_bp
     from .routes.health_routes import health_bp
 
-    admin_only = os.environ.get("ADMIN_INSTANCE") == "1"
+    is_admin = os.environ.get("ADMIN_INSTANCE") == "1"
     testing_env = os.environ.get("PYTEST_CURRENT_TEST") is not None
-    app.config["ADMIN_INSTANCE"] = admin_only
+    app.config["ADMIN_INSTANCE"] = is_admin
 
-    if admin_only:
+    if is_admin:
         app.register_blueprint(auth_bp)
         app.register_blueprint(admin_bp)
         app.register_blueprint(errors_bp)

--- a/crunevo/wsgi_admin.py
+++ b/crunevo/wsgi_admin.py
@@ -1,3 +1,6 @@
 from crunevo.app import create_app
+import os
+
+os.environ["ADMIN_INSTANCE"] = "1"
 
 app = create_app()


### PR DESCRIPTION
## Summary
- ensure admin blueprints load only when `ADMIN_INSTANCE=1`
- set `ADMIN_INSTANCE` in `wsgi_admin`
- document admin blueprint fix in `AGENTS.md`

## Testing
- `make fmt`
- `make test`
- `fly deploy -c fly-admin.toml -a crunevo-admin` *(fails: No access token available)*

------
https://chatgpt.com/codex/tasks/task_e_68548a3888d08325b4534b143b8c390e