### PR TITLE
Improve login/register UX

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,3 +166,4 @@
 - Login y registro comparten fondo degradado, tarjetas traslúcidas centradas y soporte de modo oscuro (PR login-register-theme).
 - Se corrigió el fondo oscuro en login y registro y se actualizó el logo en login (PR login-register-dark-logo).
 - Nuevo correo de confirmación con plantilla HTML y confirm_url externo; asunto actualizado (PR confirm-email-html).
+- Mejorado login y registro con tarjeta translúcida, ocultar navbar, alternar contraseña y soporte móvil (PR login-register-ux).

--- a/crunevo/static/css/login.css
+++ b/crunevo/static/css/login.css
@@ -6,9 +6,16 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
+  padding-top: 0 !important;
+  transition: background-color 0.4s ease, color 0.4s ease;
 }
+
+.navbar-crunevo {
+  display: none;
+}
+
 [data-bs-theme="dark"] body {
-  background: #121212;
+  background-color: #0a0a0a !important;
 }
 
 
@@ -26,12 +33,13 @@ body {
 .login-card {
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.15);
-  border-radius: 20px;
-  padding: 40px;
-  backdrop-filter: blur(10px);
-  box-shadow: 0 0 0.5rem rgba(0,0,0,0.2);
+  backdrop-filter: blur(12px);
+  border-radius: 16px;
+  padding: 32px;
   width: 100%;
-  max-width: 400px;
+  max-width: 500px;
+  box-shadow: 0 0 12px rgba(0, 0, 0, 0.2);
+  transition: all 0.4s ease;
 }
 
 .login-title {
@@ -95,16 +103,22 @@ body {
   color: #555;
 }
 
-[data-bs-theme="dark"] .login-card, [data-bs-theme="dark"] .register-card {
-  background: rgba(0, 0, 0, 0.3);
-  border-color: rgba(255, 255, 255, 0.2);
-  color: #fff;
-  box-shadow: 0 0 0.5rem rgba(255,255,255,0.1);
+[data-bs-theme="dark"] .login-card,
+[data-bs-theme="dark"] .register-card {
+  background: rgba(30, 30, 30, 0.6);
+  border: 1px solid #333;
+  color: #f2f2f2;
 }
-[data-bs-theme="dark"] .login-card input, [data-bs-theme="dark"] .register-card input, [data-bs-theme="dark"] .login-card select, [data-bs-theme="dark"] .register-card select, [data-bs-theme="dark"] .login-card .form-control, [data-bs-theme="dark"] .register-card .form-control {
-  background: #111 !important;
-  color: #fff !important;
-  border-color: #333 !important;
+
+[data-bs-theme="dark"] .form-control,
+[data-bs-theme="dark"] select {
+  background-color: #111;
+  color: #fff;
+  border: 1px solid #444;
+}
+
+[data-bs-theme="dark"] ::placeholder {
+  color: #aaa;
 }
 
 @media (max-width: 768px) {
@@ -120,6 +134,9 @@ body {
   .login-card {
     max-width: 90vw;
     padding: 1.5rem;
+  }
+  .right-panel, .promo-text {
+    display: none !important;
   }
 
   .brand-block {
@@ -137,4 +154,57 @@ body {
   .btn-crunevo {
     width: 100%;
   }
+}
+
+.password-group {
+  position: relative;
+}
+
+.toggle-password {
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: transparent;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+
+.fade-in {
+  opacity: 0;
+  animation: fadeIn 1s ease forwards;
+}
+
+@keyframes fadeIn {
+  to {
+    opacity: 1;
+  }
+}
+
+a, .text-muted {
+  color: #666;
+  transition: color 0.4s ease;
+}
+
+[data-bs-theme="dark"] a,
+[data-bs-theme="dark"] .text-muted {
+  color: #bbb;
+}
+
+.access-links {
+  margin-top: 20px;
+  display: flex;
+  gap: 1.5rem;
+  justify-content: center;
+}
+
+.access-links a {
+  text-decoration: none;
+  color: #6c63ff;
+  font-weight: 600;
+}
+
+[data-bs-theme="dark"] .access-links a {
+  color: #b79aff;
 }

--- a/crunevo/static/css/register.css
+++ b/crunevo/static/css/register.css
@@ -6,9 +6,16 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
+  padding-top: 0 !important;
+  transition: background-color 0.4s ease, color 0.4s ease;
 }
-body[data-bs-theme="dark"] {
-  background: #121212;
+
+.navbar-crunevo {
+  display: none;
+}
+
+[data-bs-theme="dark"] body {
+  background-color: #0a0a0a !important;
 }
 
 .register-wrapper {
@@ -21,12 +28,13 @@ body[data-bs-theme="dark"] {
 .register-card {
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.15);
-  backdrop-filter: blur(10px);
-  border-radius: 20px;
-  padding: 40px;
-  max-width: 500px;
+  backdrop-filter: blur(12px);
+  border-radius: 16px;
+  padding: 32px;
   width: 100%;
-  box-shadow: 0 0 0.5rem rgba(0,0,0,0.2);
+  max-width: 500px;
+  box-shadow: 0 0 12px rgba(0, 0, 0, 0.2);
+  transition: all 0.4s ease;
 }
 
 .register-title {
@@ -78,16 +86,20 @@ body[data-bs-theme="dark"] {
   text-decoration: underline;
 }
 
-[data-bs-theme="dark"] .register-card, [data-bs-theme="dark"] .login-card {
-  background: rgba(0, 0, 0, 0.3);
-  border-color: rgba(255, 255, 255, 0.2);
-  color: #fff;
-  box-shadow: 0 0 0.5rem rgba(255,255,255,0.1);
+[data-bs-theme="dark"] .register-card,
+[data-bs-theme="dark"] .login-card {
+  background: rgba(30, 30, 30, 0.6);
+  border: 1px solid #333;
+  color: #f2f2f2;
 }
-[data-bs-theme="dark"] .register-card input, [data-bs-theme="dark"] .login-card input, [data-bs-theme="dark"] .register-card select, [data-bs-theme="dark"] .login-card select, [data-bs-theme="dark"] .register-card .form-control, [data-bs-theme="dark"] .login-card .form-control {
-  background: #111 !important;
-  color: #fff !important;
-  border-color: #333 !important;
+[data-bs-theme="dark"] .form-control,
+[data-bs-theme="dark"] select {
+  background-color: #111;
+  color: #fff;
+  border: 1px solid #444;
+}
+[data-bs-theme="dark"] ::placeholder {
+  color: #aaa;
 }
 
 @media (max-width: 768px) {
@@ -95,4 +107,61 @@ body[data-bs-theme="dark"] {
     max-width: 90vw;
     padding: 1.5rem;
   }
+  .right-panel, .promo-text {
+    display: none !important;
+  }
 }
+
+.password-group {
+  position: relative;
+}
+
+.toggle-password {
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: transparent;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+
+.fade-in {
+  opacity: 0;
+  animation: fadeIn 1s ease forwards;
+}
+
+@keyframes fadeIn {
+  to {
+    opacity: 1;
+  }
+}
+
+a, .text-muted {
+  color: #666;
+  transition: color 0.4s ease;
+}
+
+[data-bs-theme="dark"] a,
+[data-bs-theme="dark"] .text-muted {
+  color: #bbb;
+}
+
+.access-links {
+  margin-top: 20px;
+  display: flex;
+  gap: 1.5rem;
+  justify-content: center;
+}
+
+.access-links a {
+  text-decoration: none;
+  color: #6c63ff;
+  font-weight: 600;
+}
+
+[data-bs-theme="dark"] .access-links a {
+  color: #b79aff;
+}
+

--- a/crunevo/templates/auth/login.html
+++ b/crunevo/templates/auth/login.html
@@ -6,7 +6,7 @@
 {% endblock %}
 {% block content %}
 <div class="login-wrapper container-fluid d-flex justify-content-center align-items-center min-vh-100">
-  <div class="login-card">
+  <div class="login-card fade-in">
     <h2 class="login-title">Iniciar sesión</h2>
     <form method="post">
       {{ csrf.csrf_field() }}
@@ -14,9 +14,10 @@
         <label for="username" class="form-label">Correo o usuario</label>
         <input type="text" class="form-control" id="username" name="username" required>
       </div>
-      <div class="mb-3">
+      <div class="mb-3 password-group">
         <label for="password" class="form-label">Contraseña</label>
         <input type="password" class="form-control" id="password" name="password" required>
+        <button type="button" class="toggle-password">👁️</button>
       </div>
       <button type="submit" class="btn btn-crunevo w-100">Iniciar sesión</button>
     </form>
@@ -28,10 +29,41 @@
       <a href="/onboarding/register" class="btn btn-outline-secondary w-100">Crear nueva cuenta</a>
     </div>
   </div>
-  <div class="brand-block mt-lg-0">
+  <div class="brand-block right-panel mt-lg-0">
     <img src="https://res.cloudinary.com/dnp9trhfx/image/upload/v1750494930/a642d206-74ab-4361-adf4-0ec41cb013d2_nxqy63.png" alt="Logo CRUNEVO" class="brand-img">
     <h1 class="brand-title">Bienvenido a CRUNEVO</h1>
-    <p class="brand-subtitle">Una red educativa para compartir, aprender y avanzar. Inspira con tus apuntes.</p>
+    <p class="welcome-phrase">Crunevo une a jóvenes que se esfuerzan cada día por construir un futuro mejor.</p>
+    <p class="brand-subtitle promo-text">Una red educativa para compartir, aprender y avanzar juntos.</p>
   </div>
 </div>
+<div class="access-links">
+  <a href="/tienda">Ver tienda</a>
+  <a href="/apuntes">Explorar apuntes</a>
+</div>
+{% endblock %}
+
+{% block body_end %}
+  {{ super() }}
+  <script>
+    document.querySelectorAll('.toggle-password').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const input = btn.previousElementSibling;
+        input.type = input.type === 'password' ? 'text' : 'password';
+        btn.innerHTML = input.type === 'password' ? '👁️' : '🙈';
+      });
+    });
+    const frases = [
+      'Crunevo une a jóvenes que se esfuerzan cada día por construir un futuro mejor.',
+      'Una red educativa para compartir, aprender y avanzar juntos.',
+      'Inspírate, aprende, y deja huella con tus apuntes.'
+    ];
+    let index = 0;
+    setInterval(() => {
+      const el = document.querySelector('.welcome-phrase');
+      if (el) {
+        el.textContent = frases[index];
+        index = (index + 1) % frases.length;
+      }
+    }, 5000);
+  </script>
 {% endblock %}

--- a/crunevo/templates/onboarding/register.html
+++ b/crunevo/templates/onboarding/register.html
@@ -6,7 +6,7 @@
 {% endblock %}
 {% block content %}
 <div class="register-wrapper container-fluid d-flex justify-content-center align-items-center min-vh-100">
-  <div class="register-card">
+  <div class="register-card fade-in">
     <h2 class="register-title">Crea una cuenta</h2>
     <p class="register-subtitle">Es rápido y fácil.</p>
     <form method="post">
@@ -25,8 +25,9 @@
       <div class="mb-3">
         <input type="email" class="form-control" name="email" placeholder="Correo electrónico" required>
       </div>
-      <div class="mb-3">
+      <div class="mb-3 password-group">
         <input type="password" class="form-control" name="password" placeholder="Contraseña nueva" required>
+        <button type="button" class="toggle-password">👁️</button>
       </div>
       <div class="row g-2 mb-3">
         <label class="form-label">Fecha de nacimiento</label>
@@ -84,4 +85,21 @@
     </form>
   </div>
 </div>
+<div class="access-links">
+  <a href="/tienda">Ver tienda</a>
+  <a href="/apuntes">Explorar apuntes</a>
+</div>
+{% endblock %}
+
+{% block body_end %}
+  {{ super() }}
+  <script>
+    document.querySelectorAll('.toggle-password').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const input = btn.previousElementSibling;
+        input.type = input.type === 'password' ? 'text' : 'password';
+        btn.innerHTML = input.type === 'password' ? '👁️' : '🙈';
+      });
+    });
+  </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- style login/register pages with adaptive backgrounds and transitions
- tweak card styles for better dark mode support
- add password toggle buttons and fading animation
- hide navbar on auth pages and provide quick access links
- document login/register UX upgrade in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6856d3e1439c832588c285e2732f2a17