### PR TITLE
Fix duplicate Bootstrap in admin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,3 +190,4 @@
 - Agregados alias price_paid y credits_used en Purchase, página de éxito para checkout y botones de tienda deshabilitados si no hay stock o créditos insuficientes (PR checkout-success-ui).
 - Canje con créditos descuenta stock y previene duplicados usando allow_multiple; checkout desde carrito requiere confirmación (PR store-redeem-cart-checkout).
 - Botón 'Más opciones' en /admin/store permite editar y eliminar productos con modal de confirmación (QA admin-store-options).
+- Eliminadas duplicaciones de Bootstrap quitando tabler.min.js y moviendo modales fuera de las tablas (PR admin-dropdown-conflict-fix).

--- a/crunevo/templates/admin/base_admin.html
+++ b/crunevo/templates/admin/base_admin.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}
 {% block head_extra %}
   <link href="https://unpkg.com/@tabler/core@1.3.2/dist/css/tabler.min.css" rel="stylesheet">
-  <script src="https://unpkg.com/@tabler/core@1.3.2/dist/js/tabler.min.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" defer></script>
   <link rel="stylesheet" href="{{ url_for('static', filename='admin/custom.css') }}">
 {% endblock %}

--- a/crunevo/templates/admin/manage_store.html
+++ b/crunevo/templates/admin/manage_store.html
@@ -50,11 +50,13 @@
           </div>
         </td>
       </tr>
-      {% include 'admin/modals/delete_product.html' %}
       {% endfor %}
       </tbody>
       </table>
     </div>
   </div>
 </div>
+{% for product in products %}
+  {% include 'admin/modals/delete_product.html' %}
+{% endfor %}
 {% endblock %}

--- a/crunevo/templates/admin/manage_users.html
+++ b/crunevo/templates/admin/manage_users.html
@@ -40,12 +40,14 @@
             </div>
           </td>
         </tr>
-        {% include 'admin/modals/user_actions.html' %}
-        {% include 'admin/modals/edit_role.html' %}
         {% endfor %}
       </tbody>
       </table>
     </div>
   </div>
 </div>
+{% for user in users %}
+  {% include 'admin/modals/user_actions.html' %}
+  {% include 'admin/modals/edit_role.html' %}
+{% endfor %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove Tabler JS to avoid duplicate Bootstrap instances
- move product and user modals outside tables
- document dropdown conflict fix

## Testing
- `make fmt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857bd8bad9c832583ae0bd52a56e298