### PR TITLE
Fix admin dropdown menus

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,3 +134,5 @@
 - Enlaces de perfil y productos en plantillas admin ahora usan PUBLIC_BASE_URL para apuntar al dominio público (PR admin-absolute-links2).
 - Implementados logs de productos, notificaciones internas y rol de moderador con modo lectura en admin (PR admin-logs-moderator).
 - Health check no redirige a HTTPS para pasar comprobaciones HTTP (PR health-check-http).
+- Fixed inactive dropdowns on admin tables by initializing via main.js and adding tooltips (PR admin-dropdowns-init).
+- Mejorado diseño visual del panel admin: contraste, colores y botones en modo claro/oscuro (PR admin-ui-polish).

--- a/crunevo/static/admin/custom.css
+++ b/crunevo/static/admin/custom.css
@@ -44,3 +44,38 @@
 .sidebar .nav-link.disabled {
   color: #ccc;
 }
+/* admin-ui-polish */
+.admin-dropdown-btn {
+  transition: background-color .2s, box-shadow .2s;
+}
+[data-bs-theme='light'] .admin-dropdown-btn {
+  background-color: #f0f0f0;
+  color: #333;
+  border: 1px solid #ccc;
+}
+[data-bs-theme='light'] .admin-dropdown-btn:hover {
+  background-color: #e9e9e9;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+[data-bs-theme='dark'] .admin-dropdown-btn {
+  background-color: #363636;
+  color: #fff;
+  border: 1px solid #444;
+}
+[data-bs-theme='dark'] .admin-dropdown-btn:hover {
+  background-color: #444;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+}
+[data-bs-theme='dark'] .table,
+[data-bs-theme='dark'] .card {
+  border-color: #444;
+}
+[data-bs-theme='dark'] .table th,
+[data-bs-theme='dark'] .table td {
+  border-color: #444;
+}
+.badge-primary,
+.btn-primary {
+  background-color: var(--tblr-primary);
+  border-color: var(--tblr-primary);
+}

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -28,6 +28,27 @@ function showToast(message, options = {}) {
   new bootstrap.Toast(div).show();
 }
 
+function initDropdowns(scope = document) {
+  scope.querySelectorAll('.dropdown-toggle').forEach((el) => {
+    if (!el.dataset.dropdownInitialized) {
+      new bootstrap.Dropdown(el);
+      new bootstrap.Tooltip(el, { title: 'Más opciones' });
+      el.dataset.dropdownInitialized = 'true';
+    }
+  });
+}
+
+function initDataTables() {
+  if (typeof simpleDatatables === 'undefined') return;
+  document.querySelectorAll('[data-datatable]').forEach((table) => {
+    const dt = new simpleDatatables.DataTable(table);
+    const refresh = () => initDropdowns(table.parentElement);
+    dt.on('datatable.init', refresh);
+    dt.on('datatable.page', refresh);
+    dt.on('datatable.update', refresh);
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   // theme persistence
   const saved = localStorage.getItem('theme');
@@ -35,6 +56,7 @@ document.addEventListener('DOMContentLoaded', () => {
     document.documentElement.dataset.bsTheme = saved;
   }
   document.querySelectorAll('[data-theme-toggle]').forEach((btn) => {
+    new bootstrap.Tooltip(btn);
     btn.addEventListener('click', () => {
       const html = document.documentElement;
       const next = html.dataset.bsTheme === 'dark' ? 'light' : 'dark';
@@ -91,6 +113,9 @@ document.addEventListener('DOMContentLoaded', () => {
   if (typeof initAdminCharts === 'function') {
     initAdminCharts();
   }
+
+  initDataTables();
+  initDropdowns();
 
   // Bootstrap collapse handles the mobile menu
 

--- a/crunevo/templates/admin/dashboard.html
+++ b/crunevo/templates/admin/dashboard.html
@@ -48,7 +48,9 @@
       <div class="card-body">
         <div class="mb-1">Último ranking:</div>
         <div class="text-muted small">{{ last_ranking.timestamp.strftime('%d %b %Y - %H:%M') if last_ranking else "Aún no calculado" }}</div>
-        <a href="{{ url_for('admin.run_ranking') }}" class="btn btn-outline-primary btn-sm mt-2">Recalcular ranking</a>
+        <a href="{{ url_for('admin.run_ranking') }}" class="btn btn-outline-primary btn-sm mt-2">
+          <i class="bi bi-arrow-repeat me-1"></i>Recalcular ranking
+        </a>
       </div>
     </div>
   </div>

--- a/crunevo/templates/admin/manage_credits.html
+++ b/crunevo/templates/admin/manage_credits.html
@@ -1,7 +1,9 @@
 {% extends 'admin/base_admin.html' %}
 {% block admin_content %}
 <h2 class="page-title mb-4">Historial de Créditos</h2>
-<a href="{{ url_for('admin.export_credits') }}" class="btn btn-outline-primary btn-sm mb-3">Exportar a CSV</a>
+<a href="{{ url_for('admin.export_credits') }}" class="btn btn-outline-primary btn-sm mb-3">
+  <i class="bi bi-download me-1"></i>Exportar a CSV
+</a>
 <div class="card shadow-sm">
   <div class="card-body p-0">
     <div class="table-responsive">

--- a/crunevo/templates/admin/manage_store.html
+++ b/crunevo/templates/admin/manage_store.html
@@ -4,12 +4,16 @@
 {% if current_user.role == 'admin' %}
 <a href="{{ url_for('admin.add_product') }}" class="btn btn-success mb-3 me-2">Nuevo producto</a>
 {% endif %}
-<a href="{{ url_for('admin.export_products') }}" class="btn btn-outline-primary btn-sm mb-3 me-2">Exportar a CSV</a>
-<a href="{{ url_for('admin.product_history') }}" class="btn btn-outline-secondary btn-sm mb-3">Historial</a>
+<a href="{{ url_for('admin.export_products') }}" class="btn btn-outline-primary btn-sm mb-3 me-2">
+  <i class="bi bi-download me-1"></i>Exportar a CSV
+</a>
+<a href="{{ url_for('admin.product_history') }}" class="btn btn-outline-secondary btn-sm mb-3">
+  <i class="bi bi-clock-history me-1"></i>Historial
+</a>
 <div class="card shadow-sm">
   <div class="card-body p-0">
     <div class="table-responsive">
-      <table id="tablaProductos" class="table table-vcenter card-table">
+      <table id="tablaProductos" class="table table-vcenter card-table" data-datatable>
       <thead>
         <tr>
           <th>ID</th><th>Nombre</th><th>Stock</th><th></th>
@@ -23,7 +27,7 @@
         <td>{{ product.stock }}</td>
         <td class="text-end">
           <div class="dropdown">
-            <button class="btn btn-sm btn-light dropdown-toggle" data-bs-toggle="dropdown">⋮</button>
+            <button class="btn btn-sm admin-dropdown-btn dropdown-toggle" data-bs-toggle="dropdown" title="Más opciones">⋮</button>
             <ul class="dropdown-menu shadow-sm">
               <li><a class="dropdown-item" href="{{ PUBLIC_BASE_URL }}/store/{{ product.id }}" target="_blank">Ver en tienda</a></li>
               {% if current_user.role == 'admin' %}
@@ -41,10 +45,4 @@
     </div>
   </div>
 </div>
-
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-  new simpleDatatables.DataTable('#tablaProductos');
-});
-</script>
 {% endblock %}

--- a/crunevo/templates/admin/manage_users.html
+++ b/crunevo/templates/admin/manage_users.html
@@ -1,11 +1,13 @@
 {% extends 'admin/base_admin.html' %}
 {% block admin_content %}
 <h2 class="page-title mb-4">Gestión de usuarios</h2>
-<a href="{{ url_for('admin.export_users') }}" class="btn btn-outline-primary btn-sm mb-3">Exportar a CSV</a>
+<a href="{{ url_for('admin.export_users') }}" class="btn btn-outline-primary btn-sm mb-3">
+  <i class="bi bi-download me-1"></i>Exportar a CSV
+</a>
 <div class="card shadow-sm">
   <div class="card-body p-0">
     <div class="table-responsive">
-      <table id="tablaUsuarios" class="table table-vcenter card-table">
+      <table id="tablaUsuarios" class="table table-vcenter card-table" data-datatable>
       <thead>
         <tr>
           <th>Nombre</th><th>Email</th><th>Rol</th>
@@ -24,7 +26,7 @@
           </td>
           <td class="text-end">
             <div class="dropdown">
-              <button class="btn btn-sm btn-light dropdown-toggle" data-bs-toggle="dropdown">
+              <button class="btn btn-sm admin-dropdown-btn dropdown-toggle" data-bs-toggle="dropdown" title="Más opciones">
                 ⋮
               </button>
               <ul class="dropdown-menu shadow-sm">
@@ -46,10 +48,4 @@
     </div>
   </div>
 </div>
-
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-  new simpleDatatables.DataTable('#tablaUsuarios');
-});
-</script>
 {% endblock %}

--- a/crunevo/templates/admin/partials/topbar.html
+++ b/crunevo/templates/admin/partials/topbar.html
@@ -1,8 +1,8 @@
 <header class="d-flex justify-content-between align-items-center py-3 mb-4 border-bottom">
   <h1 class="h4 m-0">CRUNEVO Admin</h1>
   <div>
-    <button class="btn btn-sm btn-outline-secondary me-2" data-theme-toggle>
-      <i class="ti ti-moon"></i>
+    <button class="btn btn-sm btn-primary me-2 admin-theme-toggle" data-theme-toggle data-bs-toggle="tooltip" title="Modo claro / oscuro">
+      <i class="bi bi-circle-half"></i>
     </button>
     <a class="btn btn-sm btn-danger" href="{{ url_for('auth.logout') }}">Cerrar sesión</a>
   </div>


### PR DESCRIPTION
## Summary
- add dropdown initialization and tooltips in `main.js`
- enable datatables and dropdowns via data attribute
- remove inline scripts from admin pages
- polish admin UI buttons and colors

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6854f596387c83258e81738986a13613