### PR TITLE
Fix dark mode on auth pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,3 +171,4 @@
 - Adjusted dark theme backgrounds to true black, improved password toggle alignment and link contrast, added fading welcome phrase rotation and disabled page scrolling (PR login-register-tweak).
 - Added theme toggle button on login and register pages, refined dark mode card translucency, extended welcome phrase interval and improved link contrast (PR login-register-theme-toggle).
 - Fixed dark theme backgrounds on login and register: body black, wrappers transparent, cards darker (PR login-register-dark-fix).
+- Ensured gradient removed in dark mode on login and register, toggle icon updates with stored preference (PR login-register-gradient-fix).

--- a/crunevo/static/css/login.css
+++ b/crunevo/static/css/login.css
@@ -16,9 +16,17 @@ body {
   display: none;
 }
 
-[data-bs-theme="dark"] body {
+[data-bs-theme="dark"] body,
+[data-bs-theme="dark"] html {
   background: #000 !important;
+  background-color: #000 !important;
   background-image: none !important;
+}
+[data-bs-theme="dark"] body::before,
+[data-bs-theme="dark"] body::after,
+[data-bs-theme="dark"] html::before,
+[data-bs-theme="dark"] html::after {
+  background: none !important;
 }
 
 
@@ -227,6 +235,7 @@ body {
   padding: 0.25rem 0.6rem;
   font-size: 1.25rem;
   cursor: pointer;
+  z-index: 1060;
   transition: background-color 0.3s ease;
 }
 [data-bs-theme="dark"] .theme-toggle-btn {

--- a/crunevo/static/css/register.css
+++ b/crunevo/static/css/register.css
@@ -16,9 +16,17 @@ body {
   display: none;
 }
 
-[data-bs-theme="dark"] body {
+[data-bs-theme="dark"] body,
+[data-bs-theme="dark"] html {
   background: #000 !important;
+  background-color: #000 !important;
   background-image: none !important;
+}
+[data-bs-theme="dark"] body::before,
+[data-bs-theme="dark"] body::after,
+[data-bs-theme="dark"] html::before,
+[data-bs-theme="dark"] html::after {
+  background: none !important;
 }
 
 .register-wrapper {
@@ -181,6 +189,7 @@ body {
   padding: 0.25rem 0.6rem;
   font-size: 1.25rem;
   cursor: pointer;
+  z-index: 1060;
   transition: background-color 0.3s ease;
 }
 [data-bs-theme="dark"] .theme-toggle-btn {

--- a/crunevo/templates/auth/login.html
+++ b/crunevo/templates/auth/login.html
@@ -73,16 +73,24 @@
       }
     }, 8000);
 
-    document.getElementById('toggle-theme').addEventListener('click', () => {
-      const current = document.documentElement.getAttribute('data-bs-theme');
-      const next = current === 'dark' ? 'light' : 'dark';
-      document.documentElement.setAttribute('data-bs-theme', next);
+    const themeBtn = document.getElementById('toggle-theme');
+    function setThemeIcon(theme) {
+      themeBtn.textContent = theme === 'dark' ? '🌙' : '☀️';
+    }
+
+    themeBtn.addEventListener('click', () => {
+      const html = document.documentElement;
+      const next = html.getAttribute('data-bs-theme') === 'dark' ? 'light' : 'dark';
+      html.setAttribute('data-bs-theme', next);
       localStorage.setItem('theme', next);
+      setThemeIcon(next);
     });
 
     document.addEventListener('DOMContentLoaded', () => {
       const stored = localStorage.getItem('theme');
-      if (stored) document.documentElement.setAttribute('data-bs-theme', stored);
+      const theme = stored || document.documentElement.getAttribute('data-bs-theme');
+      document.documentElement.setAttribute('data-bs-theme', theme);
+      setThemeIcon(theme);
     });
   </script>
 {% endblock %}

--- a/crunevo/templates/onboarding/register.html
+++ b/crunevo/templates/onboarding/register.html
@@ -105,16 +105,24 @@
       });
     });
 
-    document.getElementById('toggle-theme').addEventListener('click', () => {
-      const current = document.documentElement.getAttribute('data-bs-theme');
-      const next = current === 'dark' ? 'light' : 'dark';
-      document.documentElement.setAttribute('data-bs-theme', next);
+    const themeBtn = document.getElementById('toggle-theme');
+    function setThemeIcon(theme) {
+      themeBtn.textContent = theme === 'dark' ? '🌙' : '☀️';
+    }
+
+    themeBtn.addEventListener('click', () => {
+      const html = document.documentElement;
+      const next = html.getAttribute('data-bs-theme') === 'dark' ? 'light' : 'dark';
+      html.setAttribute('data-bs-theme', next);
       localStorage.setItem('theme', next);
+      setThemeIcon(next);
     });
 
     document.addEventListener('DOMContentLoaded', () => {
       const stored = localStorage.getItem('theme');
-      if (stored) document.documentElement.setAttribute('data-bs-theme', stored);
+      const theme = stored || document.documentElement.getAttribute('data-bs-theme');
+      document.documentElement.setAttribute('data-bs-theme', theme);
+      setThemeIcon(theme);
     });
   </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove gradient from login/register pages in dark mode
- bump z-index of theme toggle
- update theme button icon dynamically and persist preference
- document changes

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6856edeed0888325af75d353e97b0699