### PR TITLE
Add weekly missions system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,3 +219,4 @@
 - Added quick filter sidebar on feed, PDF preview on upload form, chat messages with timestamps and notifications on comments/messages (PR feed-sidebar-chat-preview).
 - Sidebar derecho unificado: apuntes, logros y ranking en una sola card; se eliminó bloque duplicado de logros en el feed (PR sidebar-right-unify).
 - Removed mobile duplicate notes/achievements block from feed (PR feed-mobile-cleanup).
+- Added weekly missions feature with models, routes, template and navbar link (PR missions-basic).

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -66,6 +66,7 @@ def create_app():
     from .routes.ranking_routes import ranking_bp
     from .routes.notifications_routes import noti_bp
     from .routes.errors import errors_bp
+    from .routes.missions_routes import missions_bp
     from .routes.health_routes import health_bp
 
     is_admin = os.environ.get("ADMIN_INSTANCE") == "1"
@@ -88,6 +89,7 @@ def create_app():
         app.register_blueprint(store_bp)
         app.register_blueprint(chat_bp)
         app.register_blueprint(noti_bp)
+        app.register_blueprint(missions_bp)
         app.register_blueprint(ranking_bp)
         app.register_blueprint(errors_bp)
         app.register_blueprint(admin_blocker_bp)

--- a/crunevo/models/__init__.py
+++ b/crunevo/models/__init__.py
@@ -23,3 +23,4 @@ from .question import Question  # noqa: F401
 from .answer import Answer  # noqa: F401
 from .saved_post import SavedPost  # noqa: F401
 from .notification import Notification  # noqa: F401
+from .mission import Mission, UserMission  # noqa: F401

--- a/crunevo/models/mission.py
+++ b/crunevo/models/mission.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+from crunevo.extensions import db
+
+
+class Mission(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    code = db.Column(db.String(50), unique=True, nullable=False)
+    description = db.Column(db.String(200), nullable=False)
+    goal = db.Column(db.Integer, default=1)
+    credit_reward = db.Column(db.Integer, default=0)
+    achievement_code = db.Column(db.String(50))
+
+
+class UserMission(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    mission_id = db.Column(db.Integer, db.ForeignKey("mission.id"), nullable=False)
+    completed_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    user = db.relationship("User", backref="missions")
+    mission = db.relationship("Mission")

--- a/crunevo/routes/missions_routes.py
+++ b/crunevo/routes/missions_routes.py
@@ -1,0 +1,84 @@
+from datetime import datetime, timedelta
+from flask import Blueprint, render_template
+from flask_login import current_user
+from sqlalchemy import func
+from crunevo.models import Mission, UserMission, Note, PostComment, Post
+from crunevo.extensions import db
+from crunevo.utils.credits import add_credit
+from crunevo.constants import CreditReasons
+
+missions_bp = Blueprint("missions", __name__, url_prefix="/misiones")
+
+
+@missions_bp.route("/")
+def list_missions():
+    if not current_user.is_authenticated:
+        return render_template("misiones/index.html", missions=[])
+
+    one_week_ago = datetime.utcnow() - timedelta(days=7)
+
+    # Ensure default missions exist
+    defaults = [
+        {
+            "code": "upload_note",
+            "description": "Subir 1 apunte esta semana",
+            "goal": 1,
+            "credit_reward": 5,
+        },
+        {
+            "code": "comment_posts",
+            "description": "Comentar en 3 publicaciones",
+            "goal": 3,
+            "credit_reward": 3,
+        },
+        {
+            "code": "receive_likes",
+            "description": "Recibir 5 likes en tus publicaciones",
+            "goal": 5,
+            "credit_reward": 3,
+        },
+    ]
+    for d in defaults:
+        if not Mission.query.filter_by(code=d["code"]).first():
+            db.session.add(Mission(**d))
+    db.session.commit()
+
+    missions = Mission.query.all()
+    mission_states = []
+    for m in missions:
+        progress = 0
+        if m.code == "upload_note":
+            progress = (
+                Note.query.filter_by(user_id=current_user.id)
+                .filter(Note.created_at >= one_week_ago)
+                .count()
+            )
+        elif m.code == "comment_posts":
+            progress = (
+                PostComment.query.filter_by(author_id=current_user.id)
+                .filter(PostComment.timestamp >= one_week_ago)
+                .count()
+            )
+        elif m.code == "receive_likes":
+            progress = (
+                db.session.query(func.coalesce(func.sum(Post.likes), 0))
+                .filter_by(author_id=current_user.id)
+                .scalar()
+                or 0
+            )
+        completed = progress >= m.goal
+        record = UserMission.query.filter_by(
+            user_id=current_user.id, mission_id=m.id
+        ).first()
+        if completed and not record:
+            db.session.add(UserMission(user_id=current_user.id, mission_id=m.id))
+            add_credit(current_user, m.credit_reward, CreditReasons.DONACION)
+            db.session.commit()
+        mission_states.append(
+            {
+                "mission": m,
+                "progress": progress,
+                "completed": completed or record is not None,
+            }
+        )
+    return render_template("misiones/index.html", missions=mission_states)

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -15,6 +15,7 @@
         <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('notes.list_notes') }}"><i class="bi bi-journal-text me-1"></i>Apuntes</a></li>
         <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('store.store_index') }}"><i class="bi bi-bag me-1"></i>Tienda</a></li>
         <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('ranking.show_ranking') }}"><i class="bi bi-trophy me-1"></i>Ranking</a></li>
