### PR TITLE
Fix weekly ranking query

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,3 +149,4 @@
 - Avoided tooltip duplication by verifying getInstance and binding show event once (QA admin-tooltip-instance-fix).
 - Implemented ranking with tabs and achievements section (PR ranking-achievements).
 - Integrado Resend como proveedor de emails y verificación en registro (PR resend-email-provider).
+- Fixed feed weekly ranking query removing nonexistent achievement join (PR achievement-table-fix).

--- a/crunevo/models/achievement.py
+++ b/crunevo/models/achievement.py
@@ -12,10 +12,7 @@ class Achievement(db.Model):
 class UserAchievement(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
-    achievement_id = db.Column(
-        db.Integer, db.ForeignKey("achievement.id"), nullable=False
-    )
+    badge_code = db.Column(db.String(50), nullable=False)
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
 
     user = db.relationship("User", backref="achievements")
-    achievement = db.relationship("Achievement")

--- a/crunevo/utils/achievements.py
+++ b/crunevo/utils/achievements.py
@@ -1,29 +1,17 @@
-from crunevo.models import Achievement, UserAchievement
+from crunevo.models import UserAchievement
 from crunevo.extensions import db
 from crunevo.utils.feed import create_feed_item_for_all
-from crunevo.constants import ACHIEVEMENT_DETAILS
 
 
 def unlock_achievement(user, badge_code):
     """Assign an achievement to the user if not already earned."""
-    ach = Achievement.query.filter_by(code=badge_code).first()
-    if ach is None:
-        details = ACHIEVEMENT_DETAILS.get(badge_code, {})
-        ach = Achievement(
-            code=badge_code,
-            title=details.get("title", badge_code.title()),
-            icon=details.get("icon", "bi-star"),
-        )
-        db.session.add(ach)
-        db.session.commit()
-
     exists = UserAchievement.query.filter_by(
-        user_id=user.id, achievement_id=ach.id
+        user_id=user.id, badge_code=badge_code
     ).first()
     if exists:
         return
 
-    new = UserAchievement(user_id=user.id, achievement_id=ach.id)
+    new = UserAchievement(user_id=user.id, badge_code=badge_code)
     db.session.add(new)
     db.session.commit()
     meta_dict = {

--- a/tests/test_achievements.py
+++ b/tests/test_achievements.py
@@ -5,16 +5,14 @@ from crunevo.constants import AchievementCodes
 def test_unlock_achievement(db_session, test_user):
     unlock_achievement(test_user, AchievementCodes.PRIMER_APUNTE)
     assert any(
-        a.achievement.code == AchievementCodes.PRIMER_APUNTE
-        for a in test_user.achievements
+        a.badge_code == AchievementCodes.PRIMER_APUNTE for a in test_user.achievements
     )
 
 
 def test_share_unlocks_sharing_badge(db_session, test_user):
     unlock_achievement(test_user, AchievementCodes.COMPARTIDOR)
     assert any(
-        a.achievement.code == AchievementCodes.COMPARTIDOR
-        for a in test_user.achievements
+        a.badge_code == AchievementCodes.COMPARTIDOR for a in test_user.achievements
     )
 
 
@@ -32,6 +30,5 @@ def test_downloads_unlocks_badge(db_session, test_user):
     unlock_achievement(test_user, AchievementCodes.DESCARGA_100)
 
     assert any(
-        a.achievement.code == AchievementCodes.DESCARGA_100
-        for a in test_user.achievements
+        a.badge_code == AchievementCodes.DESCARGA_100 for a in test_user.achievements
     )

--- a/tests/test_credits.py
+++ b/tests/test_credits.py
@@ -29,6 +29,4 @@ def test_spend_insufficient(db_session, test_user):
 def test_donor_achievement(db_session, test_user, another_user):
     add_credit(test_user, 5, CreditReasons.DONACION)
     spend_credit(test_user, 5, CreditReasons.DONACION, related_id=another_user.id)
-    assert any(
-        a.achievement.code == AchievementCodes.DONADOR for a in test_user.achievements
-    )
+    assert any(a.badge_code == AchievementCodes.DONADOR for a in test_user.achievements)

--- a/tests/test_like_achievement.py
+++ b/tests/test_like_achievement.py
@@ -17,6 +17,5 @@ def test_100_likes_unlocks_badge(client, db_session, test_user, another_user):
 
     db_session.refresh(another_user)
     assert any(
-        a.achievement.code == AchievementCodes.LIKE_100
-        for a in another_user.achievements
+        a.badge_code == AchievementCodes.LIKE_100 for a in another_user.achievements
     )

--- a/tests/test_login_history.py
+++ b/tests/test_login_history.py
@@ -9,8 +9,7 @@ def test_login_streak_unlocks(db_session, test_user):
         record_login(test_user, start + timedelta(days=i))
 
     assert any(
-        a.achievement.code == AchievementCodes.CONECTADO_7D
-        for a in test_user.achievements
+        a.badge_code == AchievementCodes.CONECTADO_7D for a in test_user.achievements
     )
 
 
@@ -20,6 +19,5 @@ def test_login_streak_not_enough(db_session, test_user):
         record_login(test_user, start + timedelta(days=i))
 
     assert not any(
-        a.achievement.code == AchievementCodes.CONECTADO_7D
-        for a in test_user.achievements
+        a.badge_code == AchievementCodes.CONECTADO_7D for a in test_user.achievements
     )

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -15,6 +15,4 @@ def test_calculate_weekly_ranking(client, test_user):
     ranking = RankingCache.query.filter_by(user_id=test_user.id).first()
     assert ranking is not None
     assert ranking.score >= 0
-    assert any(
-        a.achievement.code == AchievementCodes.TOP_3 for a in test_user.achievements
-    )
+    assert any(a.badge_code == AchievementCodes.TOP_3 for a in test_user.achievements)


### PR DESCRIPTION
## Summary
- update weekly ranking to drop Achievement join
- remove badge table usage in models
- streamline unlock_achievement
- adjust achievement tests for new badge_code
- document change in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6855a171aa28832582399683dd6a8694