### PR TITLE
Add ranking tabs and achievements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,3 +147,4 @@
 - Ensured dropdown containers use position-relative to properly render menus (QA admin-dropdown-container).
 - Prevented duplicate dropdown instances by checking getInstance first (QA admin-dropdown-instance-check).
 - Avoided tooltip duplication by verifying getInstance and binding show event once (QA admin-tooltip-instance-fix).
+- Implemented ranking with tabs and achievements section (PR ranking-achievements).

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -23,7 +23,12 @@ def create_app():
 
     @app.context_processor
     def inject_globals():
-        return {"PUBLIC_BASE_URL": app.config.get("PUBLIC_BASE_URL")}
+        from .constants import ACHIEVEMENT_DETAILS
+
+        return {
+            "PUBLIC_BASE_URL": app.config.get("PUBLIC_BASE_URL"),
+            "ACHIEVEMENT_DETAILS": ACHIEVEMENT_DETAILS,
+        }
 
     db.init_app(app)
     login_manager.init_app(app)

--- a/crunevo/constants/__init__.py
+++ b/crunevo/constants/__init__.py
@@ -1,4 +1,5 @@
 from .credit_reasons import CreditReasons
 from .achievement_codes import AchievementCodes
+from .achievement_details import ACHIEVEMENT_DETAILS
 
-__all__ = ["CreditReasons", "AchievementCodes"]
+__all__ = ["CreditReasons", "AchievementCodes", "ACHIEVEMENT_DETAILS"]

--- a/crunevo/constants/achievement_codes.py
+++ b/crunevo/constants/achievement_codes.py
@@ -5,3 +5,4 @@ class AchievementCodes:
     CONECTADO_7D = "conectado_7d"
     COMPARTIDOR = "compartidor"
     DESCARGA_100 = "100_descargas"
+    LIKE_100 = "100_likes"

--- a/crunevo/constants/achievement_details.py
+++ b/crunevo/constants/achievement_details.py
@@ -1,0 +1,9 @@
+ACHIEVEMENT_DETAILS = {
+    "primer_apunte": {"title": "Primer Apunte", "icon": "bi-file-earmark-plus"},
+    "top_3": {"title": "Top 3", "icon": "bi-trophy"},
+    "donador": {"title": "Donador", "icon": "bi-gift"},
+    "conectado_7d": {"title": "Conectado 7D", "icon": "bi-calendar-check"},
+    "compartidor": {"title": "Colaborador", "icon": "bi-share"},
+    "100_descargas": {"title": "100 Descargas", "icon": "bi-download"},
+    "100_likes": {"title": "100 Likes", "icon": "bi-hand-thumbs-up"},
+}

--- a/crunevo/models/__init__.py
+++ b/crunevo/models/__init__.py
@@ -8,7 +8,7 @@ from .post_comment import PostComment  # noqa: F401
 from .post import Post  # noqa: F401
 from .credit import Credit  # noqa: F401
 from .ranking import RankingCache  # noqa: F401
-from .achievement import UserAchievement  # noqa: F401
+from .achievement import Achievement, UserAchievement  # noqa: F401
 from .login_history import LoginHistory  # noqa: F401
 from .note_vote import NoteVote  # noqa: F401
 from .feed_item import FeedItem  # noqa: F401

--- a/crunevo/models/achievement.py
+++ b/crunevo/models/achievement.py
@@ -2,10 +2,20 @@ from datetime import datetime
 from crunevo.extensions import db
 
 
