### PR TITLE
Fix store product images

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,3 +201,4 @@
 - Implementado sistema de reseñas y preguntas en productos con filtros en favoritos y visual especial para Packs (PR store-reviews-qa).
 - Corregida vista de tienda para mostrar product.image_url con imagen por defecto si falta (PR store-image-url)
 - Feed redesign: avatar en formulario de publicación, filtros como pestañas y fechas relativas (PR feed-v1-improved)
+- Corregida plantilla store.html para usar product.image si existe, con alt y title; botón "Ver detalle" evita desbordes con tw-whitespace-nowrap (PR store-image-check)

--- a/crunevo/templates/store/store.html
+++ b/crunevo/templates/store/store.html
@@ -73,11 +73,12 @@
             {% for product in products %}
               <div class="col">
                 <div class="card position-relative h-100 shadow-sm border-0 {% if product.is_featured %}bg-light border-purple{% endif %} {% if product.category == 'Pack' %}tw-scale-[1.03]{% endif %}">
-                  {% if product.image_url %}
-                    <img src="{{ product.image_url }}" class="card-img-top" alt="{{ product.name }}">
-                  {% else %}
-                    <img src="{{ url_for('static', filename='img/default_product.png') }}" class="card-img-top" alt="Sin imagen">
-                  {% endif %}
+                  <img
+                    src="{{ product.image if product.image else url_for('static', filename='img/default_product.png') }}"
+                    class="card-img-top"
+                    alt="{{ product.name }}"
+                    title="Ver {{ product.name }}"
+                  >
                   <form method="post" action="{{ url_for('store.toggle_favorite', product_id=product.id) }}" class="position-absolute top-0 end-0 m-2">
                     {{ csrf.csrf_field() }}
                     <button class="btn btn-sm btn-light border-0" type="submit">
@@ -109,7 +110,7 @@
                     {% if product.id in purchased_ids and product.download_url %}
                       <a href="{{ product.download_url }}" class="btn btn-success w-100 mb-2" target="_blank">Descargar</a>
                     {% endif %}
-                    <a href="{{ url_for('store.view_product', product_id=product.id) }}" class="btn btn-outline-primary mt-auto">Ver detalle</a>
+                    <a href="{{ url_for('store.view_product', product_id=product.id) }}" class="btn btn-outline-primary mt-auto tw-whitespace-nowrap">Ver detalle</a>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- display product.image with fallback on /store page
- avoid wrapping on "Ver detalle" buttons
- document image fix in AGENTS instructions

## Testing
- `make fmt`
- `make test` *(fails: Could not build url for endpoint 'notes.upload')*

------
https://chatgpt.com/codex/tasks/task_e_6857d4fe6ce88325b60646611285e14d