### PR TITLE
Fix email signup flow and UI polish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,3 +155,4 @@
 - Fixed slice syntax in perfil.html loops by assigning sorted lists before slicing to avoid TemplateSyntaxError (PR profile-slice-fix).
 - Registro permite subir avatar opcional y username único; perfil muestra @username y acepta nueva foto (PR profile-avatar-upload).
 - Avatar por defecto se asigna automáticamente si no se sube imagen en el registro (PR default-avatar).
+- Registro renovado con tarjeta responsiva, vista previa de avatar y aviso si falla Resend (PR registro-ui-email-fix).

--- a/crunevo/routes/auth_routes.py
+++ b/crunevo/routes/auth_routes.py
@@ -64,7 +64,11 @@ def register():
             current_app.logger.warning("IntegrityError: %s", e)
             flash("Usuario o correo ya registrado", "danger")
             return render_template("auth/register.html"), 400
-        send_confirmation_email(user)
+        if not send_confirmation_email(user):
+            flash(
+                "No se pudo enviar el correo de confirmación. Inténtalo más tarde.",
+                "danger",
+            )
         return render_template("onboarding/confirm.html")
     return render_template("auth/register.html")
 

--- a/crunevo/routes/onboarding_routes.py
+++ b/crunevo/routes/onboarding_routes.py
@@ -31,7 +31,7 @@ def send_confirmation_email(user):
     db.session.add(EmailToken(token=token, email=user.email, user_id=user.id))
     db.session.commit()
     html = render_template("emails/confirm.html", token=token)
-    send_email(user.email, "Confirma tu cuenta", html)
+    return send_email(user.email, "Confirma tu cuenta", html)
 
 
 def _user_key():
@@ -57,7 +57,11 @@ def register():
             current_app.logger.warning("IntegrityError: %s", e)
             flash("Usuario o correo ya registrado", "danger")
             return render_template("onboarding/register.html"), 400
-        send_confirmation_email(user)
+        if not send_confirmation_email(user):
+            flash(
+                "No se pudo enviar el correo de confirmación. Inténtalo más tarde.",
+                "danger",
+            )
         return render_template("onboarding/confirm.html")
     return render_template("onboarding/register.html")
 
@@ -107,7 +111,11 @@ def pending():
 def resend():
     if current_user.activated:
         return redirect(url_for("feed.index"))
-    send_confirmation_email(current_user)
+    if not send_confirmation_email(current_user):
+        flash(
+            "No se pudo enviar el correo de confirmación. Inténtalo más tarde.",
+            "danger",
+        )
     record_auth_event(current_user, "resend_email")
     flash("Correo reenviado")
     return redirect(url_for("onboarding.pending"))

--- a/crunevo/static/css/register.css
+++ b/crunevo/static/css/register.css
@@ -1,3 +1,8 @@
 .card {
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
+#avatarPreview {
+  width: 96px;
+  height: 96px;
+  object-fit: cover;
+}

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -111,6 +111,20 @@ document.addEventListener('DOMContentLoaded', () => {
     initDropdowns();
   }
 
+  const avatarInput = document.getElementById('avatarFileInput');
+  const avatarPreview = document.getElementById('avatarPreview');
+  if (avatarInput && avatarPreview) {
+    avatarInput.addEventListener('change', () => {
+      const file = avatarInput.files[0];
+      if (file) {
+        avatarPreview.src = URL.createObjectURL(file);
+        avatarPreview.classList.remove('tw-hidden');
+      } else {
+        avatarPreview.classList.add('tw-hidden');
+      }
+    });
+  }
+
   // Bootstrap collapse handles the mobile menu
 
 });

--- a/crunevo/templates/auth/register.html
+++ b/crunevo/templates/auth/register.html
@@ -1,21 +1,40 @@
 {% extends 'base.html' %}
-{% import 'components/input.html' as forms %}
-{% import 'components/button.html' as btn %}
 {% import 'components/csrf.html' as csrf %}
 {% block head_extra %}
   {{ super() }}
   <link rel="stylesheet" href="{{ url_for('static', filename='css/register.css') }}">
 {% endblock %}
 {% block content %}
