### PR TITLE
Improve admin layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,3 +139,6 @@
 - Sidebar dark theme polished and dropdowns reinitialized after DataTable events, with theme toggle icon updates (PR admin-dark-dropdown-fix).
 - Arreglados dropdowns en tablas con getOrCreateInstance y fondo oscuro uniforme en main y tarjetas (PR admin-dropdown-dark-bg).
 - Mejorados badges de rol, icono de tema, padding inferior y estilos de main según tema (PR admin-ui-accessibility-fix).
+- Ajustados estilos oscuros de cards y badges, y se forzó fondo oscuro en sidebar para cubrir franjas blancas (PR admin-dark-ui-tweak).
+- Dropdown de "Más opciones" ocultando tooltip activo y reinicializado tras DataTables; fondo oscuro global en body y container (PR admin-dropdown-tooltip-fix).
+- Contraste de hover en el sidebar oscuro, min-height para page-content y textos muted claros; funciones de dropdowns y datatables movidas a admin_ui.js (PR admin-layout-tweak).

--- a/crunevo/static/admin/custom.css
+++ b/crunevo/static/admin/custom.css
@@ -28,12 +28,20 @@
 }
 
 [data-bs-theme='dark'] .sidebar {
-  background-color: #1f1f1f;
+  background-color: #1f1f1f !important;
   border-color: #333;
+}
+[data-bs-theme='dark'] .sidebar.collapse:not(.show) {
+  background-color: #1f1f1f !important;
 }
 
 [data-bs-theme='dark'] .sidebar .nav-link {
   color: #ddd;
+}
+
+[data-bs-theme='dark'] .sidebar .nav-link:hover {
+  background-color: #2a2a2a;
+  color: #fff;
 }
 
 [data-bs-theme='dark'] .sidebar .nav-item.text-muted {
@@ -102,8 +110,18 @@
   border-color: var(--tblr-primary);
 }
 
+.badge.bg-purple,
+.badge.bg-blue {
+  color: #fff;
+  font-weight: 600;
+}
+
 main {
   padding-bottom: 2rem;
+}
+
+main > section.page-content {
+  min-height: 80vh;
 }
 
 [data-bs-theme='light'] main {
@@ -114,6 +132,14 @@ main {
 [data-bs-theme='dark'] main {
   background-color: #121212;
 }
+[data-bs-theme='dark'] body,
+[data-bs-theme='dark'] .container-fluid {
+  background-color: #121212 !important;
+}
+
+[data-bs-theme='dark'] .text-muted {
+  color: #ccc !important;
+}
 
 [data-bs-theme='light'] .card,
 [data-bs-theme='light'] .table {
@@ -121,7 +147,8 @@ main {
 }
 
 [data-bs-theme='dark'] .card,
-[data-bs-theme='dark'] .table {
+[data-bs-theme='dark'] .table,
+[data-bs-theme='dark'] .card-body {
   background-color: #181818;
   color: #e9e9e9;
 }

--- a/crunevo/static/js/admin_ui.js
+++ b/crunevo/static/js/admin_ui.js
@@ -1,0 +1,27 @@
+function initDropdowns(scope = document) {
+  scope.querySelectorAll('[data-bs-toggle="dropdown"]').forEach((el) => {
+    bootstrap.Dropdown.getOrCreateInstance(el);
+    if (el.title) {
+      bootstrap.Tooltip.getOrCreateInstance(el);
+    }
+    const tip = bootstrap.Tooltip.getInstance(el);
+    if (tip) tip.hide();
+    if (!el.dataset.dropdownTooltipBound) {
+      el.addEventListener('show.bs.dropdown', () => {
+        const t = bootstrap.Tooltip.getInstance(el);
+        if (t) t.hide();
+      });
+      el.dataset.dropdownTooltipBound = 'true';
+    }
+  });
+}
+
+function initDataTables() {
+  if (typeof simpleDatatables === 'undefined') return;
+  document.querySelectorAll('[data-datatable]').forEach((table) => {
+    const dt = new simpleDatatables.DataTable(table);
+    const refresh = () => initDropdowns(table.parentElement);
+    ['datatable.init', 'datatable.page', 'datatable.update', 'datatable.sort', 'datatable.search'].forEach((e) => dt.on(e, refresh));
+    refresh();
+  });
+}

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -28,28 +28,7 @@ function showToast(message, options = {}) {
   new bootstrap.Toast(div).show();
 }
 
-function initDropdowns(scope = document) {
-  scope.querySelectorAll('[data-bs-toggle="dropdown"]').forEach((el) => {
-    bootstrap.Dropdown.getOrCreateInstance(el);
-    if (el.title) {
-      const tip = bootstrap.Tooltip.getOrCreateInstance(el);
-      if (!el.dataset.dropdownTooltipBound) {
-        el.addEventListener('show.bs.dropdown', () => tip.hide());
-        el.dataset.dropdownTooltipBound = 'true';
-      }
-    }
-  });
-}
 
-function initDataTables() {
-  if (typeof simpleDatatables === 'undefined') return;
-  document.querySelectorAll('[data-datatable]').forEach((table) => {
-    const dt = new simpleDatatables.DataTable(table);
-    const refresh = () => initDropdowns(table.parentElement);
-    ['datatable.init', 'datatable.page', 'datatable.update', 'datatable.sort', 'datatable.search'].forEach((e) => dt.on(e, refresh));
-    refresh();
-  });
-}
 
 function updateThemeIcons() {
   const dark = document.documentElement.dataset.bsTheme === 'dark';
@@ -125,8 +104,12 @@ document.addEventListener('DOMContentLoaded', () => {
     initAdminCharts();
   }
 
-  initDataTables();
-  initDropdowns();
+  if (typeof initDataTables === 'function') {
+    initDataTables();
+  }
+  if (typeof initDropdowns === 'function') {
+    initDropdowns();
+  }
 
   // Bootstrap collapse handles the mobile menu
 

--- a/crunevo/templates/admin/base_admin.html
+++ b/crunevo/templates/admin/base_admin.html
@@ -16,13 +16,16 @@
     <!-- Main con topbar y contenido -->
     <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4 pb-5">
       {% include "admin/partials/topbar.html" %}
-      {% block admin_content %}{% endblock %}
+      <section class="page-content">
+        {% block admin_content %}{% endblock %}
+      </section>
     </main>
   </div>
 </div>
 {% endblock %}
 
-{% block body_end %}
-  {{ super() }}
-  <script src="{{ url_for('static', filename='js/admin_stats.js') }}" defer></script>
-{% endblock %}
+  {% block body_end %}
+    {{ super() }}
+    <script src="{{ url_for('static', filename='js/admin_ui.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/admin_stats.js') }}" defer></script>
+  {% endblock %}


### PR DESCRIPTION
## Summary
- add sidebar hover contrast and dark text-muted color
- ensure pages occupy viewport height and modularize admin scripts
- wrap admin content in page-content section
- log changes in AGENTS guide

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68551c80c4788325bd2613af37e795be