### PR TITLE
Store price shows S/0 if free

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,3 +221,4 @@
 - Removed mobile duplicate notes/achievements block from feed (PR feed-mobile-cleanup).
 - Added weekly missions feature with models, routes, template and navbar link (PR missions-basic).
 - Chat page now shows an 'En construcción' message and no longer provides messaging UI (PR chat-placeholder).
+- Precios en store.html ahora muestran "S/ 0" cuando el producto es gratuito (PR store-free-price).

--- a/crunevo/templates/store/store.html
+++ b/crunevo/templates/store/store.html
@@ -94,11 +94,23 @@
                       <small class="text-muted">{{ '%.1f'|format(r) }}</small>
                     </div>
                     <p class="card-text small text-muted mb-1">{{ product.description }}</p>
-                    {% if product.price_soles %}
-                      <p class="mb-1 text-primary fw-bold">S/ {{ '%.2f' | format(product.price_soles) }}</p>
+                    {% if product.price_soles is not none %}
+                      <p class="mb-1 text-primary fw-bold">
+                        {% if product.price_soles == 0 %}
+                          S/ 0
+                        {% else %}
+                          S/ {{ '%.2f' | format(product.price_soles) }}
+                        {% endif %}
+                      </p>
                     {% endif %}
-                    {% if product.price_credits %}
-                      <p class="mb-1 text-warning fw-bold">{{ product.price_credits }} créditos</p>
+                    {% if product.price_credits is not none %}
+                      <p class="mb-1 text-warning fw-bold">
+                        {% if product.price_credits == 0 %}
+                          0 créditos
+                        {% else %}
+                          {{ product.price_credits }} créditos
+                        {% endif %}
+                      </p>
                     {% endif %}
                     <div class="mb-2">
                       {% if product.is_new %}<span class="badge bg-success">Nuevo</span>{% endif %}


### PR DESCRIPTION
## Summary
- display prices for free products on the main store page
- document change in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6858b00bc50c8325a110e3f15df99764