### PR TITLE
Fix login/register dark theme background

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,3 +172,4 @@
 - Added theme toggle button on login and register pages, refined dark mode card translucency, extended welcome phrase interval and improved link contrast (PR login-register-theme-toggle).
 - Fixed dark theme backgrounds on login and register: body black, wrappers transparent, cards darker (PR login-register-dark-fix).
 - Ensured gradient removed in dark mode on login and register, toggle icon updates with stored preference (PR login-register-gradient-fix).
+- Corrigidos estilos de login y registro: fondo negro sólido en modo oscuro, frase estable y tema guardado en localStorage (PR login-register-stability-fix).

--- a/crunevo/static/css/login.css
+++ b/crunevo/static/css/login.css
@@ -1,25 +1,29 @@
 html,
 body {
   margin: 0;
+  padding: 0;
   font-family: "Segoe UI", sans-serif;
-  background: linear-gradient(to bottom right, #f4ebff, #ffffff);
   min-height: 100vh;
   display: flex;
   align-items: center;
   justify-content: center;
   padding-top: 0 !important;
   overflow: hidden;
+  width: 100vw;
   transition: background-color 0.4s ease;
+}
+
+[data-bs-theme="light"] body {
+  background: linear-gradient(to bottom right, #f4ebff, #ffffff);
 }
 
 .navbar-crunevo {
   display: none;
 }
 
-[data-bs-theme="dark"] body,
-[data-bs-theme="dark"] html {
+[data-bs-theme="dark"] html,
+[data-bs-theme="dark"] body {
   background: #000 !important;
-  background-color: #000 !important;
   background-image: none !important;
 }
 [data-bs-theme="dark"] body::before,
@@ -35,6 +39,7 @@ body {
   flex-direction: row;
   align-items: center;
   justify-content: center;
+  min-height: 100vh;
   gap: 40px;
   max-width: 1100px;
   width: 100%;
@@ -128,6 +133,14 @@ body {
 }
 
 .welcome-phrase {
+  min-height: 3.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  font-size: 1rem;
+  line-height: 1.5;
+  font-weight: 500;
   opacity: 1;
   transition: opacity 0.6s ease;
 }

--- a/crunevo/static/css/register.css
+++ b/crunevo/static/css/register.css
@@ -1,25 +1,29 @@
 html,
 body {
   margin: 0;
+  padding: 0;
   font-family: "Segoe UI", sans-serif;
-  background: linear-gradient(to bottom right, #f4ebff, #ffffff);
   min-height: 100vh;
   display: flex;
   align-items: center;
   justify-content: center;
   padding-top: 0 !important;
   overflow: hidden;
+  width: 100vw;
   transition: background-color 0.4s ease;
+}
+
+[data-bs-theme="light"] body {
+  background: linear-gradient(to bottom right, #f4ebff, #ffffff);
 }
 
 .navbar-crunevo {
   display: none;
 }
 
-[data-bs-theme="dark"] body,
-[data-bs-theme="dark"] html {
+[data-bs-theme="dark"] html,
+[data-bs-theme="dark"] body {
   background: #000 !important;
-  background-color: #000 !important;
   background-image: none !important;
 }
 [data-bs-theme="dark"] body::before,
@@ -30,10 +34,11 @@ body {
 }
 
 .register-wrapper {
-  display: flex;
+  min-height: 100vh;
   align-items: center;
   justify-content: center;
-  height: 100vh;
+  display: flex;
+  flex-direction: row;
 }
 
 [data-bs-theme="dark"] .register-wrapper {

--- a/crunevo/templates/auth/login.html
+++ b/crunevo/templates/auth/login.html
@@ -78,19 +78,18 @@
       themeBtn.textContent = theme === 'dark' ? '🌙' : '☀️';
     }
 
+    document.addEventListener('DOMContentLoaded', () => {
+      const stored = localStorage.getItem('theme') || 'light';
+      document.documentElement.setAttribute('data-bs-theme', stored);
+      setThemeIcon(stored);
+    });
+
     themeBtn.addEventListener('click', () => {
       const html = document.documentElement;
       const next = html.getAttribute('data-bs-theme') === 'dark' ? 'light' : 'dark';
       html.setAttribute('data-bs-theme', next);
       localStorage.setItem('theme', next);
       setThemeIcon(next);
-    });
-
-    document.addEventListener('DOMContentLoaded', () => {
-      const stored = localStorage.getItem('theme');
-      const theme = stored || document.documentElement.getAttribute('data-bs-theme');
-      document.documentElement.setAttribute('data-bs-theme', theme);
-      setThemeIcon(theme);
     });
   </script>
 {% endblock %}

--- a/crunevo/templates/onboarding/register.html
+++ b/crunevo/templates/onboarding/register.html
@@ -110,19 +110,18 @@
       themeBtn.textContent = theme === 'dark' ? '🌙' : '☀️';
     }
 
+    document.addEventListener('DOMContentLoaded', () => {
+      const stored = localStorage.getItem('theme') || 'light';
+      document.documentElement.setAttribute('data-bs-theme', stored);
+      setThemeIcon(stored);
+    });
+
     themeBtn.addEventListener('click', () => {
       const html = document.documentElement;
       const next = html.getAttribute('data-bs-theme') === 'dark' ? 'light' : 'dark';
       html.setAttribute('data-bs-theme', next);
       localStorage.setItem('theme', next);
       setThemeIcon(next);
-    });
-
-    document.addEventListener('DOMContentLoaded', () => {
-      const stored = localStorage.getItem('theme');
-      const theme = stored || document.documentElement.getAttribute('data-bs-theme');
-      document.documentElement.setAttribute('data-bs-theme', theme);
-      setThemeIcon(theme);
     });
   </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- enforce pure black backgrounds in dark mode
- prevent welcome phrase shifting
- ensure theme toggle icon reflects stored setting
- center login and register cards reliably
- document changes in AGENTS guidelines

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68571ba81cb883258af02950f99d842f