### PR TITLE
Implement store listing layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,3 +174,4 @@
 - Ensured gradient removed in dark mode on login and register, toggle icon updates with stored preference (PR login-register-gradient-fix).
 - Corrigidos estilos de login y registro: fondo negro sólido en modo oscuro, frase estable y tema guardado en localStorage (PR login-register-stability-fix).
 - Tienda actualizada: precios en soles, canje con créditos y modelo Purchase; panel admin gestiona precio_creditos y flags (PR store-credits).
+- Lista de productos rediseñada con tarjetas responsive y badges; agregado store.css para estilos de tienda (PR store-layout).

--- a/crunevo/static/css/store.css
+++ b/crunevo/static/css/store.css
@@ -1,0 +1,7 @@
+.badge.bg-purple {
+  background-color: #6f42c1;
+}
+
+.border-purple {
+  border: 2px solid #6f42c1 !important;
+}

--- a/crunevo/templates/store/store.html
+++ b/crunevo/templates/store/store.html
@@ -1,5 +1,8 @@
 {% extends 'base.html' %}
 {% import 'components/button.html' as btn %}
+{% block head_extra %}
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/store.css') }}">
+{% endblock %}
 {% block content %}
 <div class="container mt-4">
   <div class="row">
@@ -30,11 +33,30 @@
             </div>
         </aside>
         <div class="col-md-9">
-          <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 g-4">
+          <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4">
             {% for product in products %}
-            <div class="col">
-              {% include 'store/product_card.html' %}
-            </div>
+              <div class="col">
+                <div class="card h-100 shadow-sm border-0 {% if product.is_featured %}bg-light border-purple{% endif %}">
+                  <img src="{{ product.image_url or '/static/img/producto-default.png' }}" class="card-img-top" alt="{{ product.name }}">
+                  <div class="card-body d-flex flex-column">
+                    <h5 class="card-title">{{ product.name }}</h5>
+                    <p class="card-text small text-muted mb-1">{{ product.description }}</p>
+                    {% if product.price_soles %}
+                      <p class="mb-1 text-primary fw-bold">S/ {{ '%.2f' | format(product.price_soles) }}</p>
+                    {% endif %}
+                    {% if product.price_credits %}
+                      <p class="mb-1 text-warning fw-bold">{{ product.price_credits }} créditos</p>
+                    {% endif %}
+                    <div class="mb-2">
+                      {% if product.is_new %}<span class="badge bg-success">Nuevo</span>{% endif %}
+                      {% if product.is_popular %}<span class="badge bg-danger">Popular</span>{% endif %}
+                      {% if product.credits_only %}<span class="badge bg-warning text-dark">Solo créditos</span>{% endif %}
+                      {% if product.is_featured %}<span class="badge bg-purple text-white">Destacado</span>{% endif %}
+                    </div>
+                    <a href="{{ url_for('store.product_detail', product_id=product.id) }}" class="btn btn-outline-primary mt-auto">Ver detalle</a>
+                  </div>
+                </div>
+              </div>
             {% endfor %}
           </div>
           <div class="mt-4 text-end">


### PR DESCRIPTION
## Summary
- redesign store product list with inline card markup and badges
- add custom store.css with purple badge and border styles
- include new CSS in store template
- document changes in AGENTS guidelines

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685781e6c1d8832583d4b44de338a19c