### PR TITLE
Fix admin store view link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,3 +192,4 @@
 - Botón 'Más opciones' en /admin/store permite editar y eliminar productos con modal de confirmación (QA admin-store-options).
 - Eliminadas duplicaciones de Bootstrap quitando tabler.min.js y moviendo modales fuera de las tablas (PR admin-dropdown-conflict-fix).
 - Historial de compras permite descargar comprobante en PDF y compartir enlace; productos comprados muestran badge "Adquirido" y deshabilitan compra/canje si no se permiten duplicados. Tras comprar o canjear se ofrece descarga directa cuando hay archivo (PR purchased-badge-download).
+- Corregido enlace 'Ver en tienda' en manage_store.html a /store/product/<id> para evitar redirección rota (PR admin-store-view-link-fix).

--- a/crunevo/templates/admin/manage_store.html
+++ b/crunevo/templates/admin/manage_store.html
@@ -41,7 +41,7 @@
           <div class="dropdown position-relative">
             <button class="btn btn-sm admin-dropdown-btn dropdown-toggle" data-bs-toggle="dropdown" title="Más opciones" aria-label="Más opciones de {{ product.name }}" aria-haspopup="true" aria-expanded="false">⋮</button>
             <ul class="dropdown-menu shadow-sm">
-              <li><a class="dropdown-item" href="{{ PUBLIC_BASE_URL }}/store/{{ product.id }}" target="_blank">Ver en tienda</a></li>
+              <li><a class="dropdown-item" href="{{ PUBLIC_BASE_URL }}/store/product/{{ product.id }}" target="_blank">Ver en tienda</a></li>
               {% if current_user.role == 'admin' %}
               <li><a class="dropdown-item" href="{{ url_for('admin.edit_product', product_id=product.id) }}">Editar</a></li>
               <li><button class="dropdown-item text-danger" data-bs-toggle="modal" data-bs-target="#deleteProductModal{{ product.id }}">Eliminar</button></li>


### PR DESCRIPTION
## Summary
- fix the `Ver en tienda` link to point at `/store/product/<id>`
- document change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6857c3ec2ef0832599b4790b5c81770f