### PR TITLE
Fix perfil include and feed loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,3 +150,4 @@
 - Implemented ranking with tabs and achievements section (PR ranking-achievements).
 - Integrado Resend como proveedor de emails y verificación en registro (PR resend-email-provider).
 - Fixed feed weekly ranking query removing nonexistent achievement join (PR achievement-table-fix).
+- Fixed profile achievements include syntax and feed loop for recent achievements (PR profile-feed-jinja-fix).

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -32,7 +32,10 @@
   {% for a in current_user.achievements %}
     {% set info = ACHIEVEMENT_DETAILS.get(a.achievement.code, {}) %}
     <div class="col">
-      {% include 'components/achievement_card.html' with icon=info.icon title=info.title timestamp=a.timestamp %}
+      {% set icon = info.icon %}
+      {% set title = info.title %}
+      {% set timestamp = a.timestamp %}
+      {% include 'components/achievement_card.html' %}
     </div>
   {% else %}
     <div class="col">Aún no tienes logros desbloqueados.</div>

--- a/crunevo/templates/feed/feed.html
+++ b/crunevo/templates/feed/feed.html
@@ -178,9 +178,9 @@
     <div class="card">
       <div class="card-header bg-info text-white">🧩 Logros recientes</div>
       <ul class="list-group list-group-flush">
-        {% for user, logros in recent_achievements %}
+        {% for username, badge_code, timestamp in recent_achievements %}
         <li class="list-group-item">
-          <strong>{{ user }}</strong>: {{ logros }}
+          <strong>{{ username }}</strong>: {{ badge_code }} <span class="text-muted">{{ timestamp.strftime('%Y-%m-%d') }}</span>
         </li>
         {% endfor %}
       </ul>


### PR DESCRIPTION
## Summary
- fix Jinja include usage in perfil template
- adjust recent achievements loop in feed template
- document changes in AGENTS

## Testing
- `make fmt`
- `make test`
- `fly deploy -a crunevo2` *(fails: No access token available)*

------
https://chatgpt.com/codex/tasks/task_e_6855a73eb54883259c65c8a61e04c363