+class Achievement(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    code = db.Column(db.String(50), unique=True, nullable=False)
+    title = db.Column(db.String(100), nullable=False)
+    icon = db.Column(db.String(100), nullable=False)
+
+
 class UserAchievement(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
-    badge_code = db.Column(db.String(50), nullable=False)
-    earned_at = db.Column(db.DateTime, default=datetime.utcnow)
+    achievement_id = db.Column(
+        db.Integer, db.ForeignKey("achievement.id"), nullable=False
+    )
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
 
     user = db.relationship("User", backref="achievements")
+    achievement = db.relationship("Achievement")

--- a/crunevo/routes/feed_routes.py
+++ b/crunevo/routes/feed_routes.py
@@ -22,6 +22,7 @@ from crunevo.models import (
     Note,
     User,
     UserAchievement,
+    Achievement,
     LoginHistory,
 )
 from crunevo.forms import FeedNoteForm, FeedImageForm
@@ -43,7 +44,7 @@ def get_featured_posts():
         db.session.query(User)
         .join(UserAchievement)
         .group_by(User.id)
-        .order_by(func.max(UserAchievement.earned_at).desc())
+        .order_by(func.max(UserAchievement.timestamp).desc())
         .limit(3)
         .all()
     )
@@ -65,9 +66,10 @@ def get_weekly_ranking():
     )
 
     recent_achievements = (
-        db.session.query(User.username, UserAchievement.badge_code)
+        db.session.query(User.username, Achievement.title)
         .join(UserAchievement)
-        .order_by(UserAchievement.earned_at.desc())
+        .join(Achievement)
+        .order_by(UserAchievement.timestamp.desc())
         .limit(5)
         .all()
     )

--- a/crunevo/routes/notes_routes.py
+++ b/crunevo/routes/notes_routes.py
@@ -204,6 +204,8 @@ def like_note(note_id):
         vote = NoteVote(user_id=current_user.id, note_id=note.id)
         db.session.add(vote)
         add_credit(note.author, 1, CreditReasons.VOTO_POSITIVO, related_id=note.id)
+        if note.likes >= 100:
+            unlock_achievement(note.author, AchievementCodes.LIKE_100)
         action = "liked"
 
     db.session.commit()

--- a/crunevo/routes/ranking_routes.py
+++ b/crunevo/routes/ranking_routes.py
@@ -1,22 +1,33 @@
-from flask import Blueprint, render_template
-from crunevo.models import RankingCache
-from datetime import datetime
+from datetime import datetime, timedelta
+from flask import Blueprint, render_template, request
+from sqlalchemy import func, desc
+from crunevo.extensions import db
+from crunevo.models import User, Credit
 
 ranking_bp = Blueprint("ranking", __name__, url_prefix="/ranking")
 
 
 @ranking_bp.route("/")
 def show_ranking():
-    top = (
-        RankingCache.query.filter_by(period="semanal")
-        .order_by(RankingCache.score.desc())
-        .limit(10)
-        .all()
-    )
-    last_update = top[0].calculated_at if top else None
+    range_opt = request.args.get("range", "week")
+    now = datetime.utcnow()
+    if range_opt == "week":
+        start = now - timedelta(days=7)
+    elif range_opt == "month":
+        start = now - timedelta(days=30)
+    else:
+        start = None
+
+    query = db.session.query(
+        User,
+        func.coalesce(func.sum(Credit.amount), 0).label("total"),
+    ).outerjoin(Credit)
+    if start:
+        query = query.filter(Credit.timestamp >= start)
+    ranking = query.group_by(User.id).order_by(desc("total")).limit(10).all()
+
     return render_template(
         "ranking/index.html",
-        ranking=top,
-        now=datetime.utcnow(),
-        last_update=last_update,
+        ranking=ranking,
+        range=range_opt,
     )

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -27,13 +27,16 @@
     <li>{{ '+' if c.amount > 0 else '' }}{{ c.amount }} – {{ c.reason }} ({{ c.timestamp.strftime('%Y-%m-%d') }})</li>
   {% endfor %}
 </ul>
-<h5>Logros desbloqueados</h5>
-<ul>
+<h5>🎖️ Logros desbloqueados</h5>
+<div class="row row-cols-2 row-cols-md-3 g-2">
   {% for a in current_user.achievements %}
-    <li>🏅 {{ a.badge_code.replace("_", " ").capitalize() }} ({{ a.earned_at.strftime('%Y-%m-%d') }})</li>
+    {% set info = ACHIEVEMENT_DETAILS.get(a.achievement.code, {}) %}
+    <div class="col">
+      {% include 'components/achievement_card.html' with icon=info.icon title=info.title timestamp=a.timestamp %}
+    </div>
   {% else %}
