### PR TITLE
Fix health check HTTP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,3 +133,4 @@
 - Agregado PUBLIC_BASE_URL en config, context processor e enlace absoluto en manage_store para acceder a la tienda pública desde admin.
 - Enlaces de perfil y productos en plantillas admin ahora usan PUBLIC_BASE_URL para apuntar al dominio público (PR admin-absolute-links2).
 - Implementados logs de productos, notificaciones internas y rol de moderador con modo lectura en admin (PR admin-logs-moderator).
+- Health check no redirige a HTTPS para pasar comprobaciones HTTP (PR health-check-http).

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -3,8 +3,7 @@ import logging
 from logging.handlers import RotatingFileHandler
 import os
 
-from .extensions import db, login_manager, migrate, mail, csrf, limiter
-from flask_talisman import Talisman
+from .extensions import db, login_manager, migrate, mail, csrf, limiter, talisman
 from flask_wtf.csrf import CSRFError
 
 DEFAULT_CSP = {
@@ -36,7 +35,7 @@ def create_app():
         csp = app.config.get("TALISMAN_CSP", DEFAULT_CSP)
         if app.config.get("ENABLE_CSP_OVERRIDE"):
             csp = None
-        Talisman(
+        talisman.init_app(
             app,
             content_security_policy=csp,
             force_https=True,

--- a/crunevo/extensions.py
+++ b/crunevo/extensions.py
@@ -5,6 +5,7 @@ from flask_mail import Mail
 from flask_wtf import CSRFProtect
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
+from flask_talisman import Talisman
 
 # Centralized extensions so models and blueprints can import `db`, `migrate` and
 # `login_manager` without causing circular imports.
@@ -14,3 +15,4 @@ login_manager = LoginManager()
 mail = Mail()
 csrf = CSRFProtect()
 limiter = Limiter(key_func=get_remote_address, default_limits=["200 per day"])
+talisman = Talisman()

--- a/crunevo/routes/health_routes.py
+++ b/crunevo/routes/health_routes.py
@@ -1,11 +1,12 @@
 from flask import Blueprint, current_app
 from sqlalchemy import text
-from crunevo.extensions import db
+from crunevo.extensions import db, talisman
 
 health_bp = Blueprint("health", __name__)
 
 
 @health_bp.route("/healthz")
+@talisman(force_https=False)
 def healthz():
     try:
         db.session.execute(text("SELECT 1"))


### PR DESCRIPTION
## Summary
- disable HTTPS enforcement for `/healthz`
- expose talisman extension to allow per-route configuration
- document health check HTTP fix in AGENTS log

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6854ef09185c8325a11f80dcf8e3bafb