### PR TITLE
Fix sidebar duplication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,3 +217,4 @@
 - Added migration for notifications table to fix runtime errors (QA notifications-migration).
 
 - Added quick filter sidebar on feed, PDF preview on upload form, chat messages with timestamps and notifications on comments/messages (PR feed-sidebar-chat-preview).
+- Sidebar derecho unificado: apuntes, logros y ranking en una sola card; se eliminó bloque duplicado de logros en el feed (PR sidebar-right-unify).

--- a/crunevo/templates/components/sidebar_right.html
+++ b/crunevo/templates/components/sidebar_right.html
@@ -1,33 +1,33 @@
-<div class="sidebar">
-  <div class="mb-4">
-    <h6 class="text-muted">🏆 Ranking semanal</h6>
-    <ul class="list-group small">
-      {% for u in top_ranked or [] %}
-      <li class="list-group-item d-flex justify-content-between align-items-start">
+<div class="card shadow-sm border-0 mb-4">
+  <div class="card-body">
+    <h6 class="text-uppercase text-muted mb-3">📚 Últimos apuntes</h6>
+    <ul class="list-group list-group-flush mb-3">
+      {% for n in latest_notes or [] %}
+      <li class="list-group-item px-0">
+        <a href="{{ url_for('notes.view_note', id=n.id) }}">{{ n.title }}</a>
+      </li>
+      {% endfor %}
+    </ul>
+    <hr>
+    <h6 class="text-uppercase text-muted mb-3">🧩 Logros recientes</h6>
+    <ul class="list-group list-group-flush mb-3">
+      {% for username, badge_code, timestamp in recent_achievements or [] %}
+      <li class="list-group-item px-0">
+        <strong>{{ username }}</strong> – {{ badge_code }}
+      </li>
+      {% endfor %}
+    </ul>
+    {% if top_ranked %}
+    <hr>
+    <h6 class="text-uppercase text-muted mb-3">🏆 Ranking semanal</h6>
+    <ul class="list-group list-group-flush">
+      {% for u in top_ranked %}
+      <li class="list-group-item d-flex justify-content-between align-items-start px-0">
         <span>{{ u.username }}</span>
         <span class="badge bg-success">{{ u.credits }}</span>
       </li>
       {% endfor %}
     </ul>
-  </div>
-  <div class="mb-4">
-    <h6 class="text-muted">📚 Últimos apuntes</h6>
-    <ul class="list-group small">
-      {% for n in latest_notes or [] %}
-      <li class="list-group-item">
-        <a href="{{ url_for('notes.view_note', id=n.id) }}">{{ n.title }}</a>
-      </li>
-      {% endfor %}
-    </ul>
-  </div>
-  <div class="mb-4">
-    <h6 class="text-muted">🧩 Logros recientes</h6>
-    <ul class="list-group small">
-      {% for username, badge_code, timestamp in recent_achievements or [] %}
-      <li class="list-group-item">
-        <strong>{{ username }}</strong> – {{ badge_code }}
-      </li>
-      {% endfor %}
-    </ul>
+    {% endif %}
   </div>
 </div>

--- a/crunevo/templates/feed/feed.html
+++ b/crunevo/templates/feed/feed.html
@@ -158,16 +158,6 @@
       </ul>
     </div>
 
-    <div class="card">
-      <div class="card-header bg-info text-white">🧩 Logros recientes</div>
-      <ul class="list-group list-group-flush">
-        {% for username, badge_code, timestamp in recent_achievements %}
-        <li class="list-group-item">
-          <strong>{{ username }}</strong>: {{ badge_code }} <span class="text-muted">{{ timestamp.strftime('%Y-%m-%d') }}</span>
-        </li>
-        {% endfor %}
-      </ul>
-    </div>
   </div> <!-- Fin row de publicaciones -->
   </div> <!-- cierre feed-section publicaciones -->
 
@@ -184,16 +174,7 @@
         {% endfor %}
       </ul>
     </div>
-    <div class="card">
-      <div class="card-header bg-info text-white">🧩 Logros recientes</div>
-      <ul class="list-group list-group-flush">
-        {% for username, badge_code, timestamp in recent_achievements %}
-        <li class="list-group-item">
-          <strong>{{ username }}</strong>: {{ badge_code }} <span class="text-muted">{{ timestamp.strftime('%Y-%m-%d') }}</span>
-        </li>
-        {% endfor %}
-      </ul>
-    </div>
+    {% include 'components/sidebar_right.html' %}
   </div>
 
   <div data-section="apuntes" class="feed-section d-none">


### PR DESCRIPTION
## Summary
- consolidate right sidebar with notes, achievements and weekly ranking
- show new sidebar after posts on mobile
- document sidebar change in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685899e1a74883259784a1a7233c8181