### PR TITLE
Fix admin dropdowns and main theme styles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,3 +137,5 @@
 - Fixed inactive dropdowns on admin tables by initializing via main.js and adding tooltips (PR admin-dropdowns-init).
 - Mejorado diseño visual del panel admin: contraste, colores y botones en modo claro/oscuro (PR admin-ui-polish).
 - Sidebar dark theme polished and dropdowns reinitialized after DataTable events, with theme toggle icon updates (PR admin-dark-dropdown-fix).
+- Arreglados dropdowns en tablas con getOrCreateInstance y fondo oscuro uniforme en main y tarjetas (PR admin-dropdown-dark-bg).
+- Mejorados badges de rol, icono de tema, padding inferior y estilos de main según tema (PR admin-ui-accessibility-fix).

--- a/crunevo/static/admin/custom.css
+++ b/crunevo/static/admin/custom.css
@@ -101,3 +101,31 @@
   background-color: var(--tblr-primary);
   border-color: var(--tblr-primary);
 }
+
+main {
+  padding-bottom: 2rem;
+}
+
+[data-bs-theme='light'] main {
+  background-color: #f8f9fa;
+}
+
+/* dark mode backgrounds */
+[data-bs-theme='dark'] main {
+  background-color: #121212;
+}
+
+[data-bs-theme='light'] .card,
+[data-bs-theme='light'] .table {
+  background-color: #fff;
+}
+
+[data-bs-theme='dark'] .card,
+[data-bs-theme='dark'] .table {
+  background-color: #181818;
+  color: #e9e9e9;
+}
+
+[data-bs-theme='dark'] .table th {
+  background-color: #1f1f1f;
+}

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -30,10 +30,13 @@ function showToast(message, options = {}) {
 
 function initDropdowns(scope = document) {
   scope.querySelectorAll('[data-bs-toggle="dropdown"]').forEach((el) => {
-    if (!el.dataset.dropdownInitialized) {
-      bootstrap.Dropdown.getOrCreateInstance(el);
-      if (el.title) new bootstrap.Tooltip(el);
-      el.dataset.dropdownInitialized = 'true';
+    bootstrap.Dropdown.getOrCreateInstance(el);
+    if (el.title) {
+      const tip = bootstrap.Tooltip.getOrCreateInstance(el);
+      if (!el.dataset.dropdownTooltipBound) {
+        el.addEventListener('show.bs.dropdown', () => tip.hide());
+        el.dataset.dropdownTooltipBound = 'true';
+      }
     }
   });
 }
@@ -44,14 +47,14 @@ function initDataTables() {
     const dt = new simpleDatatables.DataTable(table);
     const refresh = () => initDropdowns(table.parentElement);
     ['datatable.init', 'datatable.page', 'datatable.update', 'datatable.sort', 'datatable.search'].forEach((e) => dt.on(e, refresh));
+    refresh();
   });
 }
 
 function updateThemeIcons() {
   const dark = document.documentElement.dataset.bsTheme === 'dark';
   document.querySelectorAll('[data-theme-toggle] i').forEach((icon) => {
-    icon.classList.remove('bi-sun', 'bi-moon');
-    icon.classList.add(dark ? 'bi-moon' : 'bi-sun');
+    icon.className = 'bi ' + (dark ? 'bi-moon' : 'bi-sun');
   });
 }
 

--- a/crunevo/templates/admin/base_admin.html
+++ b/crunevo/templates/admin/base_admin.html
@@ -14,7 +14,7 @@
     </nav>
 
     <!-- Main con topbar y contenido -->
-    <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
+    <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4 pb-5">
       {% include "admin/partials/topbar.html" %}
       {% block admin_content %}{% endblock %}
     </main>

--- a/crunevo/templates/admin/manage_store.html
+++ b/crunevo/templates/admin/manage_store.html
@@ -27,7 +27,7 @@
         <td>{{ product.stock }}</td>
         <td class="text-end">
           <div class="dropdown">
-            <button class="btn btn-sm admin-dropdown-btn dropdown-toggle" data-bs-toggle="dropdown" title="Más opciones">⋮</button>
+            <button class="btn btn-sm admin-dropdown-btn dropdown-toggle" data-bs-toggle="dropdown" title="Más opciones" aria-label="Más opciones de {{ product.name }}" aria-haspopup="true" aria-expanded="false">⋮</button>
             <ul class="dropdown-menu shadow-sm">
               <li><a class="dropdown-item" href="{{ PUBLIC_BASE_URL }}/store/{{ product.id }}" target="_blank">Ver en tienda</a></li>
               {% if current_user.role == 'admin' %}

--- a/crunevo/templates/admin/manage_users.html
+++ b/crunevo/templates/admin/manage_users.html
@@ -19,14 +19,14 @@
         <tr>
           <td>{{ user.username }}</td>
           <td>{{ user.email }}</td>
-          <td><span class="badge bg-{{ 'purple' if user.role == 'admin' else 'blue' }}">{{ 'Admin' if user.role == 'admin' else 'Estudiante' }}</span></td>
+          <td><span class="badge text-white fw-semibold bg-{{ 'purple' if user.role == 'admin' else 'blue' }}">{{ 'Admin' if user.role == 'admin' else 'Estudiante' }}</span></td>
           <td>{{ user.credits }}</td>
           <td>
             <span class="status-dot status-dot-{{ 'green' if user.activated else 'red' }}"></span>
           </td>
           <td class="text-end">
             <div class="dropdown">
-              <button class="btn btn-sm admin-dropdown-btn dropdown-toggle" data-bs-toggle="dropdown" title="Más opciones">
+              <button class="btn btn-sm admin-dropdown-btn dropdown-toggle" data-bs-toggle="dropdown" title="Más opciones" aria-label="Más opciones de {{ user.username }}" aria-haspopup="true" aria-expanded="false">
                 ⋮
               </button>
               <ul class="dropdown-menu shadow-sm">


### PR DESCRIPTION
## Summary
- adjust badges for better contrast and add ARIA labels to dropdown buttons
- hide tooltips when dropdowns open and clean up theme toggle icons
- sync main backgrounds for light/dark themes with bottom padding
- document the update in `AGENTS.md`

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6855180aa8888325a3a888b93b704e8e