-    <li>Aún no tienes logros desbloqueados.</li>
+    <div class="col">Aún no tienes logros desbloqueados.</div>
   {% endfor %}
-</ul>
+</div>
 {% endblock %}
 

--- a/crunevo/templates/components/achievement_card.html
+++ b/crunevo/templates/components/achievement_card.html
@@ -1,0 +1,8 @@
+<div class="card text-center tw-bg-gradient-to-r tw-from-purple-500/20 tw-to-indigo-500/20">
+  <div class="card-body p-2">
+    <i class="bi {{ icon }} fs-3"></i>
+    <div class="fw-bold">{{ title }}</div>
+    {% if timestamp %}<small class="text-muted">{{ timestamp.strftime('%Y-%m-%d') }}</small>{% endif %}
+  </div>
+</div>
+

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -14,6 +14,7 @@
         <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('feed.trending') }}"><i class="bi bi-fire me-1"></i>Tendencias</a></li>
         <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('notes.list_notes') }}"><i class="bi bi-journal-text me-1"></i>Apuntes</a></li>
         <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('store.store_index') }}"><i class="bi bi-bag me-1"></i>Tienda</a></li>
+        <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('ranking.show_ranking') }}"><i class="bi bi-trophy me-1"></i>Ranking</a></li>
         <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('chat.chat_index') }}"><i class="bi bi-chat-dots me-1"></i>Chat</a></li>
         {% if config.ADMIN_INSTANCE and current_user.is_authenticated and current_user.role == 'admin' %}
         <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('admin.dashboard') }}"><i class="bi bi-speedometer2 me-1"></i>Admin</a></li>

--- a/crunevo/templates/perfil_publico.html
+++ b/crunevo/templates/perfil_publico.html
@@ -22,13 +22,25 @@
     </div>
     <h5>Últimos apuntes</h5>
     <ul class="list-group">
-      {% for note in user.notes|sort(attribute='created_at', reverse=True)[:5] %}
-      <li class="list-group-item d-flex justify-content-between align-items-start">
-        <a href="{{ url_for('notes.view_note', id=note.id) }}">{{ note.title }}</a>
-        <small class="text-muted">{{ note.created_at.strftime('%Y-%m-%d') }}</small>
-      </li>
-      {% endfor %}
-    </ul>
+  {% for note in user.notes|sort(attribute='created_at', reverse=True)[:5] %}
+  <li class="list-group-item d-flex justify-content-between align-items-start">
+    <a href="{{ url_for('notes.view_note', id=note.id) }}">{{ note.title }}</a>
+    <small class="text-muted">{{ note.created_at.strftime('%Y-%m-%d') }}</small>
+  </li>
+  {% endfor %}
+  </ul>
+
+  <h5 class="mt-4">🎖️ Logros desbloqueados</h5>
+  <div class="row row-cols-2 row-cols-md-3 g-2">
+    {% for a in user.achievements %}
+      {% set info = ACHIEVEMENT_DETAILS.get(a.achievement.code, {}) %}
+      <div class="col">
+        {% include 'components/achievement_card.html' with icon=info.icon title=info.title timestamp=a.timestamp %}
+      </div>
+    {% else %}
+      <div class="col">Aún no tiene logros.</div>
+    {% endfor %}
   </div>
+</div>
 </div>
 {% endblock %}

--- a/crunevo/templates/ranking/index.html
+++ b/crunevo/templates/ranking/index.html
@@ -1,29 +1,37 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2 class="mb-4">🏆 Ranking Semanal</h2>
-{% if last_update %}
-<p class="text-muted">Última actualización: {{ last_update.strftime('%Y-%m-%d %H:%M') }}</p>
-{% endif %}
+<h2 class="mb-4">🏆 Ranking</h2>
+<ul class="nav nav-tabs mb-3">
+  <li class="nav-item">
+    <a class="nav-link {% if range == 'week' %}active{% endif %}" href="{{ url_for('ranking.show_ranking', range='week') }}">Semanal</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link {% if range == 'month' %}active{% endif %}" href="{{ url_for('ranking.show_ranking', range='month') }}">Mensual</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link {% if range == 'all' %}active{% endif %}" href="{{ url_for('ranking.show_ranking', range='all') }}">Histórico</a>
+  </li>
+</ul>
 <div class="table-responsive">
 <table class="table table-hover align-middle">
   <thead>
     <tr>
       <th class="text-center">#</th>
       <th>Usuario</th>
