### PR TITLE
Implement basic user notifications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,3 +213,4 @@
 - Public profile links now use usernames, new profile page lists notes, posts and achievements, and feed posts include a "Ver perfil" button. Added user notes route (PR feed-profile-links).
 - Redesigned public profile with larger avatar, achievements grid and posts/notes sections. Added /perfil/<username>/apuntes route and updated templates to use profile_by_username links (PR public-profile-redesign).
 - Fixed public profile template to avoid Jinja 'with' syntax (PR profile-jinja-fix).
+- Implemented basic user notification system with model, utility, routes and navbar indicator (PR notifications-basic).

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -64,6 +64,7 @@ def create_app():
     from .routes.admin_blocker import admin_blocker_bp
     from .routes.admin.email_routes import admin_email_bp
     from .routes.ranking_routes import ranking_bp
+    from .routes.notifications_routes import noti_bp
     from .routes.errors import errors_bp
     from .routes.health_routes import health_bp
 
@@ -86,6 +87,7 @@ def create_app():
         app.register_blueprint(feed_bp)
         app.register_blueprint(store_bp)
         app.register_blueprint(chat_bp)
+        app.register_blueprint(noti_bp)
         app.register_blueprint(ranking_bp)
         app.register_blueprint(errors_bp)
         app.register_blueprint(admin_blocker_bp)

--- a/crunevo/models/__init__.py
+++ b/crunevo/models/__init__.py
@@ -22,3 +22,4 @@ from .review import Review  # noqa: F401
 from .question import Question  # noqa: F401
 from .answer import Answer  # noqa: F401
 from .saved_post import SavedPost  # noqa: F401
+from .notification import Notification  # noqa: F401

--- a/crunevo/models/notification.py
+++ b/crunevo/models/notification.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+from crunevo.extensions import db
+
+
+class Notification(db.Model):
+    __tablename__ = "notifications"
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    message = db.Column(db.String(255), nullable=False)
+    url = db.Column(db.String(255), nullable=True)
+    is_read = db.Column(db.Boolean, default=False)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+
+    user = db.relationship("User", back_populates="notifications")

--- a/crunevo/models/user.py
+++ b/crunevo/models/user.py
@@ -28,6 +28,9 @@ class User(UserMixin, db.Model):
     )
     comments = db.relationship("Comment", backref="author", lazy=True)
     post_comments = db.relationship("PostComment", backref="author", lazy=True)
+    notifications = db.relationship(
+        "Notification", back_populates="user", lazy="dynamic"
+    )
 
     def set_password(self, password):
         self.password_hash = generate_hash(password)

--- a/crunevo/routes/auth_routes.py
+++ b/crunevo/routes/auth_routes.py
@@ -18,7 +18,7 @@ import cloudinary.uploader
 from werkzeug.utils import secure_filename
 from crunevo.extensions import db
 from crunevo.models import User, Note
-from crunevo.utils import spend_credit, record_login
+from crunevo.utils import spend_credit, record_login, send_notification
 from crunevo.constants import CreditReasons
 
 IS_ADMIN = os.environ.get("ADMIN_INSTANCE") == "1"
@@ -133,6 +133,9 @@ def agradecer(user_id):
     try:
         spend_credit(
             current_user, 1, CreditReasons.AGRADECIMIENTO, related_id=target.id
+        )
+        send_notification(
+            target.id, f"{current_user.username} te ha agradecido con 1 crédito."
         )
         flash("¡Gracias enviado!")
     except ValueError:

--- a/crunevo/routes/feed_routes.py
+++ b/crunevo/routes/feed_routes.py
@@ -24,7 +24,11 @@ from crunevo.models import (
     UserAchievement,
 )
 from crunevo.forms import FeedNoteForm, FeedImageForm
-from crunevo.utils import create_feed_item_for_all, unlock_achievement
+from crunevo.utils import (
+    create_feed_item_for_all,
+    unlock_achievement,
+    send_notification,
+)
 from crunevo.utils.credits import add_credit, spend_credit
 from crunevo.constants import CreditReasons, AchievementCodes
 import redis
