### PR TITLE
Implement checkout success flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,3 +187,4 @@
 - Historial de compras accesible en /store/compras con tarjetas de detalle y opción de descarga (PR store-purchases-page).
 - Checkout real crea registros en Purchase y descuenta stock; botón "Comprar ahora" en productos (PR real-checkout).
 - Corregido enlace de eliminar del carrito para usar store.remove_item y evitar BuildError (PR fix-cart-remove-link).
+- Agregados alias price_paid y credits_used en Purchase, página de éxito para checkout y botones de tienda deshabilitados si no hay stock o créditos insuficientes (PR checkout-success-ui).

--- a/crunevo/models/purchase.py
+++ b/crunevo/models/purchase.py
@@ -13,3 +13,23 @@ class Purchase(db.Model):
 
     user = db.relationship("User")
     product = db.relationship("Product")
+
+    # Backwards compatible aliases
+
+    @property
+    def price_paid(self) -> float:
+        """Return the amount paid in soles."""
+        return self.price_soles
+
+    @price_paid.setter
+    def price_paid(self, value: float) -> None:
+        self.price_soles = value
+
+    @property
+    def credits_used(self) -> int:
+        """Return the credits spent."""
+        return self.price_credits
+
+    @credits_used.setter
+    def credits_used(self, value: int) -> None:
+        self.price_credits = value

--- a/crunevo/routes/store_routes.py
+++ b/crunevo/routes/store_routes.py
@@ -195,8 +195,7 @@ def checkout():
 
     db.session.commit()
     session.pop("cart", None)
-    flash("Compra realizada exitosamente", "success")
-    return redirect(url_for("store.view_purchases"))
+    return render_template("store/checkout_success.html")
 
 
 @store_bp.route("/favorite/<int:product_id>", methods=["POST"])

--- a/crunevo/templates/store/checkout_success.html
+++ b/crunevo/templates/store/checkout_success.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container py-5 text-center">
+  <h2 class="mb-4">¡Compra completada!</h2>
+  <p>Tu pedido se ha registrado correctamente.</p>
+  <a href="{{ url_for('store.view_purchases') }}" class="btn btn-primary mt-3">Ver historial de compras</a>
+</div>
+{% endblock %}

--- a/crunevo/templates/store/product_card.html
+++ b/crunevo/templates/store/product_card.html
@@ -24,7 +24,9 @@
     {% endif %}
   </div>
   <div class="card-footer bg-white border-0">
-    {% if product.price_credits and current_user.is_authenticated %}
+    {% if product.stock <= 0 %}
+      <button class="btn btn-outline-secondary w-100" disabled>Sin stock</button>
+    {% elif product.price_credits and current_user.is_authenticated %}
       {% if current_user.credits >= product.price_credits %}
         <form method="post" action="{{ url_for('store.redeem_product', product_id=product.id) }}">
           {{ csrf.csrf_field() }}

--- a/crunevo/templates/store/view_product.html
+++ b/crunevo/templates/store/view_product.html
@@ -20,22 +20,30 @@
       {% if product.stock > 0 %}
         <span class="badge bg-success mb-3">En stock</span>
       {% else %}
-        <span class="badge bg-secondary mb-3">Próximamente</span>
+        <span class="badge bg-secondary mb-3">Sin stock</span>
       {% endif %}
       {% if product.price_credits and current_user.is_authenticated %}
-      <form method="post" action="{{ url_for('store.redeem_product', product_id=product.id) }}" class="mb-2">
-        {{ csrf.csrf_field() }}
-        <button class="btn btn-primary w-100" type="submit">Canjear</button>
-      </form>
+        {% if current_user.credits >= product.price_credits %}
+          <form method="post" action="{{ url_for('store.redeem_product', product_id=product.id) }}" class="mb-2">
+            {{ csrf.csrf_field() }}
+            <button class="btn btn-primary w-100" type="submit">Canjear</button>
+          </form>
+        {% else %}
+          <button class="btn btn-outline-secondary w-100 mb-2" disabled>Requiere {{ product.price_credits }} créditos</button>
+        {% endif %}
       {% elif product.price_credits and not current_user.is_authenticated %}
-      <a href="{{ url_for('auth.login') }}" class="btn btn-primary w-100 mb-2">Inicia sesión</a>
+        <a href="{{ url_for('auth.login') }}" class="btn btn-primary w-100 mb-2">Inicia sesión</a>
       {% endif %}
       {% if not product.credits_only %}
-      <form method="post" action="{{ url_for('store.buy_product', product_id=product.id) }}" class="mb-2">
-        {{ csrf.csrf_field() }}
-        <button class="btn btn-success w-100" type="submit">Comprar ahora</button>
-      </form>
-      <a href="{{ url_for('store.add_to_cart', product_id=product.id) }}" class="btn btn-primary w-100">Agregar al carrito</a>
+        {% if product.stock > 0 %}
+          <form method="post" action="{{ url_for('store.buy_product', product_id=product.id) }}" class="mb-2">
+            {{ csrf.csrf_field() }}
+            <button class="btn btn-success w-100" type="submit">Comprar ahora</button>
+          </form>
+          <a href="{{ url_for('store.add_to_cart', product_id=product.id) }}" class="btn btn-primary w-100">Agregar al carrito</a>
+        {% else %}
+          <button class="btn btn-outline-secondary w-100" disabled>Sin stock</button>
+        {% endif %}
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
## Summary
- alias `price_paid` and `credits_used` in Purchase model
- show success page after checkout
- disable product buttons when out of stock or insufficient credits
- document changes in AGENTS guidelines

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6857af112ec8832593a5f0190261bc50