### PR TITLE
Fix mobile duplication on feed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,3 +218,4 @@
 
 - Added quick filter sidebar on feed, PDF preview on upload form, chat messages with timestamps and notifications on comments/messages (PR feed-sidebar-chat-preview).
 - Sidebar derecho unificado: apuntes, logros y ranking en una sola card; se eliminó bloque duplicado de logros en el feed (PR sidebar-right-unify).
+- Removed mobile duplicate notes/achievements block from feed (PR feed-mobile-cleanup).

--- a/crunevo/templates/feed/feed.html
+++ b/crunevo/templates/feed/feed.html
@@ -161,21 +161,7 @@
   </div> <!-- Fin row de publicaciones -->
   </div> <!-- cierre feed-section publicaciones -->
 
-  <div class="d-lg-none mt-4">
-    <h5 class="text-center">🏆 Ranking y logros</h5>
-    <div class="card mb-3">
-      <div class="card-header bg-primary text-white">💡 Publicaciones destacadas</div>
-      <ul class="list-group list-group-flush">
-        {% for p in weekly_top_posts %}
-        <li class="list-group-item d-flex justify-content-between align-items-start">
-          <a href="{{ url_for('feed.view_post', post_id=p.id) }}">{{ p.content|truncate(40) }}</a>
-          <span class="badge bg-primary">{{ p.likes or 0 }}</span>
-        </li>
-        {% endfor %}
-      </ul>
-    </div>
-    {% include 'components/sidebar_right.html' %}
-  </div>
+
 
   <div data-section="apuntes" class="feed-section d-none">
     <h5 class="mb-3">Últimos apuntes</h5>


### PR DESCRIPTION
## Summary
- remove duplicated notes and achievements block on mobile
- log the change in AGENTS guidelines

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68589ea92b0483258b9b30786449e0c0