### PR TITLE
Add weekly top posts sidebar and view buttons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,3 +209,4 @@
 - Rediseñada página /trending con vista propia y posts ordenados por likes (PR trending-redesign)
 - Vista individual de post ahora incluye botón de compartir y enlace a más publicaciones del autor; se añadió ruta feed.user_posts y se muestran 0 likes por defecto (PR post-page-share).
 - Added share buttons, dynamic comments via AJAX and bottom-right toasts with Open Graph meta (PR feed-share-toasts).
+- Sidebar right now highlights weekly top posts and shows achievements on mobile; posts include "Ver publicación" button and badge restyled (PR feed-highlights).

--- a/crunevo/routes/auth_routes.py
+++ b/crunevo/routes/auth_routes.py
@@ -107,6 +107,13 @@ def public_profile(user_id):
     return render_template("perfil_publico.html", user=user)
 
 
+@auth_bp.route("/perfil/<username>")
+@activated_required
+def profile_by_username(username: str):
+    user = User.query.filter_by(username=username).first_or_404()
+    return render_template("perfil_publico.html", user=user)
+
+
 @auth_bp.route("/agradecer/<int:user_id>", methods=["POST"])
 @activated_required
 def agradecer(user_id):

--- a/crunevo/routes/feed_routes.py
+++ b/crunevo/routes/feed_routes.py
@@ -49,6 +49,19 @@ def get_featured_posts():
     return top_notes, top_posts, top_users
 
 
