### PR TITLE
Implement admin store actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,3 +188,4 @@
 - Checkout real crea registros en Purchase y descuenta stock; botón "Comprar ahora" en productos (PR real-checkout).
 - Corregido enlace de eliminar del carrito para usar store.remove_item y evitar BuildError (PR fix-cart-remove-link).
 - Agregados alias price_paid y credits_used en Purchase, página de éxito para checkout y botones de tienda deshabilitados si no hay stock o créditos insuficientes (PR checkout-success-ui).
+- Botón 'Más opciones' en /admin/store permite editar y eliminar productos con modal de confirmación (QA admin-store-options).

--- a/crunevo/templates/admin/add_edit_product.html
+++ b/crunevo/templates/admin/add_edit_product.html
@@ -41,4 +41,5 @@
   <a href="{{ PUBLIC_BASE_URL }}/store/{{ product.id }}" target="_blank" class="btn btn-outline-info ms-2">Ver en tienda</a>
   {% endif %}
 </form>
+<a href="{{ url_for('admin.manage_store') }}" class="btn btn-link mt-2">&larr; Volver a tienda</a>
 {% endblock %}

--- a/crunevo/templates/admin/manage_store.html
+++ b/crunevo/templates/admin/manage_store.html
@@ -28,7 +28,12 @@
       {% for product in products %}
       <tr>
         <td>{{ product.id }}</td>
-        <td>{{ product.name }}</td>
+        <td>
+          {{ product.name }}
+          {% if product.is_popular %}<span class="badge bg-warning text-dark ms-1">Popular</span>{% endif %}
+          {% if product.is_new %}<span class="badge bg-success ms-1">Nuevo</span>{% endif %}
+          {% if product.credits_only %}<span class="badge bg-info text-dark ms-1">Solo créditos</span>{% endif %}
+        </td>
         <td>{{ '%.2f'|format(product.price) }}</td>
         <td>{{ product.price_credits or '' }}</td>
         <td>{{ product.stock }}</td>

--- a/tests/test_admin_store.py
+++ b/tests/test_admin_store.py
@@ -1,0 +1,20 @@
+from crunevo.models import User, Product
+
+
+def test_admin_delete_product(client, db_session):
+    admin = User(
+        username="adm",
+        email="adm@example.com",
+        role="admin",
+        activated=True,
+        avatar_url="a",
+    )
+    admin.set_password("pass")
+    product = Product(name="prod", price=1, stock=1)
+    db_session.add_all([admin, product])
+    db_session.commit()
+
+    client.post("/login", data={"username": "adm", "password": "pass"})
+    resp = client.post(f"/admin/products/{product.id}/delete")
+    assert resp.status_code == 302
+    assert Product.query.get(product.id) is None


### PR DESCRIPTION
## Summary
- add product badges in admin store listing
- add back link in add/edit product form
- test product deletion route
- document admin store features in AGENTS

## Testing
- `make fmt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857b8d264e88325b4fb9155dd5614b1