### PR TITLE
Integrate Resend email provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,6 @@ FLASK_ENV=production
 SECRET_KEY=changeme
 DATABASE_URL=postgresql://user:password@localhost:5432/dbname
 CLOUDINARY_URL=cloudinary://APIKEY:SECRET@cloudname
+RESEND_API_KEY=
+MAIL_USERNAME=noreply@crunevo.com
+MAIL_PROVIDER=resend

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,3 +148,4 @@
 - Prevented duplicate dropdown instances by checking getInstance first (QA admin-dropdown-instance-check).
 - Avoided tooltip duplication by verifying getInstance and binding show event once (QA admin-tooltip-instance-fix).
 - Implemented ranking with tabs and achievements section (PR ranking-achievements).
+- Integrado Resend como proveedor de emails y verificación en registro (PR resend-email-provider).

--- a/crunevo/config.py
+++ b/crunevo/config.py
@@ -31,12 +31,13 @@ class Config:
     MAIL_SERVER = os.getenv("MAIL_SERVER", "smtp.gmail.com")
     MAIL_PORT = int(os.getenv("MAIL_PORT", 587))
     MAIL_USE_TLS = True
-    MAIL_USERNAME = os.getenv("MAIL_USERNAME")
+    MAIL_USERNAME = os.getenv("MAIL_USERNAME", "noreply@crunevo.com")
     MAIL_PASSWORD = os.getenv("MAIL_PASSWORD")
-    MAIL_DEFAULT_SENDER = os.getenv("MAIL_SENDER", "Crunevo <no-reply@crunevo.io>")
+    MAIL_DEFAULT_SENDER = os.getenv("MAIL_SENDER", f"Crunevo <{MAIL_USERNAME}>")
 
     RESEND_API_KEY = os.getenv("RESEND_API_KEY")
-    USE_RESEND = RESEND_API_KEY is not None
+    MAIL_PROVIDER = os.getenv("MAIL_PROVIDER", "smtp")
+    USE_RESEND = MAIL_PROVIDER == "resend" or RESEND_API_KEY is not None
     MAIL_SUPPRESS_SEND = (
         not (MAIL_SERVER and MAIL_USERNAME and MAIL_PASSWORD) and not USE_RESEND
     )

--- a/crunevo/routes/auth_routes.py
+++ b/crunevo/routes/auth_routes.py
@@ -19,6 +19,7 @@ from crunevo.models import User
 from crunevo.utils import spend_credit, record_login
 from crunevo.constants import CreditReasons
 from sqlalchemy.exc import IntegrityError
+from crunevo.routes.onboarding_routes import send_confirmation_email
 
 auth_bp = Blueprint("auth", __name__)
 
@@ -42,8 +43,8 @@ def register():
             current_app.logger.warning("IntegrityError: %s", e)
             flash("Usuario o correo ya registrado", "danger")
             return render_template("auth/register.html"), 400
-        flash("Registro exitoso. Inicia sesión")
-        return redirect(url_for("auth.login"))
+        send_confirmation_email(user)
+        return render_template("onboarding/confirm.html")
     return render_template("auth/register.html")
 
 

--- a/crunevo/routes/feed_routes.py
+++ b/crunevo/routes/feed_routes.py
@@ -67,8 +67,9 @@ def get_weekly_ranking():
 
     recent_achievements = (
         db.session.query(User.username, Achievement.title)
-        .join(UserAchievement)
-        .join(Achievement)
+        .select_from(UserAchievement)
+        .join(User, User.id == UserAchievement.user_id)
+        .join(Achievement, Achievement.id == UserAchievement.achievement_id)
         .order_by(UserAchievement.timestamp.desc())
         .limit(5)
         .all()


### PR DESCRIPTION
## Summary
- add Resend email settings to config
- provide send_email helper using Resend
- trigger confirmation email on `/register`
- fix feed ranking query ambiguity
- update example environment variables
- document Resend provider in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6855984ba3e08325bc596ebaba30bb02