-      <th class="text-end">Puntaje</th>
+      <th class="text-end">Créditos</th>
     </tr>
   </thead>
   <tbody>
-    {% for r in ranking %}
+    {% for user, total in ranking %}
     <tr class="{% if loop.index == 1 %}table-warning border-gold{% elif loop.index == 2 %}table-secondary border-silver{% elif loop.index == 3 %}table-bronze border-bronze{% endif %}">
       <td class="text-center fs-4">
         {% if loop.index == 1 %}<i class="bi bi-trophy-fill text-warning"></i>{% elif loop.index == 2 %}<i class="bi bi-trophy-fill text-secondary"></i>{% elif loop.index == 3 %}<i class="bi bi-trophy-fill text-brown"></i>{% else %}{{ loop.index }}{% endif %}
       </td>
       <td>
-        <img src="{{ r.user.avatar_url or url_for('static', filename='img/default.png') }}" width="32" height="32" class="rounded-circle me-1">
-        {{ r.user.username }} <small class="text-muted">({{ r.user.carrera or '' }})</small>
+        <img src="{{ user.avatar_url or url_for('static', filename='img/default.png') }}" width="32" height="32" class="rounded-circle me-1">
+        {{ user.username }}
       </td>
-      <td class="text-end"><strong>{{ r.score }}</strong></td>
+      <td class="text-end"><strong>{{ '%.0f'|format(total) }}</strong></td>
     </tr>
     {% endfor %}
   </tbody>

--- a/crunevo/utils/achievements.py
+++ b/crunevo/utils/achievements.py
@@ -1,17 +1,33 @@
-from crunevo.models import UserAchievement
+from crunevo.models import Achievement, UserAchievement
 from crunevo.extensions import db
 from crunevo.utils.feed import create_feed_item_for_all
+from crunevo.constants import ACHIEVEMENT_DETAILS
 
 
 def unlock_achievement(user, badge_code):
