### PR TITLE
Fix wsgi app import and env

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,3 +126,4 @@
 
 - Dockerfile now reads FLASK_APP to run gunicorn, enabling admin instance to use wsgi_admin (PR admin-gunicorn-env).
 - Updated create_app to use `is_admin` flag and ensure admin blueprints load only when ADMIN_INSTANCE=1. wsgi_admin.py now sets this variable explicitly (PR admin-blueprint-filter).
+- Updated wsgi.py to import create_app from crunevo.app and set FLASK_APP to 'crunevo.wsgi:app' in fly.toml to ensure Gunicorn loads the app correctly (PR wsgi-app-fix).

--- a/crunevo/wsgi.py
+++ b/crunevo/wsgi.py
@@ -1,3 +1,3 @@
-from crunevo import create_app
+from crunevo.app import create_app
 
 app = create_app()

--- a/fly.toml
+++ b/fly.toml
@@ -10,7 +10,7 @@ primary_region = 'bog'
   release_command = "flask db upgrade"
 
 [env]
-  FLASK_APP = 'crunevo.wsgi'
+  FLASK_APP = 'crunevo.wsgi:app'
   FLASK_ENV = 'production'
   PORT = "8080"
 


### PR DESCRIPTION
## Summary
- ensure `wsgi.py` imports `create_app` from `crunevo.app`
- set `FLASK_APP` to `crunevo.wsgi:app` in `fly.toml`
- document fix in `AGENTS.md`

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6854918b0b3083258f3c0967bcdc5779