### PR TITLE
Fix dark theme card styling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,3 +143,4 @@
 - Dropdown de "Más opciones" ocultando tooltip activo y reinicializado tras DataTables; fondo oscuro global en body y container (PR admin-dropdown-tooltip-fix).
 - Contraste de hover en el sidebar oscuro, min-height para page-content y textos muted claros; funciones de dropdowns y datatables movidas a admin_ui.js (PR admin-layout-tweak).
 - Reparado dropdown de "Más opciones" en tablas admin, corrigiendo conflictos con DataTables y tooltips (PR admin-dropdown-final-fix).
+- Ajustado soporte de modo oscuro en feed, apuntes y tienda (PR dark-theme-fix)

--- a/crunevo/static/css/main.css
+++ b/crunevo/static/css/main.css
@@ -1,0 +1,38 @@
+/* Modo oscuro */
+[data-bs-theme="dark"] .card {
+  background-color: #1f1f1f !important;
+  color: #f8f9fa !important;
+  border-color: #333 !important;
+}
+
+[data-bs-theme="dark"] .card .btn {
+  color: #fff;
+}
+
+[data-bs-theme="dark"] .card-title,
+[data-bs-theme="dark"] .card-text,
+[data-bs-theme="dark"] .badge {
+  color: #f1f1f1 !important;
+}
+
+[data-bs-theme="dark"] .list-group-item {
+  background-color: #1f1f1f !important;
+  border-color: #333;
+  color: #f1f1f1 !important;
+}
+
+[data-bs-theme="dark"] .form-control {
+  background-color: #2c2c2c;
+  color: #fff;
+}
+
+[data-bs-theme="dark"] .btn-outline-primary {
+  color: #aad4ff;
+  border-color: #aad4ff;
+}
+
+[data-bs-theme="dark"] .dropdown-menu {
+  background-color: #2c2c2c;
+  color: #fff;
+  border-color: #444;
+}

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/fix-bootstrap.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/navbar.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
     {% block head_extra %}{% endblock %}
 </head>
 <body class="d-flex flex-column min-vh-100">


### PR DESCRIPTION
## Summary
- add dark theme CSS overrides
- include `main.css` in base template
- document dark theme fix in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6855244e06388325881e09a7c35eff45