### PR TITLE
Add dark text theme support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,3 +203,4 @@
 - Feed redesign: avatar en formulario de publicación, filtros como pestañas y fechas relativas (PR feed-v1-improved)
 - Corregida plantilla store.html para usar product.image si existe, con alt y title; botón "Ver detalle" evita desbordes con tw-whitespace-nowrap (PR store-image-check)
 - Added SavedPost model, donation endpoints and mobile nav.
+- Añadido soporte de tema oscuro para textos grises en tarjetas del feed (PR dark-text-support).

--- a/crunevo/templates/components/feed_card.html
+++ b/crunevo/templates/components/feed_card.html
@@ -8,13 +8,13 @@
   {% endif %}
   <h3 class="tw-text-lg tw-font-semibold">{{ note.title }}</h3>
   <p class="tw-text-sm tw-text-gray-600 dark:tw-text-gray-400">{{ note.description }}</p>
-  <ul class="tw-flex tw-flex-wrap tw-gap-1 tw-text-xs tw-text-gray-500">
+  <ul class="tw-flex tw-flex-wrap tw-gap-1 tw-text-xs tw-text-gray-500 dark:tw-text-gray-400">
     {% for tag in (note.tags or '').split(',') if tag %}
     <li>#{{ tag }}</li>
     {% endfor %}
   </ul>
-  <div class="tw-text-xs tw-text-gray-500">{{ note.author.username }} · {{ note.created_at|timesince }}</div>
-  <div class="tw-flex tw-gap-3 tw-text-xs tw-text-gray-500">
+  <div class="tw-text-xs tw-text-gray-500 dark:tw-text-gray-400">{{ note.author.username }} · {{ note.created_at|timesince }}</div>
+  <div class="tw-flex tw-gap-3 tw-text-xs tw-text-gray-500 dark:tw-text-gray-400">
     <span><i class="bi bi-star-fill"></i> {{ note.downloads }}</span>
   </div>
   <a href="{{ url_for('notes.view_note', id=note.id) }}" class="tw-text-sm tw-underline">Ver detalle</a>

--- a/crunevo/templates/components/note_card.html
+++ b/crunevo/templates/components/note_card.html
@@ -5,7 +5,7 @@
     <img src="{{ url_for('static', filename='img/placeholder.svg') }}" alt="preview" class="tw-rounded mb-4 tw-w-full">
   {% endif %}
   <h3 class="tw-text-lg tw-font-semibold mb-2">{{ note.title }}</h3>
-  <ul class="tw-flex tw-flex-wrap tw-gap-1 tw-text-sm tw-text-gray-500 mb-4">
+  <ul class="tw-flex tw-flex-wrap tw-gap-1 tw-text-sm tw-text-gray-500 dark:tw-text-gray-400 mb-4">
     {% for tag in (note.tags or '').split(',') %}
       <li>#{{ tag }}</li>
     {% endfor %}

--- a/crunevo/templates/components/post_card.html
+++ b/crunevo/templates/components/post_card.html
@@ -17,7 +17,7 @@
       <img src="{{ post.file_url }}" alt="imagen" class="tw-rounded tw-w-full">
     {% endif %}
   {% endif %}
-  <div class="tw-flex tw-gap-3 tw-text-xs tw-text-gray-500">
+  <div class="tw-flex tw-gap-3 tw-text-xs tw-text-gray-500 dark:tw-text-gray-400">
     <span><i class="bi bi-star-fill"></i> {{ post.likes }}</span>
     <span><i class="bi bi-chat"></i> {{ post.comments|length }}</span>
   </div>


### PR DESCRIPTION
## Summary
- add dark text color classes in feed, post and note cards
- document change in AGENTS guidelines

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68583cede8408325995776d0c0076057