### PR TITLE
Improve theme toggle on auth pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,3 +169,4 @@
 - Mejorado login y registro con tarjeta translúcida, ocultar navbar, alternar contraseña y soporte móvil (PR login-register-ux).
 - Optimized login and register pages with smoother theme transitions, rotating welcome phrases and accessible password toggles using 🙊/🙈 icons. Dark mode styling fixed (PR login-register-polish).
 - Adjusted dark theme backgrounds to true black, improved password toggle alignment and link contrast, added fading welcome phrase rotation and disabled page scrolling (PR login-register-tweak).
+- Added theme toggle button on login and register pages, refined dark mode card translucency, extended welcome phrase interval and improved link contrast (PR login-register-theme-toggle).

--- a/crunevo/static/css/login.css
+++ b/crunevo/static/css/login.css
@@ -9,7 +9,7 @@ body {
   justify-content: center;
   padding-top: 0 !important;
   overflow: hidden;
-  transition: all 0.3s ease;
+  transition: background-color 0.4s ease;
 }
 
 .navbar-crunevo {
@@ -17,7 +17,7 @@ body {
 }
 
 [data-bs-theme="dark"] body {
-  background-color: #0a0a0a !important;
+  background-color: #000 !important;
 }
 
 
@@ -134,8 +134,9 @@ body {
 
 [data-bs-theme="dark"] .login-card,
 [data-bs-theme="dark"] .register-card {
-  background-color: #000;
-  border: 1px solid #333;
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.15);
   color: #f2f2f2;
 }
 
@@ -210,6 +211,24 @@ body {
   animation: fadeIn 1s ease forwards;
 }
 
+.theme-toggle-btn {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  background: rgba(255, 255, 255, 0.3);
+  backdrop-filter: blur(4px);
+  border: none;
+  border-radius: 50%;
+  padding: 0.25rem 0.6rem;
+  font-size: 1.25rem;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+}
+[data-bs-theme="dark"] .theme-toggle-btn {
+  background: rgba(0, 0, 0, 0.4);
+  color: #fff;
+}
+
 @keyframes fadeIn {
   to {
     opacity: 1;
@@ -223,7 +242,7 @@ a, .text-muted {
 
 [data-bs-theme="dark"] a,
 [data-bs-theme="dark"] .text-muted {
-  color: #bbb;
+  color: #ddd;
 }
 
 .access-links {
@@ -240,5 +259,5 @@ a, .text-muted {
 }
 
 [data-bs-theme="dark"] .access-links a {
-  color: #b79aff;
+  color: #d5c7ff;
 }

--- a/crunevo/static/css/register.css
+++ b/crunevo/static/css/register.css
@@ -9,7 +9,7 @@ body {
   justify-content: center;
   padding-top: 0 !important;
   overflow: hidden;
-  transition: all 0.3s ease;
+  transition: background-color 0.4s ease;
 }
 
 .navbar-crunevo {
@@ -17,7 +17,7 @@ body {
 }
 
 [data-bs-theme="dark"] body {
-  background-color: #0a0a0a !important;
+  background-color: #000 !important;
 }
 
 .register-wrapper {
@@ -111,12 +111,13 @@ body {
 }
 
 [data-bs-theme="dark"] .link-sm {
-  color: #b79aff;
+  color: #d5c7ff;
 }
 
 [data-bs-theme="dark"] .register-card {
-  background-color: #000;
-  border: 1px solid #444;
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.15);
   color: #f2f2f2;
 }
 [data-bs-theme="dark"] .form-control,
@@ -164,6 +165,24 @@ body {
   animation: fadeIn 1s ease forwards;
 }
 
+.theme-toggle-btn {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  background: rgba(255, 255, 255, 0.3);
+  backdrop-filter: blur(4px);
+  border: none;
+  border-radius: 50%;
+  padding: 0.25rem 0.6rem;
+  font-size: 1.25rem;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+}
+[data-bs-theme="dark"] .theme-toggle-btn {
+  background: rgba(0, 0, 0, 0.4);
+  color: #fff;
+}
+
 @keyframes fadeIn {
   to {
     opacity: 1;
@@ -177,7 +196,7 @@ a, .text-muted {
 
 [data-bs-theme="dark"] a,
 [data-bs-theme="dark"] .text-muted {
-  color: #bbb;
+  color: #ddd;
 }
 
 .access-links {
@@ -194,6 +213,6 @@ a, .text-muted {
 }
 
 [data-bs-theme="dark"] .access-links a {
-  color: #b79aff;
+  color: #d5c7ff;
 }
 

--- a/crunevo/templates/auth/login.html
+++ b/crunevo/templates/auth/login.html
@@ -5,6 +5,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/login.css') }}">
 {% endblock %}
 {% block content %}
+<button id="toggle-theme" class="theme-toggle-btn">🌙</button>
 <div class="login-wrapper container-fluid d-flex justify-content-center align-items-center min-vh-100">
   <div class="login-card fade-in">
     <h2 class="login-title">Iniciar sesión</h2>
@@ -70,6 +71,18 @@
           fraseEl.style.opacity = 1;
         }, 500);
       }
-    }, 5000);
+    }, 8000);
+
+    document.getElementById('toggle-theme').addEventListener('click', () => {
+      const current = document.documentElement.getAttribute('data-bs-theme');
+      const next = current === 'dark' ? 'light' : 'dark';
+      document.documentElement.setAttribute('data-bs-theme', next);
+      localStorage.setItem('theme', next);
+    });
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const stored = localStorage.getItem('theme');
+      if (stored) document.documentElement.setAttribute('data-bs-theme', stored);
+    });
   </script>
 {% endblock %}

--- a/crunevo/templates/onboarding/register.html
+++ b/crunevo/templates/onboarding/register.html
@@ -5,6 +5,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/register.css') }}">
 {% endblock %}
 {% block content %}
+<button id="toggle-theme" class="theme-toggle-btn">🌙</button>
 <div class="register-wrapper container-fluid d-flex justify-content-center align-items-center min-vh-100">
   <div class="register-card fade-in">
     <h2 class="register-title">Crea una cuenta</h2>
@@ -102,6 +103,18 @@
         btn.innerHTML = hide ? '🙈' : '🙊';
         btn.setAttribute('aria-label', hide ? 'Mostrar contraseña' : 'Ocultar contraseña');
       });
+    });
+
+    document.getElementById('toggle-theme').addEventListener('click', () => {
+      const current = document.documentElement.getAttribute('data-bs-theme');
+      const next = current === 'dark' ? 'light' : 'dark';
+      document.documentElement.setAttribute('data-bs-theme', next);
+      localStorage.setItem('theme', next);
+    });
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const stored = localStorage.getItem('theme');
+      if (stored) document.documentElement.setAttribute('data-bs-theme', stored);
     });
   </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- refine dark background for login and register pages
- keep auth cards translucent in dark mode
- add a fixed theme toggle button and update rotating phrase timing
- adjust link colours for better dark-mode contrast
- document changes in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6856e88eaea88325be2c154df80c7abc