### PR TITLE
Post page share and author posts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,3 +207,4 @@
 - Feed principal reorganizado para mostrar solo publicaciones recientes con paginación básica y sin secciones de apuntes (PR feed-wall-redesign).
 - Restaurado sistema de pestañas en el feed con secciones dinámicas y etiqueta "📢 Publicación" en lugar de "📝 Apunte" (PR feed-tabs-restore).
 - Rediseñada página /trending con vista propia y posts ordenados por likes (PR trending-redesign)
+- Vista individual de post ahora incluye botón de compartir y enlace a más publicaciones del autor; se añadió ruta feed.user_posts y se muestran 0 likes por defecto (PR post-page-share).

--- a/crunevo/routes/feed_routes.py
+++ b/crunevo/routes/feed_routes.py
@@ -239,6 +239,23 @@ def view_post(post_id: int):
     return render_template("feed/post_detail.html", post=post)
 
 
+@feed_bp.route("/user/<int:user_id>/posts")
+@activated_required
+def user_posts(user_id: int):
+    """List posts from a specific user."""
+    user = User.query.get_or_404(user_id)
+    page = request.args.get("page", 1, type=int)
+    pagination = (
+        Post.query.filter_by(author_id=user.id)
+        .order_by(Post.created_at.desc())
+        .paginate(page=page, per_page=10)
+    )
+    posts = pagination.items
+    return render_template(
+        "feed/user_posts.html", user=user, posts=posts, pagination=pagination
+    )
+
+
 # Alias route for backwards compatibility
 feed_bp.add_url_rule("/posts/<int:post_id>", endpoint="view_post", view_func=view_post)
 

--- a/crunevo/templates/components/post_card.html
+++ b/crunevo/templates/components/post_card.html
@@ -18,7 +18,7 @@
     {% endif %}
   {% endif %}
   <div class="tw-flex tw-gap-3 tw-text-xs tw-text-gray-500 dark:tw-text-gray-400">
-    <span><i class="bi bi-star-fill"></i> {{ post.likes }}</span>
+    <span><i class="bi bi-star-fill"></i> {{ post.likes or 0 }}</span>
     <span><i class="bi bi-chat"></i> {{ post.comments|length }}</span>
     <a href="{{ url_for('feed.view_post', post_id=post.id) }}" class="btn btn-sm btn-outline-primary tw-ml-auto">Ver detalle</a>
   </div>

--- a/crunevo/templates/feed/feed.html
+++ b/crunevo/templates/feed/feed.html
@@ -80,7 +80,7 @@
         {% endif %}
         <p class="text-muted small mb-2">
             <strong>Likes:</strong>
-            <span id="likeCount{{ post.id }}">{{ post.likes }}</span>
+            <span id="likeCount{{ post.id }}">{{ post.likes or 0 }}</span>
         </p>
         <form
             class="like-form mb-3"

--- a/crunevo/templates/feed/post_detail.html
+++ b/crunevo/templates/feed/post_detail.html
@@ -26,7 +26,7 @@
       {% endif %}
       <p class="text-muted small mb-2">
         <strong>Likes:</strong>
-        <span id="likeCount{{ post.id }}">{{ post.likes }}</span>
+        <span id="likeCount{{ post.id }}">{{ post.likes or 0 }}</span>
       </p>
       <form
         id="likeForm"
@@ -37,6 +37,17 @@
         {{ csrf.csrf_field() }}
         <button class="btn btn-outline-success btn-sm" type="submit">👍 Me gusta</button>
       </form>
+
+      <div class="d-flex gap-2 my-3">
+        <button type="button" class="btn btn-outline-secondary btn-sm share-btn" data-share-url="{{ url_for('feed.view_post', post_id=post.id, _external=True) }}">
+          <i class="bi bi-share"></i> Compartir
+        </button>
+        {% if author %}
+        <a href="{{ url_for('feed.user_posts', user_id=author.id) }}" class="btn btn-outline-primary btn-sm">
+          Ver más publicaciones de este usuario
+        </a>
+        {% endif %}
+      </div>
 
       <h6 class="mt-3 mb-2">Comentarios</h6>
       <div id="comments{{ post.id }}">

--- a/crunevo/templates/feed/trending.html
+++ b/crunevo/templates/feed/trending.html
@@ -44,7 +44,7 @@
             <img src="{{ post.file_url }}" class="img-fluid rounded mb-2">
             {% endif %}
           {% endif %}
-          <p class="fs-5 fw-bold text-danger mb-0"><i class="bi bi-heart-fill me-1"></i>{{ post.likes }}</p>
+          <p class="fs-5 fw-bold text-danger mb-0"><i class="bi bi-heart-fill me-1"></i>{{ post.likes or 0 }}</p>
         </div>
       </div>
       {% endfor %}

--- a/crunevo/templates/feed/user_posts.html
+++ b/crunevo/templates/feed/user_posts.html
@@ -1,0 +1,34 @@
+{% extends 'base.html' %}
+{% block title %}Publicaciones de {{ user.username }}{% endblock %}
+{% block content %}
+<h2 class="mb-4">Publicaciones de {{ user.username }}</h2>
+<div class="mb-3">
+  <a href="{{ url_for('feed.index') }}" class="btn btn-sm btn-secondary">&larr; Volver al feed</a>
+</div>
+<div class="row row-cols-1 g-3">
+  {% for post in posts %}
+  <div class="col">
+    {% include 'components/post_card.html' %}
+  </div>
+  {% else %}
+  <p class="text-muted">No hay publicaciones.</p>
+  {% endfor %}
+</div>
+{% if pagination.pages > 1 %}
+<nav aria-label="Navegación de páginas" class="mt-3">
+  <ul class="pagination justify-content-center">
+    {% if pagination.has_prev %}
+    <li class="page-item"><a class="page-link" href="{{ url_for('feed.user_posts', user_id=user.id, page=pagination.prev_num) }}">&laquo;</a></li>
+    {% else %}
+    <li class="page-item disabled"><span class="page-link">&laquo;</span></li>
+    {% endif %}
+    <li class="page-item disabled"><span class="page-link">{{ pagination.page }} / {{ pagination.pages }}</span></li>
+    {% if pagination.has_next %}
+    <li class="page-item"><a class="page-link" href="{{ url_for('feed.user_posts', user_id=user.id, page=pagination.next_num) }}">&raquo;</a></li>
+    {% else %}
+    <li class="page-item disabled"><span class="page-link">&raquo;</span></li>
+    {% endif %}
+  </ul>
+</nav>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- show 0 likes instead of `None` across feed templates
- improve post detail page with share button and link to author posts
- add `feed.user_posts` route and template
- document update in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68584e513a108325b904ae49e1690b5b