### PR TITLE
Feed redesign with posts only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,3 +204,4 @@
 - Corregida plantilla store.html para usar product.image si existe, con alt y title; botón "Ver detalle" evita desbordes con tw-whitespace-nowrap (PR store-image-check)
 - Added SavedPost model, donation endpoints and mobile nav.
 - Añadido soporte de tema oscuro para textos grises en tarjetas del feed (PR dark-text-support).
+- Feed principal reorganizado para mostrar solo publicaciones recientes con paginación básica y sin secciones de apuntes (PR feed-wall-redesign).

--- a/crunevo/routes/feed_routes.py
+++ b/crunevo/routes/feed_routes.py
@@ -183,36 +183,42 @@ def index():
         flash("Publicación creada")
         return redirect(url_for("feed.index"))
 
-    filter_opt = request.args.get("filter", "recientes")
-
-    query = Post.query
-    if filter_opt == "populares":
-        query = query.order_by(Post.likes.desc())
-    else:  # recientes por defecto
-        query = query.order_by(Post.created_at.desc())
-
-    posts = query.limit(10).all()
-    top_notes, top_posts, top_users = get_featured_posts()
+    page = request.args.get("page", 1, type=int)
+    pagination = Post.query.order_by(Post.created_at.desc()).paginate(
+        page=page, per_page=10
+    )
+    posts = pagination.items
     top_ranked, recent_achievements = get_weekly_ranking()
     latest_notes = Note.query.order_by(Note.created_at.desc()).limit(5).all()
     return render_template(
         "feed/feed.html",
         posts=posts,
-        top_notes=top_notes,
-        top_posts=top_posts,
-        top_users=top_users,
+        pagination=pagination,
         top_ranked=top_ranked,
         recent_achievements=recent_achievements,
         latest_notes=latest_notes,
-        filter=filter_opt,
     )
 
 
 @feed_bp.route("/trending")
 @activated_required
 def trending():
-    posts = Post.query.order_by(Post.created_at.desc()).limit(10).all()
-    return render_template("feed/feed.html", posts=posts, trending=True)
+    page = request.args.get("page", 1, type=int)
+    pagination = Post.query.order_by(Post.created_at.desc()).paginate(
+        page=page, per_page=10
+    )
+    posts = pagination.items
+    top_ranked, recent_achievements = get_weekly_ranking()
+    latest_notes = Note.query.order_by(Note.created_at.desc()).limit(5).all()
+    return render_template(
+        "feed/feed.html",
+        posts=posts,
+        pagination=pagination,
+        top_ranked=top_ranked,
+        recent_achievements=recent_achievements,
+        latest_notes=latest_notes,
+        trending=True,
+    )
 
 
 @feed_bp.route("/post/<int:post_id>", endpoint="view_post")

--- a/crunevo/templates/components/post_card.html
+++ b/crunevo/templates/components/post_card.html
@@ -20,5 +20,6 @@
   <div class="tw-flex tw-gap-3 tw-text-xs tw-text-gray-500 dark:tw-text-gray-400">
     <span><i class="bi bi-star-fill"></i> {{ post.likes }}</span>
     <span><i class="bi bi-chat"></i> {{ post.comments|length }}</span>
+    <a href="{{ url_for('feed.view_post', post_id=post.id) }}" class="btn btn-sm btn-outline-primary tw-ml-auto">Ver detalle</a>
   </div>
 </article>

--- a/crunevo/templates/feed/feed.html
+++ b/crunevo/templates/feed/feed.html
@@ -9,7 +9,7 @@
 
   <!-- Contenido central -->
   <div class="col-lg-7 col-md-12">
-    <h5 class="mb-3">Feed</h5>
+    <h5 class="mb-3">Publicaciones recientes</h5>
     <form method="post" enctype="multipart/form-data" class="mb-4">
       {{ csrf.csrf_field() }}
       <div class="d-flex mb-2">
@@ -28,87 +28,8 @@
         <button class="btn btn-primary btn-sm" type="submit">Publicar</button>
       </div>
     </form>
