### PR TITLE
Fix dark theme backgrounds for login and register pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,3 +170,4 @@
 - Optimized login and register pages with smoother theme transitions, rotating welcome phrases and accessible password toggles using 🙊/🙈 icons. Dark mode styling fixed (PR login-register-polish).
 - Adjusted dark theme backgrounds to true black, improved password toggle alignment and link contrast, added fading welcome phrase rotation and disabled page scrolling (PR login-register-tweak).
 - Added theme toggle button on login and register pages, refined dark mode card translucency, extended welcome phrase interval and improved link contrast (PR login-register-theme-toggle).
+- Fixed dark theme backgrounds on login and register: body black, wrappers transparent, cards darker (PR login-register-dark-fix).

--- a/crunevo/static/css/login.css
+++ b/crunevo/static/css/login.css
@@ -17,7 +17,8 @@ body {
 }
 
 [data-bs-theme="dark"] body {
-  background-color: #000 !important;
+  background: #000 !important;
+  background-image: none !important;
 }
 
 
@@ -30,6 +31,10 @@ body {
   max-width: 1100px;
   width: 100%;
   padding: 20px;
+}
+
+[data-bs-theme="dark"] .login-wrapper {
+  background: transparent !important;
 }
 
 .login-card {
@@ -134,10 +139,10 @@ body {
 
 [data-bs-theme="dark"] .login-card,
 [data-bs-theme="dark"] .register-card {
-  background: rgba(0, 0, 0, 0.4);
+  background: rgba(0, 0, 0, 0.5);
   backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  color: #f2f2f2;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: #fff;
 }
 
 [data-bs-theme="dark"] .form-control,

--- a/crunevo/static/css/register.css
+++ b/crunevo/static/css/register.css
@@ -17,7 +17,8 @@ body {
 }
 
 [data-bs-theme="dark"] body {
-  background-color: #000 !important;
+  background: #000 !important;
+  background-image: none !important;
 }
 
 .register-wrapper {
@@ -25,6 +26,10 @@ body {
   align-items: center;
   justify-content: center;
   height: 100vh;
+}
+
+[data-bs-theme="dark"] .register-wrapper {
+  background: transparent !important;
 }
 
 .register-card {
@@ -115,10 +120,10 @@ body {
 }
 
 [data-bs-theme="dark"] .register-card {
-  background: rgba(0, 0, 0, 0.4);
+  background: rgba(0, 0, 0, 0.5);
   backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  color: #f2f2f2;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: #fff;
 }
 [data-bs-theme="dark"] .form-control,
 [data-bs-theme="dark"] select {


### PR DESCRIPTION
## Summary
- refine dark theme CSS for `/login` and `/onboarding/register`
- keep main wrappers transparent and cards darker for better contrast
- record update in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6856eb6fdfd48325bdb735a7de1aa8ba