### PR TITLE
Feed UI tweaks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,3 +200,4 @@
 - En edición de productos se sube imagen a Cloudinary y el enlace "Ver en tienda" apunta a /store/product/<id> (PR product-cloudinary-fix).
 - Implementado sistema de reseñas y preguntas en productos con filtros en favoritos y visual especial para Packs (PR store-reviews-qa).
 - Corregida vista de tienda para mostrar product.image_url con imagen por defecto si falta (PR store-image-url)
+- Feed redesign: avatar en formulario de publicación, filtros como pestañas y fechas relativas (PR feed-v1-improved)

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -30,6 +30,10 @@ def create_app():
             "ACHIEVEMENT_DETAILS": ACHIEVEMENT_DETAILS,
         }
 
+    from .utils.helpers import timesince
+
+    app.jinja_env.filters["timesince"] = timesince
+
     db.init_app(app)
     login_manager.init_app(app)
     mail.init_app(app)

--- a/crunevo/templates/components/feed_card.html
+++ b/crunevo/templates/components/feed_card.html
@@ -13,6 +13,9 @@
     <li>#{{ tag }}</li>
     {% endfor %}
   </ul>
-  <div class="tw-text-xs tw-text-gray-500">{{ note.author.username }} · {{ note.created_at.strftime('%Y-%m-%d') }}</div>
+  <div class="tw-text-xs tw-text-gray-500">{{ note.author.username }} · {{ note.created_at|timesince }}</div>
+  <div class="tw-flex tw-gap-3 tw-text-xs tw-text-gray-500">
+    <span><i class="bi bi-star-fill"></i> {{ note.downloads }}</span>
+  </div>
   <a href="{{ url_for('notes.view_note', id=note.id) }}" class="tw-text-sm tw-underline">Ver detalle</a>
 </article>

--- a/crunevo/templates/components/post_card.html
+++ b/crunevo/templates/components/post_card.html
@@ -1,8 +1,13 @@
 <article class="tw-rounded-2xl tw-shadow-sm tw-bg-white dark:tw-bg-gray-900 tw-p-4 tw-space-y-2">
   <div class="tw-flex tw-items-center tw-mb-2">
-    <img src="{{ post.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
-    <a href="{{ url_for('auth.public_profile', user_id=post.author.id) }}" class="me-auto text-decoration-none"><strong>{{ post.author.username }}</strong></a>
-    <small class="text-muted">{{ post.created_at.strftime('%Y-%m-%d') }}</small>
+    {% set author = post.author %}
+    <img src="{{ (author and author.avatar_url) or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
+    {% if author %}
+    <a href="{{ url_for('auth.public_profile', user_id=author.id) }}" class="me-auto text-decoration-none"><strong>{{ author.username }}</strong></a>
+    {% else %}
+    <span class="me-auto text-muted">Usuario eliminado</span>
+    {% endif %}
+    <small class="text-muted">{{ post.created_at|timesince }}</small>
   </div>
   <p class="tw-text-base">{{ post.content }}</p>
   {% if post.file_url %}
@@ -12,5 +17,8 @@
       <img src="{{ post.file_url }}" alt="imagen" class="tw-rounded tw-w-full">
     {% endif %}
   {% endif %}
-  <div class="tw-text-xs tw-text-gray-500">{{ post.likes }} likes</div>
+  <div class="tw-flex tw-gap-3 tw-text-xs tw-text-gray-500">
+    <span><i class="bi bi-star-fill"></i> {{ post.likes }}</span>
+    <span><i class="bi bi-chat"></i> {{ post.comments|length }}</span>
+  </div>
 </article>

--- a/crunevo/templates/feed/feed.html
+++ b/crunevo/templates/feed/feed.html
@@ -12,9 +12,21 @@
     <h5 class="mb-3">Feed</h5>
     <form method="post" enctype="multipart/form-data" class="mb-4">
       {{ csrf.csrf_field() }}