-    if not any(a.badge_code == badge_code for a in user.achievements):
-        new = UserAchievement(user_id=user.id, badge_code=badge_code)
-        db.session.add(new)
-        db.session.commit()
-        meta_dict = {
-            "badge_code": badge_code,
-            "username": user.username,
-        }
-        create_feed_item_for_all(
-            "logro", new.id, meta_dict=meta_dict, is_highlight=True
+    """Assign an achievement to the user if not already earned."""
+    ach = Achievement.query.filter_by(code=badge_code).first()
+    if ach is None:
+        details = ACHIEVEMENT_DETAILS.get(badge_code, {})
+        ach = Achievement(
+            code=badge_code,
+            title=details.get("title", badge_code.title()),
+            icon=details.get("icon", "bi-star"),
         )
+        db.session.add(ach)
+        db.session.commit()
+
+    exists = UserAchievement.query.filter_by(
+        user_id=user.id, achievement_id=ach.id
+    ).first()
+    if exists:
+        return
+
+    new = UserAchievement(user_id=user.id, achievement_id=ach.id)
+    db.session.add(new)
+    db.session.commit()
+    meta_dict = {
+        "badge_code": badge_code,
+        "username": user.username,
+    }
+    create_feed_item_for_all("logro", new.id, meta_dict=meta_dict, is_highlight=True)

--- a/tests/test_achievements.py
+++ b/tests/test_achievements.py
@@ -5,14 +5,16 @@ from crunevo.constants import AchievementCodes
 def test_unlock_achievement(db_session, test_user):
     unlock_achievement(test_user, AchievementCodes.PRIMER_APUNTE)
     assert any(
-        a.badge_code == AchievementCodes.PRIMER_APUNTE for a in test_user.achievements
+        a.achievement.code == AchievementCodes.PRIMER_APUNTE
+        for a in test_user.achievements
     )
 
 
 def test_share_unlocks_sharing_badge(db_session, test_user):
     unlock_achievement(test_user, AchievementCodes.COMPARTIDOR)
     assert any(
-        a.badge_code == AchievementCodes.COMPARTIDOR for a in test_user.achievements
+        a.achievement.code == AchievementCodes.COMPARTIDOR
+        for a in test_user.achievements
     )
 
 
@@ -30,5 +32,6 @@ def test_downloads_unlocks_badge(db_session, test_user):
     unlock_achievement(test_user, AchievementCodes.DESCARGA_100)
 
     assert any(
-        a.badge_code == AchievementCodes.DESCARGA_100 for a in test_user.achievements
+        a.achievement.code == AchievementCodes.DESCARGA_100
+        for a in test_user.achievements
     )

--- a/tests/test_credits.py
+++ b/tests/test_credits.py
@@ -29,4 +29,6 @@ def test_spend_insufficient(db_session, test_user):
 def test_donor_achievement(db_session, test_user, another_user):
     add_credit(test_user, 5, CreditReasons.DONACION)
     spend_credit(test_user, 5, CreditReasons.DONACION, related_id=another_user.id)
-    assert any(a.badge_code == AchievementCodes.DONADOR for a in test_user.achievements)
+    assert any(
+        a.achievement.code == AchievementCodes.DONADOR for a in test_user.achievements
+    )

--- a/tests/test_like_achievement.py
+++ b/tests/test_like_achievement.py
@@ -1,0 +1,22 @@
+from crunevo.models import Note
+from crunevo.constants import AchievementCodes
+
+
+def login(client, username, password):
+    return client.post("/login", data={"username": username, "password": password})
+
+
+def test_100_likes_unlocks_badge(client, db_session, test_user, another_user):
+    note = Note(title="test", author=another_user, likes=99)
+    db_session.add(note)
+    db_session.commit()
+
+    login(client, "tester", "secret")
+    resp = client.post(f"/notes/{note.id}/like")
+    assert resp.status_code == 200
+
+    db_session.refresh(another_user)
+    assert any(
+        a.achievement.code == AchievementCodes.LIKE_100
+        for a in another_user.achievements
+    )

--- a/tests/test_login_history.py
+++ b/tests/test_login_history.py
@@ -9,7 +9,8 @@ def test_login_streak_unlocks(db_session, test_user):
         record_login(test_user, start + timedelta(days=i))
 
     assert any(
-        a.badge_code == AchievementCodes.CONECTADO_7D for a in test_user.achievements
+        a.achievement.code == AchievementCodes.CONECTADO_7D
+        for a in test_user.achievements
     )
 
 
@@ -19,5 +20,6 @@ def test_login_streak_not_enough(db_session, test_user):
         record_login(test_user, start + timedelta(days=i))
 
     assert not any(
-        a.badge_code == AchievementCodes.CONECTADO_7D for a in test_user.achievements
+        a.achievement.code == AchievementCodes.CONECTADO_7D
+        for a in test_user.achievements
     )

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -15,4 +15,6 @@ def test_calculate_weekly_ranking(client, test_user):
     ranking = RankingCache.query.filter_by(user_id=test_user.id).first()
     assert ranking is not None
     assert ranking.score >= 0
-    assert any(a.badge_code == AchievementCodes.TOP_3 for a in test_user.achievements)
+    assert any(
+        a.achievement.code == AchievementCodes.TOP_3 for a in test_user.achievements
+    )


### PR DESCRIPTION
## Summary
- add Achievement model with details and use it in unlock_achievement
- create ranking page with week/month/history tabs
- display achievements on profile pages with new card component
- add Ranking link in navbar
- test 100-likes achievement
- document change in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68552d327cfc83259df7d6a93553cd18