### PR TITLE
Implement admin email sender

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,3 +156,4 @@
 - Registro permite subir avatar opcional y username único; perfil muestra @username y acepta nueva foto (PR profile-avatar-upload).
 - Avatar por defecto se asigna automáticamente si no se sube imagen en el registro (PR default-avatar).
 - Registro renovado con tarjeta responsiva, vista previa de avatar y aviso si falla Resend (PR registro-ui-email-fix).
+- Implemented secure admin route to send custom emails with preview and sidebar link (PR admin-email-sender).

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -58,6 +58,7 @@ def create_app():
     from .routes.chat_routes import chat_bp
     from .routes.admin_routes import admin_bp
     from .routes.admin_blocker import admin_blocker_bp
+    from .routes.admin.email_routes import admin_email_bp
     from .routes.ranking_routes import ranking_bp
     from .routes.errors import errors_bp
     from .routes.health_routes import health_bp
@@ -72,6 +73,7 @@ def create_app():
     if is_admin:
         app.register_blueprint(auth_bp)
         app.register_blueprint(admin_bp)
+        app.register_blueprint(admin_email_bp)
         app.register_blueprint(errors_bp)
     else:
         app.register_blueprint(onboarding_bp)
@@ -85,6 +87,7 @@ def create_app():
         app.register_blueprint(admin_blocker_bp)
         if testing_env:
             app.register_blueprint(admin_bp)
+            app.register_blueprint(admin_email_bp)
 
     @app.errorhandler(CSRFError)
     def handle_csrf_error(e):

--- a/crunevo/routes/admin/email_routes.py
+++ b/crunevo/routes/admin/email_routes.py
@@ -1,0 +1,34 @@
+from flask import Blueprint, render_template, request, flash, redirect, url_for
+from flask_login import login_required, current_user
+from markupsafe import escape
+
+from crunevo.utils.mailer import send_email
+from crunevo.utils.helpers import admin_required
+from crunevo.utils.audit import record_auth_event
+
+admin_email_bp = Blueprint("admin_email", __name__, url_prefix="/admin")
+
+
+@admin_email_bp.route("/send-email", methods=["GET", "POST"])
+@login_required
+@admin_required
+def send_admin_email():
+    if request.method == "POST":
+        recipient = escape(request.form.get("to", "").strip())
+        subject = escape(request.form.get("subject", "").strip())
+        html_content = request.form.get("content", "")
+
+        if not recipient or not subject or not html_content:
+            flash("Todos los campos son obligatorios", "danger")
+            return render_template("admin/send_email.html")
+
+        success = send_email(recipient, subject, html_content)
+        if success:
+            flash("Correo enviado correctamente", "success")
+            record_auth_event(current_user, "admin_send_email")
+        else:
+            flash("No se pudo enviar el correo", "danger")
+
+        return redirect(url_for("admin_email.send_admin_email"))
+
+    return render_template("admin/send_email.html")

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -111,6 +111,10 @@ document.addEventListener('DOMContentLoaded', () => {
     initDropdowns();
   }
 
+  if (typeof initEmailPreview === 'function') {
+    initEmailPreview();
+  }
+
   const avatarInput = document.getElementById('avatarFileInput');
   const avatarPreview = document.getElementById('avatarPreview');
   if (avatarInput && avatarPreview) {

--- a/crunevo/templates/admin/partials/sidebar.html
+++ b/crunevo/templates/admin/partials/sidebar.html
@@ -18,6 +18,9 @@
   <a class="nav-link {% if request.endpoint == 'admin.manage_credits' %}active{% endif %}" href="{{ url_for('admin.manage_credits') }}">
     <i class="ti ti-coin me-2"></i> Créditos
   </a>
+  <a class="nav-link {% if request.endpoint == 'admin_email.send_admin_email' %}active{% endif %}" href="{{ url_for('admin_email.send_admin_email') }}">
+    <i class="ti ti-mail me-2"></i> Enviar correo
+  </a>
 
   <span class="text-muted fw-bold small mt-4 mb-2">🏅 Comunidad</span>
   <a class="nav-link disabled"><i class="ti ti-check me-2"></i> Verificaciones</a>

--- a/crunevo/templates/admin/send_email.html
+++ b/crunevo/templates/admin/send_email.html
@@ -1,0 +1,36 @@
+{% extends 'admin/base_admin.html' %}
+{% import 'components/csrf.html' as csrf %}
+{% block admin_content %}
+<h2 class="page-title mb-4">Enviar correo</h2>
+<form method="post" class="card shadow-sm p-3 tw-space-y-3">
+  {{ csrf.csrf_field() }}
+  <div class="mb-3">
+    <label class="form-label">Email destino</label>
+    <input type="email" name="to" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Asunto</label>
+    <input type="text" name="subject" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Contenido HTML</label>
+    <textarea name="content" id="emailContent" class="form-control" rows="6" required></textarea>
+  </div>
+  <button class="btn btn-primary" type="submit">Enviar ahora</button>
+</form>
+<h5 class="tw-mt-4">Vista previa</h5>
+<iframe id="previewFrame" class="w-100 border tw-rounded" style="height:300px;"></iframe>
+{% endblock %}
+{% block body_end %}
+  {{ super() }}
+  <script>
+  function initEmailPreview() {
+    const textarea = document.getElementById('emailContent');
+    const frame = document.getElementById('previewFrame');
+    if (!textarea || !frame) return;
+    const update = () => { frame.srcdoc = textarea.value; };
+    textarea.addEventListener('input', update);
+    update();
+  }
+  </script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add secure admin email route and blueprint
- show email preview and call initEmailPreview() from main JS
- add sidebar link for quick access
- register blueprint in app factory
- document new feature in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6855e8b23330832591ad229a627137ff