### PR TITLE
Fix admin dropdowns and dark sidebar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,3 +136,4 @@
 - Health check no redirige a HTTPS para pasar comprobaciones HTTP (PR health-check-http).
 - Fixed inactive dropdowns on admin tables by initializing via main.js and adding tooltips (PR admin-dropdowns-init).
 - Mejorado diseño visual del panel admin: contraste, colores y botones en modo claro/oscuro (PR admin-ui-polish).
+- Sidebar dark theme polished and dropdowns reinitialized after DataTable events, with theme toggle icon updates (PR admin-dark-dropdown-fix).

--- a/crunevo/static/admin/custom.css
+++ b/crunevo/static/admin/custom.css
@@ -27,6 +27,19 @@
   border-right: 1px solid #e0e0e0;
 }
 
+[data-bs-theme='dark'] .sidebar {
+  background-color: #1f1f1f;
+  border-color: #333;
+}
+
+[data-bs-theme='dark'] .sidebar .nav-link {
+  color: #ddd;
+}
+
+[data-bs-theme='dark'] .sidebar .nav-item.text-muted {
+  color: #aaa;
+}
+
 .sidebar .nav-link {
   color: #333;
   padding: 0.75rem 1rem;
@@ -41,8 +54,17 @@
   border-radius: 0.375rem;
 }
 
+[data-bs-theme='dark'] .sidebar .nav-link.active {
+  background-color: #7b3aed;
+  color: #fff;
+}
+
 .sidebar .nav-link.disabled {
   color: #ccc;
+}
+
+[data-bs-theme='dark'] .sidebar .nav-link.disabled {
+  color: #555;
 }
 /* admin-ui-polish */
 .admin-dropdown-btn {

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -29,10 +29,10 @@ function showToast(message, options = {}) {
 }
 
 function initDropdowns(scope = document) {
-  scope.querySelectorAll('.dropdown-toggle').forEach((el) => {
+  scope.querySelectorAll('[data-bs-toggle="dropdown"]').forEach((el) => {
     if (!el.dataset.dropdownInitialized) {
-      new bootstrap.Dropdown(el);
-      new bootstrap.Tooltip(el, { title: 'Más opciones' });
+      bootstrap.Dropdown.getOrCreateInstance(el);
+      if (el.title) new bootstrap.Tooltip(el);
       el.dataset.dropdownInitialized = 'true';
     }
   });
@@ -43,9 +43,15 @@ function initDataTables() {
   document.querySelectorAll('[data-datatable]').forEach((table) => {
     const dt = new simpleDatatables.DataTable(table);
     const refresh = () => initDropdowns(table.parentElement);
-    dt.on('datatable.init', refresh);
-    dt.on('datatable.page', refresh);
-    dt.on('datatable.update', refresh);
+    ['datatable.init', 'datatable.page', 'datatable.update', 'datatable.sort', 'datatable.search'].forEach((e) => dt.on(e, refresh));
+  });
+}
+
+function updateThemeIcons() {
+  const dark = document.documentElement.dataset.bsTheme === 'dark';
+  document.querySelectorAll('[data-theme-toggle] i').forEach((icon) => {
+    icon.classList.remove('bi-sun', 'bi-moon');
+    icon.classList.add(dark ? 'bi-moon' : 'bi-sun');
   });
 }
 
@@ -55,6 +61,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (saved) {
     document.documentElement.dataset.bsTheme = saved;
   }
+  updateThemeIcons();
   document.querySelectorAll('[data-theme-toggle]').forEach((btn) => {
     new bootstrap.Tooltip(btn);
     btn.addEventListener('click', () => {
@@ -62,6 +69,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const next = html.dataset.bsTheme === 'dark' ? 'light' : 'dark';
       html.dataset.bsTheme = next;
       localStorage.setItem('theme', next);
+      updateThemeIcons();
     });
   });
 

--- a/crunevo/templates/admin/partials/topbar.html
+++ b/crunevo/templates/admin/partials/topbar.html
@@ -1,8 +1,8 @@
 <header class="d-flex justify-content-between align-items-center py-3 mb-4 border-bottom">
   <h1 class="h4 m-0">CRUNEVO Admin</h1>
   <div>
-    <button class="btn btn-sm btn-primary me-2 admin-theme-toggle" data-theme-toggle data-bs-toggle="tooltip" title="Modo claro / oscuro">
-      <i class="bi bi-circle-half"></i>
+    <button class="btn btn-sm btn-outline-primary me-2 admin-theme-toggle" data-theme-toggle data-bs-toggle="tooltip" title="Modo claro / oscuro">
+      <i class="bi"></i>
     </button>
     <a class="btn btn-sm btn-danger" href="{{ url_for('auth.logout') }}">Cerrar sesión</a>
   </div>


### PR DESCRIPTION
## Summary
- restore dropdown functionality after DataTable updates
- darken admin sidebar and tune nav link colors in dark mode
- tweak theme toggle button and update icon via JS
- document the changes in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6854fb1c54fc8325a290badbabbeb991