### PR TITLE
Fix health blueprint registration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,3 +129,4 @@
 - Updated wsgi.py to import create_app from crunevo.app and set FLASK_APP to 'crunevo.wsgi:app' in fly.toml to ensure Gunicorn loads the app correctly (PR wsgi-app-fix).
 - Confirmed admin instance loads wsgi_admin via fly-admin.toml and blueprints register only in that mode (QA admin-deploy-fix).
 - wsgi_admin.py ahora establece ADMIN_INSTANCE antes de importar create_app para evitar que el panel admin muestre el feed público (PR wsgi-admin-env-order).
+- Health check blueprint registered globally and Fly admin HTTP checks configured. Added console log for instance mode (PR admin-health-check).

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -58,11 +58,13 @@ def create_app():
     testing_env = os.environ.get("PYTEST_CURRENT_TEST") is not None
     app.config["ADMIN_INSTANCE"] = is_admin
 
+    app.register_blueprint(health_bp)
+    app.logger.info("Running in ADMIN mode" if is_admin else "Running in PUBLIC mode")
+
     if is_admin:
         app.register_blueprint(auth_bp)
         app.register_blueprint(admin_bp)
         app.register_blueprint(errors_bp)
-        app.register_blueprint(health_bp)
     else:
         app.register_blueprint(onboarding_bp)
         app.register_blueprint(auth_bp)
@@ -72,7 +74,6 @@ def create_app():
         app.register_blueprint(chat_bp)
         app.register_blueprint(ranking_bp)
         app.register_blueprint(errors_bp)
-        app.register_blueprint(health_bp)
         app.register_blueprint(admin_blocker_bp)
         if testing_env:
             app.register_blueprint(admin_bp)

--- a/fly-admin.toml
+++ b/fly-admin.toml
@@ -29,12 +29,12 @@ primary_region = "bog"
     handlers = ["tls", "http"]
 
   [[services.http_checks]]
-    interval     = 10000
-    timeout      = 2000
-    grace_period = "30s"
+    interval     = "10s"
+    timeout      = "2s"
+    grace_period = "5s"
     method       = "get"
     path         = "/healthz"
-    protocol     = "https"
+    protocol     = "http"
 
 [[vm]]
   memory = "1gb"


### PR DESCRIPTION
## Summary
- always register the health blueprint
- add instance mode log
- configure HTTP health check for admin Fly app
- document changes in AGENTS

## Testing
- `make fmt`
- `make test`
- `flyctl deploy -c fly-admin.toml -a crunevo-admin --remote-only` *(fails: No access token available)*
- `flyctl status -a crunevo-admin` *(fails: No access token available)*

------
https://chatgpt.com/codex/tasks/task_e_6854a62f994c8325b6642d185e109f50