+def get_weekly_top_posts(limit=3):
+    """Return posts with most likes from the last week."""
+    from datetime import datetime, timedelta
+
+    last_week = datetime.utcnow() - timedelta(days=7)
+    return (
+        Post.query.filter(Post.created_at > last_week)
+        .order_by(Post.likes.desc())
+        .limit(limit)
+        .all()
+    )
+
+
 def get_weekly_ranking(limit=5):
     """Return recent achievements for the feed."""
     recent_achievements = (
@@ -191,6 +204,7 @@ def index():
     top_ranked, recent_achievements = get_weekly_ranking()
     latest_notes = Note.query.order_by(Note.created_at.desc()).limit(5).all()
     top_notes, top_posts, top_users = get_featured_posts()
+    weekly_top_posts = get_weekly_top_posts()
     return render_template(
         "feed/feed.html",
         posts=posts,
@@ -200,6 +214,7 @@ def index():
         latest_notes=latest_notes,
         top_notes=top_notes,
         top_posts=top_posts,
+        weekly_top_posts=weekly_top_posts,
         top_users=top_users,
         news=[],
     )

--- a/crunevo/templates/components/post_card.html
+++ b/crunevo/templates/components/post_card.html
@@ -17,12 +17,12 @@
       <img src="{{ post.file_url }}" alt="imagen" class="tw-rounded tw-w-full">
     {% endif %}
   {% endif %}
+  <a href="{{ url_for('feed.view_post', post_id=post.id) }}" class="btn btn-sm btn-outline-primary">Ver publicación</a>
   <div class="tw-flex tw-gap-3 tw-text-xs tw-text-gray-500 dark:tw-text-gray-400">
     <span><i class="bi bi-star-fill"></i> {{ post.likes or 0 }}</span>
     <span><i class="bi bi-chat"></i> {{ post.comments|length }}</span>
     <button type="button" class="btn btn-sm btn-outline-secondary share-btn" data-share-url="{{ url_for('feed.view_post', post_id=post.id, _external=True) }}">
       <i class="bi bi-share"></i>
     </button>
-    <a href="{{ url_for('feed.view_post', post_id=post.id) }}" class="btn btn-sm btn-outline-primary tw-ml-auto">Ver detalle</a>
   </div>
 </article>

--- a/crunevo/templates/feed/feed.html
+++ b/crunevo/templates/feed/feed.html
@@ -48,7 +48,7 @@
       </div>
     </form>
     <hr>
-    <p class="text-center">Explora publicaciones de estudiantes</p>
+    <h5 class="mb-3 text-muted text-center">📢 Explora las publicaciones más recientes de estudiantes</h5>
 
   <div class="row">
     <div class="col-lg-8">
@@ -56,8 +56,12 @@
     <div class="card mb-3 shadow-sm">
       <div class="card-body">
         {% set badge = '💬 Debate' if post.type == 'foro' else '🏅 Logro' if post.type == 'logro' else '📢 Publicación' %}
-        <span class="badge bg-secondary mb-2">{{ badge }}</span>
         <div class="d-flex align-items-center mb-2">
+          {% if badge == '📢 Publicación' %}
+          <span class="badge bg-primary me-2">{{ badge }}</span>
+          {% else %}
+          <span class="badge bg-secondary me-2">{{ badge }}</span>
+          {% endif %}
           {% set author = post.author %}
           {% if author %}
           <img src="{{ author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
@@ -78,6 +82,7 @@
           <img src="{{ post.file_url }}" class="img-fluid rounded mb-2">
           {% endif %}
         {% endif %}
+        <a href="{{ url_for('feed.view_post', post_id=post.id) }}" class="btn btn-sm btn-outline-primary mb-2">Ver publicación</a>
         <p class="text-muted small mb-2">
             <strong>Likes:</strong>
             <span id="likeCount{{ post.id }}">{{ post.likes or 0 }}</span>
@@ -136,14 +141,14 @@
       </div>
       {% endfor %}
   </div>
-  <div class="col-lg-4 mt-4 mt-lg-0">
+  <div class="col-lg-4 mt-4 mt-lg-0 d-none d-lg-block">
     <div class="card mb-3">
-      <div class="card-header bg-success text-white">🏆 Top de la semana</div>
+      <div class="card-header bg-primary text-white">💡 Publicaciones destacadas</div>
       <ul class="list-group list-group-flush">
-        {% for user in top_ranked %}
-        <li class="list-group-item">
-          <strong>{{ user.username }}</strong><br>
-          Créditos: {{ user.credits }}
+        {% for p in weekly_top_posts %}
+        <li class="list-group-item d-flex justify-content-between align-items-start">
+          <a href="{{ url_for('feed.view_post', post_id=p.id) }}">{{ p.content|truncate(40) }}</a>
+          <span class="badge bg-primary">{{ p.likes or 0 }}</span>
         </li>
         {% endfor %}
       </ul>
@@ -162,6 +167,31 @@
   </div> <!-- Fin row de publicaciones -->
   </div> <!-- cierre feed-section publicaciones -->
 
+  <div class="d-lg-none mt-4">
+    <h5 class="text-center">🏆 Ranking y logros</h5>
+    <div class="card mb-3">
+      <div class="card-header bg-primary text-white">💡 Publicaciones destacadas</div>
+      <ul class="list-group list-group-flush">
+        {% for p in weekly_top_posts %}
+        <li class="list-group-item d-flex justify-content-between align-items-start">
+          <a href="{{ url_for('feed.view_post', post_id=p.id) }}">{{ p.content|truncate(40) }}</a>
+          <span class="badge bg-primary">{{ p.likes or 0 }}</span>
+        </li>
+        {% endfor %}
+      </ul>
+    </div>
+    <div class="card">
+      <div class="card-header bg-info text-white">🧩 Logros recientes</div>
+      <ul class="list-group list-group-flush">
+        {% for username, badge_code, timestamp in recent_achievements %}
+        <li class="list-group-item">
+          <strong>{{ username }}</strong>: {{ badge_code }} <span class="text-muted">{{ timestamp.strftime('%Y-%m-%d') }}</span>
+        </li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+
   <div data-section="apuntes" class="feed-section d-none">
     <h5 class="mb-3">Últimos apuntes</h5>
     <div class="row">
@@ -179,7 +209,11 @@
     <div class="card mb-3 shadow-sm">
       <div class="card-body">
         {% set badge = '💬 Debate' if post.type == 'foro' else '🏅 Logro' if post.type == 'logro' else '📢 Publicación' %}
-        <span class="badge bg-secondary mb-2">{{ badge }}</span>
+        {% if badge == '📢 Publicación' %}
+        <span class="badge bg-primary me-2">{{ badge }}</span>
+        {% else %}
+        <span class="badge bg-secondary me-2">{{ badge }}</span>
+        {% endif %}
         <p class="card-text">{{ post.content }}</p>
         <small class="text-muted">{{ post.likes }} likes</small>
       </div>


### PR DESCRIPTION
## Summary
- add `get_weekly_top_posts` helper and expose results in feed
- show weekly top posts widget on desktop and mobile
- add "Ver publicación" buttons to posts
- restyle publication badge next to author
- support public profile by username
- update agent notes

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685862c4c3988325af616cda0fc4b3ab