### PR TITLE
Add avatar upload during register and profile update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,3 +154,4 @@
 - Updated profile templates to use a.badge_code and redesigned personal profile with activity dashboard (PR profile-redesign).
 - Fixed slice syntax in perfil.html loops by assigning sorted lists before slicing to avoid TemplateSyntaxError (PR profile-slice-fix).
 - Registro permite subir avatar opcional y username único; perfil muestra @username y acepta nueva foto (PR profile-avatar-upload).
+- Avatar por defecto se asigna automáticamente si no se sube imagen en el registro (PR default-avatar).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,3 +153,4 @@
 - Fixed profile achievements include syntax and feed loop for recent achievements (PR profile-feed-jinja-fix).
 - Updated profile templates to use a.badge_code and redesigned personal profile with activity dashboard (PR profile-redesign).
 - Fixed slice syntax in perfil.html loops by assigning sorted lists before slicing to avoid TemplateSyntaxError (PR profile-slice-fix).
+- Registro permite subir avatar opcional y username único; perfil muestra @username y acepta nueva foto (PR profile-avatar-upload).

--- a/crunevo/models/user.py
+++ b/crunevo/models/user.py
@@ -2,6 +2,11 @@ from flask_login import UserMixin
 from crunevo.security.passwords import generate_hash, verify_hash
 from crunevo.extensions import db, login_manager
 