@@ -299,6 +303,12 @@ def like_post(post_id):
     if post.likes is None:
         post.likes = 0
     post.likes += 1
+    if post.author_id != current_user.id:
+        send_notification(
+            post.author_id,
+            f"{current_user.username} le dio like a tu publicación",
+            url_for("feed.view_post", post_id=post.id),
+        )
     db.session.commit()
     return jsonify({"likes": post.likes})
 

--- a/crunevo/routes/notifications_routes.py
+++ b/crunevo/routes/notifications_routes.py
@@ -1,0 +1,17 @@
+from flask import Blueprint, render_template
+from flask_login import current_user
+from crunevo.utils.helpers import activated_required
+from crunevo.models import Notification
+
+noti_bp = Blueprint("noti", __name__)
+
+
+@noti_bp.route("/notificaciones")
+@activated_required
+def ver_notificaciones():
+    notificaciones = (
+        Notification.query.filter_by(user_id=current_user.id)
+        .order_by(Notification.timestamp.desc())
+        .all()
+    )
+    return render_template("notificaciones/lista.html", notificaciones=notificaciones)

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -23,6 +23,14 @@
         <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('auth.perfil') }}"><i class="bi bi-person-circle me-1"></i>Perfil</a></li>
         <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('auth.logout') }}"><i class="bi bi-box-arrow-right me-1"></i>Salir</a></li>
         <li class="nav-item text-white mx-2"><i class="bi bi-coin"></i> {{ current_user.credits }}</li>
+        <li class="nav-item">
+          <a class="nav-link text-white" href="{{ url_for('noti.ver_notificaciones') }}">
+            <i class="bi bi-bell"></i>
+            {% if current_user.notifications.filter_by(is_read=False).count() > 0 %}
+              <span class="badge bg-danger">{{ current_user.notifications.filter_by(is_read=False).count() }}</span>
+            {% endif %}
+          </a>
+        </li>
         {% if current_user.verification_level >= 2 %}
           {% include 'components/edu_badge.html' %}
         {% endif %}

--- a/crunevo/templates/notificaciones/lista.html
+++ b/crunevo/templates/notificaciones/lista.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container my-4">
+  <h3>🔔 Notificaciones</h3>
+  <ul class="list-group">
+    {% for n in notificaciones %}
+    <li class="list-group-item {% if not n.is_read %}list-group-item-info{% endif %}">
+      <a href="{{ n.url or '#' }}">{{ n.message }}</a>
+      <small class="text-muted d-block">{{ n.timestamp|timesince }} atrás</small>
+    </li>
+    {% else %}
+    <li class="list-group-item">No tienes notificaciones.</li>
+    {% endfor %}
+  </ul>
+</div>
+{% endblock %}
+

--- a/crunevo/utils/__init__.py
+++ b/crunevo/utils/__init__.py
@@ -3,3 +3,4 @@ from .credits import add_credit, spend_credit  # noqa: F401
 from .achievements import unlock_achievement  # noqa: F401
 from .login_history import record_login  # noqa: F401
 from .feed import create_feed_item_for_all  # noqa: F401
+from .notify import send_notification  # noqa: F401

--- a/crunevo/utils/notify.py
+++ b/crunevo/utils/notify.py
@@ -1,0 +1,8 @@
+from crunevo.models.notification import Notification
+from crunevo.extensions import db
+
+
+def send_notification(user_id, message, url=None):
+    notif = Notification(user_id=user_id, message=message, url=url)
+    db.session.add(notif)
+    db.session.commit()


### PR DESCRIPTION
## Summary
- add `Notification` model and register in models package
- allow users to access `notifications` relationship on `User`
- provide `send_notification` helper
- notify post authors on likes and users on credits thanks
- expose notifications list at `/notificaciones`
- show bell icon with unread count in navbar
- document change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68587792a57c83259b8f199e4af8dcbe