### PR TITLE
Fix admin dropdown tooltip creation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,3 +144,6 @@
 - Contraste de hover en el sidebar oscuro, min-height para page-content y textos muted claros; funciones de dropdowns y datatables movidas a admin_ui.js (PR admin-layout-tweak).
 - Reparado dropdown de "Más opciones" en tablas admin, corrigiendo conflictos con DataTables y tooltips (PR admin-dropdown-final-fix).
 - Ajustado soporte de modo oscuro en feed, apuntes y tienda (PR dark-theme-fix)
+- Ensured dropdown containers use position-relative to properly render menus (QA admin-dropdown-container).
+- Prevented duplicate dropdown instances by checking getInstance first (QA admin-dropdown-instance-check).
+- Avoided tooltip duplication by verifying getInstance and binding show event once (QA admin-tooltip-instance-fix).

--- a/crunevo/static/js/admin_ui.js
+++ b/crunevo/static/js/admin_ui.js
@@ -1,11 +1,13 @@
 function initDropdowns(scope = document) {
   scope.querySelectorAll('[data-bs-toggle="dropdown"]').forEach((el) => {
-    bootstrap.Dropdown.getOrCreateInstance(el);
-    if (el.title) {
+    if (!bootstrap.Dropdown.getInstance(el)) {
+      bootstrap.Dropdown.getOrCreateInstance(el);
+    }
+
+    if (el.title && !bootstrap.Tooltip.getInstance(el)) {
       bootstrap.Tooltip.getOrCreateInstance(el);
     }
-    const tip = bootstrap.Tooltip.getInstance(el);
-    if (tip) tip.hide();
+
     if (!el.dataset.dropdownTooltipBound) {
       el.addEventListener('show.bs.dropdown', () => {
         const t = bootstrap.Tooltip.getInstance(el);

--- a/crunevo/templates/admin/manage_store.html
+++ b/crunevo/templates/admin/manage_store.html
@@ -26,7 +26,7 @@
         <td>{{ product.name }}</td>
         <td>{{ product.stock }}</td>
         <td class="text-end">
-          <div class="dropdown">
+          <div class="dropdown position-relative">
             <button class="btn btn-sm admin-dropdown-btn dropdown-toggle" data-bs-toggle="dropdown" title="Más opciones" aria-label="Más opciones de {{ product.name }}" aria-haspopup="true" aria-expanded="false">⋮</button>
             <ul class="dropdown-menu shadow-sm">
               <li><a class="dropdown-item" href="{{ PUBLIC_BASE_URL }}/store/{{ product.id }}" target="_blank">Ver en tienda</a></li>

--- a/crunevo/templates/admin/manage_users.html
+++ b/crunevo/templates/admin/manage_users.html
@@ -25,7 +25,7 @@
             <span class="status-dot status-dot-{{ 'green' if user.activated else 'red' }}"></span>
           </td>
           <td class="text-end">
-            <div class="dropdown">
+            <div class="dropdown position-relative">
               <button class="btn btn-sm admin-dropdown-btn dropdown-toggle" data-bs-toggle="dropdown" title="Más opciones" aria-label="Más opciones de {{ user.username }}" aria-haspopup="true" aria-expanded="false">
                 ⋮
               </button>


### PR DESCRIPTION
## Summary
- avoid duplicating tooltip and dropdown instances in admin_ui.js
- document tooltip fix in AGENTS guidelines

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6855255bf6688325bdf71cd02db4eac8