-
-    <div class="d-flex flex-wrap gap-2 mb-4">
-      <button class="btn btn-outline-primary active" data-section-btn="apuntes">📘 Apuntes más vistos</button>
-      <button class="btn btn-outline-primary" data-section-btn="populares">🔥 Publicaciones populares</button>
-      <button class="btn btn-outline-primary" data-section-btn="usuarios">🏅 Usuarios destacados</button>
-      <button class="btn btn-outline-primary" data-section-btn="noticias">📰 Noticias de CRUNEVO</button>
-    </div>
-
-    <div class="section-apuntes mb-4" data-section="apuntes">
-      <h5 class="text-center mb-3">📘 Apuntes más vistos</h5>
-      <div class="row row-cols-1 row-cols-md-3 g-3">
-        {% for note in top_notes %}
-        <div class="col">
-          <div class="card h-100 shadow-sm d-flex flex-column justify-content-between">
-            <div class="card-body">
-              <h6 class="card-title">{{ note.title }}</h6>
-              <a href="{{ url_for('notes.detail', note_id=note.id) }}" class="btn btn-sm btn-primary">Ver</a>
-            </div>
-          </div>
-        </div>
-        {% endfor %}
-      </div>
-    </div>
-
-    <div class="section-populares mb-4" data-section="populares">
-      <h5 class="text-center mb-3">🔥 Publicaciones populares</h5>
-      <div class="row row-cols-1 row-cols-md-3 g-3">
-        {% for post in top_posts %}
-        <div class="col">
-          <div class="card h-100 shadow-sm d-flex flex-column justify-content-between">
-            <div class="card-body">
-              <p>{{ post.content[:100] }}...</p>
-              <a href="{{ url_for('feed.view_post', post_id=post.id) }}" class="btn btn-sm btn-outline-primary">Ver más</a>
-            </div>
-          </div>
-        </div>
-        {% endfor %}
-      </div>
-    </div>
-
-    <div class="section-usuarios mb-4" data-section="usuarios">
-      <h5 class="text-center mb-3">🏅 Usuarios destacados</h5>
-      <div class="row row-cols-1 row-cols-md-3 g-3">
-        {% for user in top_users %}
-        <div class="col">
-          <div class="card h-100 shadow-sm d-flex flex-column justify-content-between">
-            <div class="card-body">
-              <strong>{{ user.username }}</strong><br>
-              <span class="badge bg-info">Logros recientes</span>
-            </div>
-          </div>
-        </div>
-        {% endfor %}
-      </div>
-    </div>
-
-    <div class="card mb-4 border-info section-noticias" data-section="noticias">
-      <div class="card-header bg-info text-white d-flex justify-content-between align-items-center">
-        <span>📰 Noticias de CRUNEVO</span>
-        <button class="btn btn-sm btn-outline-light d-md-none" type="button" data-bs-toggle="collapse" data-bs-target="#feedNews" aria-expanded="false" aria-controls="feedNews">Mostrar</button>
-      </div>
-    <div id="feedNews" class="collapse d-md-block">
-        <ul class="list-group list-group-flush">
-          <li class="list-group-item">🎉 Ya puedes subir videos educativos a CRUNEVO</li>
-          <li class="list-group-item">🔧 Nuevo: ahora puedes bloquear usuarios en el chat</li>
-          <li class="list-group-item">🏆 Participa en el sorteo del mes (20 créditos)</li>
-        </ul>
-      </div>
-    </div>
-
-    <ul class="nav nav-pills justify-content-center mb-4">
-      <li class="nav-item">
-        <a href="{{ url_for('feed.index', filter='recientes') }}" class="nav-link {% if filter == 'recientes' %}active{% endif %}">🕒 Recientes</a>
-      </li>
-      <li class="nav-item">
-        <a href="{{ url_for('feed.index', filter='populares') }}" class="nav-link {% if filter == 'populares' %}active{% endif %}">🔥 Populares</a>
-      </li>
-      <li class="nav-item">
-        <a href="{{ url_for('feed.index', filter='votados') }}" class="nav-link {% if filter == 'votados' %}active{% endif %}">👍 Más votados</a>
-      </li>
-    </ul>
+    <hr>
+    <p class="text-center">Explora publicaciones de estudiantes</p>
 
   <div class="row">
     <div class="col-lg-8">
@@ -282,17 +203,6 @@ document.querySelectorAll('.donate-btn').forEach(btn => {
   });
 });
 
-const sectionButtons = document.querySelectorAll('[data-section-btn]');
-const sections = document.querySelectorAll('[data-section]');
-sectionButtons.forEach(btn => {
-  btn.addEventListener('click', () => {
-    const target = btn.dataset.sectionBtn;
-    sectionButtons.forEach(b => b.classList.toggle('active', b === btn));
-    sections.forEach(sec => {
-      sec.style.display = sec.dataset.section === target ? '' : 'none';
-    });
-  });
-});
 </script>
 <div class="modal fade" id="donateModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered">


### PR DESCRIPTION
## Summary
- load feed posts ordered by newest first and paginate
- simplify feed view to a social wall of recent posts
- add "Ver detalle" link on post cards
- document redesign in AGENTS guidelines

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68583ee4822c8325a53a54d269586a0c