### PR TITLE
Unify login/register styles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,3 +163,4 @@
 - Login page updated with transparent card and centered mobile layout (PR login-transparent-blur).
 - Register page redesigned with transparent card and additional fields (PR register-redesign).
 - Unified registration under /onboarding/register and removed /register route (PR register-unification).
+- Login y registro comparten fondo degradado, tarjetas traslúcidas centradas y soporte de modo oscuro (PR login-register-theme).

--- a/crunevo/static/css/login.css
+++ b/crunevo/static/css/login.css
@@ -1,7 +1,7 @@
 body {
   margin: 0;
   font-family: "Segoe UI", sans-serif;
-  background: linear-gradient(to bottom right, #ede7f6, #ffffff);
+  background: linear-gradient(to bottom right, #f4ebff, #ffffff);
   min-height: 100vh;
   display: flex;
   align-items: center;
@@ -21,11 +21,11 @@ body {
 
 .login-card {
   background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.15);
   border-radius: 20px;
   padding: 40px;
-  backdrop-filter: blur(8px);
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+  backdrop-filter: blur(10px);
+  box-shadow: 0 0 0.5rem rgba(0,0,0,0.2);
   width: 100%;
   max-width: 400px;
 }
@@ -91,6 +91,18 @@ body {
   color: #555;
 }
 
+[data-bs-theme="dark"] .login-card, [data-bs-theme="dark"] .register-card {
+  background: rgba(0, 0, 0, 0.3);
+  border-color: rgba(255, 255, 255, 0.2);
+  color: #fff;
+  box-shadow: 0 0 0.5rem rgba(255,255,255,0.1);
+}
+[data-bs-theme="dark"] .login-card input, [data-bs-theme="dark"] .register-card input, [data-bs-theme="dark"] .login-card select, [data-bs-theme="dark"] .register-card select, [data-bs-theme="dark"] .login-card .form-control, [data-bs-theme="dark"] .register-card .form-control {
+  background: #111 !important;
+  color: #fff !important;
+  border-color: #333 !important;
+}
+
 @media (max-width: 768px) {
   body {
     padding: 40px 10px;
@@ -102,10 +114,8 @@ body {
   }
 
   .login-card {
-    background: transparent;
-    border: none;
-    padding: 0;
-    box-shadow: none;
+    max-width: 90vw;
+    padding: 1.5rem;
   }
 
   .brand-block {
@@ -122,9 +132,4 @@ body {
 
   .btn-crunevo {
     width: 100%;
-  }
-
-  .form-control {
-    background-color: #fff;
-  }
-}
+  }}

--- a/crunevo/static/css/register.css
+++ b/crunevo/static/css/register.css
@@ -1,22 +1,28 @@
 body {
   margin: 0;
   font-family: "Segoe UI", sans-serif;
-  background: linear-gradient(to bottom right, #f9f9f9, #ffffff);
+  background: linear-gradient(to bottom right, #f4ebff, #ffffff);
   min-height: 100vh;
   display: flex;
   align-items: center;
   justify-content: center;
 }
+.register-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+}
 
 .register-card {
   background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(0, 0, 0, 0.1);
-  backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  backdrop-filter: blur(10px);
   border-radius: 20px;
   padding: 40px;
   max-width: 500px;
   width: 100%;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 0 0.5rem rgba(0,0,0,0.2);
 }
 
 .register-title {
@@ -66,4 +72,23 @@ body {
 
 .legal-text a:hover {
   text-decoration: underline;
+}
+
+[data-bs-theme="dark"] .register-card, [data-bs-theme="dark"] .login-card {
+  background: rgba(0, 0, 0, 0.3);
+  border-color: rgba(255, 255, 255, 0.2);
+  color: #fff;
+  box-shadow: 0 0 0.5rem rgba(255,255,255,0.1);
+}
+[data-bs-theme="dark"] .register-card input, [data-bs-theme="dark"] .login-card input, [data-bs-theme="dark"] .register-card select, [data-bs-theme="dark"] .login-card select, [data-bs-theme="dark"] .register-card .form-control, [data-bs-theme="dark"] .login-card .form-control {
+  background: #111 !important;
+  color: #fff !important;
+  border-color: #333 !important;
+}
+
+@media (max-width: 768px) {
+  .register-card {
+    max-width: 90vw;
+    padding: 1.5rem;
+  }
 }

--- a/crunevo/templates/auth/login.html
+++ b/crunevo/templates/auth/login.html
@@ -5,7 +5,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/login.css') }}">
 {% endblock %}
 {% block content %}
-<div class="login-wrapper">
+<div class="login-wrapper container-fluid d-flex justify-content-center align-items-center min-vh-100">
   <div class="login-card">
     <h2 class="login-title">Iniciar sesión</h2>
     <form method="post">

--- a/crunevo/templates/onboarding/register.html
+++ b/crunevo/templates/onboarding/register.html
@@ -5,7 +5,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/register.css') }}">
 {% endblock %}
 {% block content %}
-<div class="register-wrapper">
+<div class="register-wrapper container-fluid d-flex justify-content-center align-items-center min-vh-100">
   <div class="register-card">
     <h2 class="register-title">Crea una cuenta</h2>
     <p class="register-subtitle">Es rápido y fácil.</p>


### PR DESCRIPTION
## Summary
- share purple gradient background for login and register
- keep blurred translucent cards on both pages
- center the cards with Bootstrap flex utilities
- support dark theme for login and register cards
- document change in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685662db74f48325b9095401f687ca39