### PR TITLE
Implement real checkout and buy-now

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,3 +185,4 @@
 - Sistema de favoritos funcional con modelo FavoriteProduct, rutas y iconos de corazón (PR store-favorites).
 - Filtros por categoría y precio habilitados en la tienda (PR store-filters).
 - Historial de compras accesible en /store/compras con tarjetas de detalle y opción de descarga (PR store-purchases-page).
+- Checkout real crea registros en Purchase y descuenta stock; botón "Comprar ahora" en productos (PR real-checkout).

--- a/crunevo/templates/store/carrito.html
+++ b/crunevo/templates/store/carrito.html
@@ -58,7 +58,7 @@
         ← Seguir comprando
       </a>
       <div>
-        <a href="#" class="btn btn-outline-success me-2 disabled">Finalizar compra</a>
+        <a href="{{ url_for('store.checkout') }}" class="btn btn-outline-success me-2">Finalizar compra</a>
         <a href="#" class="btn btn-primary disabled">Canjear con créditos</a>
       </div>
     </div>

--- a/crunevo/templates/store/view_product.html
+++ b/crunevo/templates/store/view_product.html
@@ -31,7 +31,11 @@
       <a href="{{ url_for('auth.login') }}" class="btn btn-primary w-100 mb-2">Inicia sesión</a>
       {% endif %}
       {% if not product.credits_only %}
-      <a href="{{ url_for('store.add_to_cart', product_id=product.id) }}" class="btn btn-primary w-100">Comprar</a>
+      <form method="post" action="{{ url_for('store.buy_product', product_id=product.id) }}" class="mb-2">
+        {{ csrf.csrf_field() }}
+        <button class="btn btn-success w-100" type="submit">Comprar ahora</button>
+      </form>
+      <a href="{{ url_for('store.add_to_cart', product_id=product.id) }}" class="btn btn-primary w-100">Agregar al carrito</a>
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
## Summary
- implement purchase logic in `/checkout`
- add `/buy/<id>` endpoint for direct purchase
- pass `cart_items` to cart view and enable checkout button
- add "Comprar ahora" button in product page
- document new checkout feature in AGENTS guidelines

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6857a5f48e4083258b0572d9e7880ab0