+        <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('missions.list_missions') }}"><i class="bi bi-check2-circle me-1"></i>Misiones</a></li>
         <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('chat.chat_index') }}"><i class="bi bi-chat-dots me-1"></i>Chat</a></li>
         {% if config.ADMIN_INSTANCE and current_user.is_authenticated and current_user.role == 'admin' %}
         <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('admin.dashboard') }}"><i class="bi bi-speedometer2 me-1"></i>Admin</a></li>

--- a/crunevo/templates/misiones/index.html
+++ b/crunevo/templates/misiones/index.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container my-4">
+  <h1 class="mb-4">Misiones semanales</h1>
+  <div class="row row-cols-1 row-cols-md-2 g-3">
+  {% for m in missions %}
+    <div class="col">
+      <div class="card h-100">
+        <div class="card-body d-flex flex-column">
+          <h5 class="card-title">{{ m.mission.description }}</h5>
+          <p class="card-text">Progreso: {{ m.progress }}/{{ m.mission.goal }}</p>
+          {% if m.completed %}
+          <span class="badge bg-success mt-auto">✔ Completada</span>
+          {% else %}
+          <span class="badge bg-secondary mt-auto">❌ Pendiente</span>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  {% else %}
+    <p class="text-muted">No hay misiones.</p>
+  {% endfor %}
+  </div>
+</div>
+{% endblock %}

--- a/migrations/versions/b1b2b3b4c5d6_add_missions.py
+++ b/migrations/versions/b1b2b3b4c5d6_add_missions.py
@@ -1,0 +1,41 @@
+"""add missions tables
+
+Revision ID: b1b2b3b4c5d6
+Revises: a17386de259a
+Create Date: 2025-07-02 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "b1b2b3b4c5d6"
+down_revision = "a17386de259a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "mission",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("code", sa.String(length=50), nullable=False, unique=True),
+        sa.Column("description", sa.String(length=200), nullable=False),
+        sa.Column("goal", sa.Integer(), nullable=True),
+        sa.Column("credit_reward", sa.Integer(), nullable=True),
+        sa.Column("achievement_code", sa.String(length=50), nullable=True),
+    )
+    op.create_table(
+        "user_mission",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("user.id"), nullable=False),
+        sa.Column(
+            "mission_id", sa.Integer(), sa.ForeignKey("mission.id"), nullable=False
+        ),
+        sa.Column("completed_at", sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_table("user_mission")
+    op.drop_table("mission")


### PR DESCRIPTION
## Summary
- create Mission and UserMission models
- expose `/misiones` blueprint with default weekly tasks
- register missions blueprint and add navbar link
- document feature in AGENTS guidelines
- generate migration for missions

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6858ac40ad788325ba2e459611793e39