-      <textarea name="content" class="form-control mb-2" placeholder="Comparte una idea" required></textarea>
-      <input type="file" name="file" accept=".jpg,.png,.pdf" class="form-control mb-2">
-      <button class="btn btn-primary" type="submit">Publicar</button>
+      <div class="d-flex mb-2">
+        <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
+        <textarea name="content" class="form-control" rows="3" placeholder="¿Qué deseas compartir?" required></textarea>
+      </div>
+      <div class="d-flex justify-content-between align-items-center gap-2">
+        <div class="btn-group">
+          <a href="{{ url_for('notes.upload') }}" class="btn btn-outline-secondary btn-sm"><i class="bi bi-file-earmark-plus"></i> Apunte</a>
+          <label class="btn btn-outline-secondary btn-sm mb-0">
+            <i class="bi bi-image"></i> Imagen
+            <input type="file" name="file" accept=".jpg,.png,.pdf" class="d-none">
+          </label>
+          <button type="button" class="btn btn-outline-secondary btn-sm" disabled><i class="bi bi-trophy"></i> Logro</button>
+        </div>
+        <button class="btn btn-primary btn-sm" type="submit">Publicar</button>
+      </div>
     </form>
 
     <div class="d-flex flex-wrap gap-2 mb-4">
@@ -86,11 +98,17 @@
       </div>
     </div>
 
-    <div class="d-flex justify-content-center gap-2 mb-4">
-      <a href="{{ url_for('feed.index', filter='recientes') }}" class="btn btn-outline-primary {% if filter == 'recientes' %}active{% endif %}">📅 Recientes</a>
-      <a href="{{ url_for('feed.index', filter='populares') }}" class="btn btn-outline-primary {% if filter == 'populares' %}active{% endif %}">🔥 Populares</a>
-      <a href="{{ url_for('feed.index', filter='votados') }}" class="btn btn-outline-primary {% if filter == 'votados' %}active{% endif %}">👍 Más votados</a>
-    </div>
+    <ul class="nav nav-pills justify-content-center mb-4">
+      <li class="nav-item">
+        <a href="{{ url_for('feed.index', filter='recientes') }}" class="nav-link {% if filter == 'recientes' %}active{% endif %}">🕒 Recientes</a>
+      </li>
+      <li class="nav-item">
+        <a href="{{ url_for('feed.index', filter='populares') }}" class="nav-link {% if filter == 'populares' %}active{% endif %}">🔥 Populares</a>
+      </li>
+      <li class="nav-item">
+        <a href="{{ url_for('feed.index', filter='votados') }}" class="nav-link {% if filter == 'votados' %}active{% endif %}">👍 Más votados</a>
+      </li>
+    </ul>
 
   <div class="row">
     <div class="col-lg-8">
@@ -108,7 +126,7 @@
           <img src="{{ url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
           <span class="me-auto text-muted">Usuario eliminado</span>
           {% endif %}
-          <small class="text-muted">{{ post.created_at.strftime('%Y-%m-%d') }}</small>
+          <small class="text-muted">{{ post.created_at|timesince }}</small>
         </div>
         <p class="card-text">{{ post.content }}</p>
         {% if post.file_url %}
@@ -139,7 +157,7 @@
               <img src="{{ c.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
               <div>
                 <div class="small text-muted">
-                  <a href="{{ url_for('auth.public_profile', user_id=c.author.id) }}" class="text-decoration-none">{{ c.author.username }}</a> • {{ c.timestamp.strftime('%Y-%m-%d %H:%M') }}
+                  <a href="{{ url_for('auth.public_profile', user_id=c.author.id) }}" class="text-decoration-none">{{ c.author.username }}</a> • {{ c.timestamp|timesince }}
                 </div>
                 <div>{{ c.body }}</div>
               </div>

--- a/crunevo/utils/helpers.py
+++ b/crunevo/utils/helpers.py
@@ -1,4 +1,5 @@
 from functools import wraps
+from datetime import datetime
 from flask import redirect, url_for
 from flask_login import current_user, login_required
 
@@ -53,3 +54,24 @@ def verified_required(f):
         return f(*args, **kwargs)
 
     return decorated
+
+
+def timesince(dt):
+    """Return human readable delta from now in Spanish."""
+    if not dt:
+        return ""
+    now = datetime.utcnow()
+    if dt.tzinfo is not None:
+        now = now.replace(tzinfo=dt.tzinfo)
+    delta = now - dt
+    seconds = int(delta.total_seconds())
+    if seconds < 60:
+        return "hace unos segundos"
+    minutes = seconds // 60
+    if minutes < 60:
+        return f"hace {minutes} minuto{'s' if minutes != 1 else ''}"
+    hours = minutes // 60
+    if hours < 24:
+        return f"hace {hours} hora{'s' if hours != 1 else ''}"
+    days = hours // 24
+    return f"hace {days} d\u00eda{'s' if days != 1 else ''}"


### PR DESCRIPTION
## Summary
- show user avatar and action buttons in feed form
- convert feed filter buttons into nav tabs
- show relative timestamps with new `timesince` filter
- add like/comment icons on cards
- document task in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6857d2839c548325ad4dac2270d14262