-<div class="tw-max-w-md tw-mx-auto tw-my-16 card tw-p-4 tw-space-y-4">
-  <h2 class="text-center">Registro</h2>
-  <form method="post" enctype="multipart/form-data" class="tw-space-y-4">
-    {{ csrf.csrf_field() }}
-    {{ forms.input('username', placeholder='Nombre de usuario') }}
-    {{ forms.input('email', type='email', placeholder='Email') }}
-    {{ forms.input('password', type='password', placeholder='Contraseña') }}
-    <input type="file" name="avatar_file" accept="image/*" class="form-control" />
-    {{ btn.button('Registrar', type='submit', class='w-100') }}
-  </form>
+<div class="container py-5">
+  <div class="row justify-content-center">
+    <div class="col-md-8 col-lg-6 col-xl-5">
+      <div class="card shadow">
+        <div class="card-body p-4 p-md-5">
+          <h2 class="text-center mb-4">Crear cuenta</h2>
+          <form method="post" enctype="multipart/form-data">
+            {{ csrf.csrf_field() }}
+            <div class="input-group mb-3">
+              <span class="input-group-text"><i class="bi bi-person-fill"></i></span>
+              <input type="text" class="form-control" id="username" name="username" placeholder="Nombre de usuario" required>
+            </div>
+            <div class="input-group mb-3">
+              <span class="input-group-text"><i class="bi bi-envelope-fill"></i></span>
+              <input type="email" class="form-control" id="email" name="email" placeholder="Correo electrónico" required>
+            </div>
+            <div class="input-group mb-3">
+              <span class="input-group-text"><i class="bi bi-lock-fill"></i></span>
+              <input type="password" class="form-control" id="password" name="password" placeholder="Contraseña" required>
+            </div>
+            <div class="mb-3 text-center">
+              <img id="avatarPreview" class="rounded-circle tw-hidden mb-2" width="96" height="96" alt="avatar">
+              <input class="form-control" type="file" id="avatarFileInput" name="avatar_file" accept="image/*">
+            </div>
+            <button class="btn btn-primary w-100" type="submit">Registrarme</button>
+          </form>
+          <p class="text-muted small mt-3 text-center">Recibirás un correo para activar tu cuenta.</p>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 {% endblock %}

--- a/crunevo/templates/onboarding/confirm.html
+++ b/crunevo/templates/onboarding/confirm.html
@@ -1,4 +1,14 @@
 {% extends 'base.html' %}
 {% block content %}
-<p>Revisa tu correo para confirmar tu cuenta.</p>
+<div class="container py-5">
+  <div class="row justify-content-center">
+    <div class="col-md-6">
+      <div class="card shadow text-center p-4">
+        <i class="bi bi-envelope-fill display-4 text-primary"></i>
+        <h4 class="mt-3">Revisa tu correo</h4>
+        <p class="mb-0">Te enviamos un enlace para verificar tu cuenta. Si no lo ves, revisa la carpeta de spam.</p>
+      </div>
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/crunevo/templates/onboarding/register.html
+++ b/crunevo/templates/onboarding/register.html
@@ -1,19 +1,31 @@
 {% extends 'base.html' %}
-{% import 'components/input.html' as forms %}
-{% import 'components/button.html' as btn %}
 {% import 'components/csrf.html' as csrf %}
 {% block content %}
-<div class="tw-max-w-md tw-mx-auto tw-my-16 card">
-  <h2>Registro</h2>
-  <form method="post" class="tw-space-y-4">
-    {{ csrf.csrf_field() }}
-    {{ forms.input('email', type='email', placeholder='Email') }}
-    {{ forms.input('password', type='password', placeholder='Contraseña') }}
-    {{ btn.button('Crear cuenta', type='submit') }}
-  </form>
-  <p class="mt-4 tw-text-center tw-text-sm">
-    ¿Ya tienes cuenta?
-    <a href="{{ url_for('auth.login') }}" class="tw-text-[var(--primary)] tw-underline">Inicia sesión</a>
-  </p>
+<div class="container py-5">
+  <div class="row justify-content-center">
+    <div class="col-md-6 col-lg-5">
+      <div class="card shadow">
+        <div class="card-body p-4 p-md-5">
+          <h2 class="text-center mb-4">Registro</h2>
+          <form method="post">
+            {{ csrf.csrf_field() }}
+            <div class="input-group mb-3">
+              <span class="input-group-text"><i class="bi bi-envelope-fill"></i></span>
+              <input type="email" class="form-control" name="email" placeholder="Correo electrónico" required>
+            </div>
+            <div class="input-group mb-4">
+              <span class="input-group-text"><i class="bi bi-lock-fill"></i></span>
+              <input type="password" class="form-control" name="password" placeholder="Contraseña" required>
+            </div>
+            <button type="submit" class="btn btn-primary w-100">Crear cuenta</button>
+          </form>
+          <p class="mt-4 text-center small">
+            ¿Ya tienes cuenta?
+            <a href="{{ url_for('auth.login') }}" class="tw-text-[var(--primary)] tw-underline">Inicia sesión</a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 {% endblock %}

--- a/crunevo/utils/mailer.py
+++ b/crunevo/utils/mailer.py
@@ -22,6 +22,14 @@ def send_email(to, subject, html):
                 timeout=5,
             )
             current_app.logger.info("Resend response: %s", resp.text)
+            if resp.status_code != 200:
+                flash(
+                    "No se pudo enviar el correo de confirmación. Inténtalo más tarde.",
+                    "danger",
+                )
+                current_app.logger.warning(
+                    "Resend failed with status %s", resp.status_code
+                )
             return resp.status_code == 200
         except Exception as e:
             current_app.logger.error("Email error: %s", e)


### PR DESCRIPTION
## Summary
- show flash when Resend fails to send email
- update registration forms with Bootstrap card style and avatar preview
- improve confirm page with explanatory message
- display selected avatar before upload
- log Resend failures

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6855e44239e08325b7ca5eea8b8639d5