+# Default avatar used when no image is uploaded
+DEFAULT_AVATAR_URL = (
+    "https://res.cloudinary.com/dnp9trhfx/image/upload/v1750458582/avatar_h8okpo.png"
+)
+
 
 class User(UserMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -14,7 +19,7 @@ class User(UserMixin, db.Model):
     chat_enabled = db.Column(db.Boolean, default=True)
     activated = db.Column(db.Boolean, default=False)
     verification_level = db.Column(db.SmallInteger, default=0)
-    avatar_url = db.Column(db.String(255))
+    avatar_url = db.Column(db.String(255), default=DEFAULT_AVATAR_URL)
     about = db.Column(db.Text)
     credit_history = db.relationship("Credit", back_populates="user", lazy=True)
     notes = db.relationship("Note", backref="author", lazy=True)

--- a/crunevo/routes/auth_routes.py
+++ b/crunevo/routes/auth_routes.py
@@ -19,6 +19,7 @@ import cloudinary.uploader
 from werkzeug.utils import secure_filename
 from crunevo.extensions import db
 from crunevo.models import User
+from crunevo.models.user import DEFAULT_AVATAR_URL
 from crunevo.utils import spend_credit, record_login
 from crunevo.constants import CreditReasons
 from sqlalchemy.exc import IntegrityError
@@ -39,7 +40,7 @@ def register():
         if len(password) < 12 or zxcvbn(password)["score"] < 2:
             flash("Contraseña débil", "danger")
             return render_template("auth/register.html"), 400
-        avatar_url = None
+        avatar_url = DEFAULT_AVATAR_URL
         f = request.files.get("avatar_file")
         if f and f.filename:
             cloud_url = current_app.config.get("CLOUDINARY_URL")

--- a/crunevo/routes/auth_routes.py
+++ b/crunevo/routes/auth_routes.py
@@ -14,6 +14,9 @@ from zxcvbn import zxcvbn
 from crunevo.utils.audit import record_auth_event
 from urllib.parse import urlparse  # ✅ Corrección aquí
 import json
+import os
+import cloudinary.uploader
+from werkzeug.utils import secure_filename
 from crunevo.extensions import db
 from crunevo.models import User
 from crunevo.utils import spend_credit, record_login
@@ -30,10 +33,27 @@ def register():
         username = request.form["username"]
         email = request.form["email"]
         password = request.form["password"]
+        if User.query.filter_by(username=username).first():
+            flash("Nombre de usuario ya registrado", "danger")
+            return render_template("auth/register.html"), 400
         if len(password) < 12 or zxcvbn(password)["score"] < 2:
             flash("Contraseña débil", "danger")
             return render_template("auth/register.html"), 400
-        user = User(username=username, email=email)
+        avatar_url = None
+        f = request.files.get("avatar_file")
+        if f and f.filename:
+            cloud_url = current_app.config.get("CLOUDINARY_URL")
+            if cloud_url:
+                result = cloudinary.uploader.upload(f, resource_type="auto")
+                avatar_url = result["secure_url"]
+            else:
+                filename = secure_filename(f.filename)
+                upload_folder = current_app.config["UPLOAD_FOLDER"]
+                os.makedirs(upload_folder, exist_ok=True)
+                filepath = os.path.join(upload_folder, filename)
+                f.save(filepath)
+                avatar_url = filepath
+        user = User(username=username, email=email, avatar_url=avatar_url)
         user.set_password(password)
         db.session.add(user)
         try:
@@ -89,9 +109,19 @@ def logout():
 def perfil():
     if request.method == "POST":
         current_user.about = request.form.get("about")
-        avatar_url = request.form.get("avatar_url")
-        if avatar_url:
-            current_user.avatar_url = avatar_url
+        file = request.files.get("avatar_file")
+        if file and file.filename:
+            cloud_url = current_app.config.get("CLOUDINARY_URL")
+            if cloud_url:
+                res = cloudinary.uploader.upload(file, resource_type="auto")
+                current_user.avatar_url = res["secure_url"]
+            else:
+                filename = secure_filename(file.filename)
+                upload_folder = current_app.config["UPLOAD_FOLDER"]
+                os.makedirs(upload_folder, exist_ok=True)
+                filepath = os.path.join(upload_folder, filename)
+                file.save(filepath)
+                current_user.avatar_url = filepath
         db.session.commit()
         flash("Perfil actualizado")
     return render_template("auth/perfil.html")

--- a/crunevo/static/css/perfil.css
+++ b/crunevo/static/css/perfil.css
@@ -1,0 +1,3 @@
+.card img {
+  object-fit: cover;
+}

--- a/crunevo/static/css/register.css
+++ b/crunevo/static/css/register.css
@@ -1,0 +1,3 @@
+.card {
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -1,17 +1,21 @@
 {% extends 'base.html' %}
 {% import 'components/csrf.html' as csrf %}
 
+{% block head_extra %}
+  {{ super() }}
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/perfil.css') }}">
+{% endblock %}
 {% block content %}
 <div class="row g-4">
   <div class="col-lg-4">
     <div class="card text-center">
       <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle mx-auto mt-3" width="120" height="120" alt="avatar">
-      <h3 class="mt-2">{{ current_user.username }}</h3>
+      <h3 class="mt-2">@{{ current_user.username }}</h3>
       <p class="text-muted">{{ current_user.role|title }}</p>
-      <form method="post" class="mt-3 tw-space-y-2">
+      <form method="post" enctype="multipart/form-data" class="mt-3 tw-space-y-2">
         {{ csrf.csrf_field() }}
         <textarea name="about" class="form-control" placeholder="Sobre mí">{{ current_user.about }}</textarea>
-        <input name="avatar_url" type="text" class="form-control" placeholder="URL del avatar" value="{{ current_user.avatar_url }}">
+        <input type="file" name="avatar_file" accept="image/*" class="form-control">
         <button class="btn btn-primary" type="submit">Guardar</button>
       </form>
       <div class="mt-3">

--- a/crunevo/templates/auth/register.html
+++ b/crunevo/templates/auth/register.html
@@ -2,15 +2,20 @@
 {% import 'components/input.html' as forms %}
 {% import 'components/button.html' as btn %}
 {% import 'components/csrf.html' as csrf %}
+{% block head_extra %}
+  {{ super() }}
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/register.css') }}">
+{% endblock %}
 {% block content %}
-<div class="tw-max-w-md tw-mx-auto tw-my-16 tw-rounded-2xl tw-shadow-sm tw-bg-white dark:tw-bg-gray-900 tw-p-4 tw-space-y-4">
-  <h2>Registro</h2>
-  <form method="post" class="tw-space-y-4">
+<div class="tw-max-w-md tw-mx-auto tw-my-16 card tw-p-4 tw-space-y-4">
+  <h2 class="text-center">Registro</h2>
+  <form method="post" enctype="multipart/form-data" class="tw-space-y-4">
     {{ csrf.csrf_field() }}
-    {{ forms.input('username', placeholder='Usuario') }}
+    {{ forms.input('username', placeholder='Nombre de usuario') }}
     {{ forms.input('email', type='email', placeholder='Email') }}
     {{ forms.input('password', type='password', placeholder='Contraseña') }}
-    {{ btn.button('Registrar', type='submit') }}
+    <input type="file" name="avatar_file" accept="image/*" class="form-control" />
+    {{ btn.button('Registrar', type='submit', class='w-100') }}
   </form>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow uploading optional avatar during registration
- ensure username is unique on register
- show @username and upload avatar from profile
- minor CSS styling for register & profile pages
- document feature in AGENTS guidelines

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6855ddce45788325a2e8792ae726e51f