### PR TITLE
Fix admin dropdown final

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,3 +142,4 @@
 - Ajustados estilos oscuros de cards y badges, y se forzó fondo oscuro en sidebar para cubrir franjas blancas (PR admin-dark-ui-tweak).
 - Dropdown de "Más opciones" ocultando tooltip activo y reinicializado tras DataTables; fondo oscuro global en body y container (PR admin-dropdown-tooltip-fix).
 - Contraste de hover en el sidebar oscuro, min-height para page-content y textos muted claros; funciones de dropdowns y datatables movidas a admin_ui.js (PR admin-layout-tweak).
+- Reparado dropdown de "Más opciones" en tablas admin, corrigiendo conflictos con DataTables y tooltips (PR admin-dropdown-final-fix).

--- a/crunevo/static/admin/custom.css
+++ b/crunevo/static/admin/custom.css
@@ -156,3 +156,12 @@ main > section.page-content {
 [data-bs-theme='dark'] .table th {
   background-color: #1f1f1f;
 }
+
+/* admin-dropdown-final-fix */
+.table-responsive {
+  overflow: visible;
+}
+
+.dropdown-menu {
+  z-index: 1055;
+}


### PR DESCRIPTION
## Summary
- keep dropdown menus visible in admin tables by overriding table-responsive overflow and raising z-index
- document the fix in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6855223456f0832594e5997016f3e14a