### PR TITLE
Add purchases history page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,3 +184,4 @@
 - Ficha de producto modernizada con sección de características y stock (PR store-product-detail-redesign).
 - Sistema de favoritos funcional con modelo FavoriteProduct, rutas y iconos de corazón (PR store-favorites).
 - Filtros por categoría y precio habilitados en la tienda (PR store-filters).
+- Historial de compras accesible en /store/compras con tarjetas de detalle y opción de descarga (PR store-purchases-page).

--- a/crunevo/routes/store_routes.py
+++ b/crunevo/routes/store_routes.py
@@ -182,3 +182,14 @@ def view_favorites():
         Product.query.filter(Product.id.in_(product_ids)).all() if product_ids else []
     )
     return render_template("store/favorites.html", products=products)
+
+
+@store_bp.route("/compras")
+@activated_required
+def view_purchases():
+    compras = (
+        Purchase.query.filter_by(user_id=current_user.id)
+        .order_by(Purchase.timestamp.desc())
+        .all()
+    )
+    return render_template("store/compras.html", compras=compras)

--- a/crunevo/templates/store/compras.html
+++ b/crunevo/templates/store/compras.html
@@ -1,0 +1,31 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container mt-4">
+  <h2 class="mb-4">Mis compras</h2>
+  {% for compra in compras %}
+    <div class="card mb-3">
+      <div class="row g-0">
+        <div class="col-md-2 text-center">
+          <img src="{{ compra.product.image_url or '/static/img/producto-default.png' }}" class="img-fluid rounded-start">
+        </div>
+        <div class="col-md-10">
+          <div class="card-body">
+            <h5 class="card-title">{{ compra.product.name }}</h5>
+            <p class="card-text text-muted">Comprado el {{ compra.timestamp.strftime('%d/%m/%Y') }}</p>
+            {% if compra.price_soles %}
+              <p class="card-text text-primary">S/ {{ '%.2f'|format(compra.price_soles) }}</p>
+            {% elif compra.price_credits %}
+              <p class="card-text text-warning">{{ compra.price_credits }} créditos</p>
+            {% endif %}
+            {% if compra.product.download_url %}
+              <a href="{{ compra.product.download_url }}" target="_blank" class="btn btn-success btn-sm">Descargar</a>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    </div>
+  {% else %}
+    <p class="text-muted">Aún no has comprado nada.</p>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/crunevo/templates/store/store.html
+++ b/crunevo/templates/store/store.html
@@ -24,9 +24,9 @@
               </a>
             </li>
             <li class="nav-item mb-2">
-              <span class="nav-link px-0 disabled">
+              <a class="nav-link px-0" href="{{ url_for('store.view_purchases') }}">
                 💸 Mis compras
-              </span>
+              </a>
             </li>
             <li class="nav-item mb-2">
               <a class="nav-link px-0" href="{{ url_for('store.view_favorites') }}">


### PR DESCRIPTION
## Summary
- show purchases history for logged-in users
- link to purchases page from store sidebar
- document change in AGENTS guidelines

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6857a1faf3b08325b6a5f4b2c30dcf0b