### PR TITLE
Cleanup feed and add PDF previews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,3 +224,4 @@
 - Precios en store.html ahora muestran "S/ 0" cuando el producto es gratuito (PR store-free-price).
 
 - Corrigio plantillas de tienda para usar `product.price` en lugar de `price_soles` evitando UndefinedError (PR store-price-fix).
+- Se movió la sección "Últimos apuntes" del feed a /apuntes y se mejoró el sidebar con botones. Las tarjetas de apuntes cargan vista previa PDF usando PDF.js. Productos de la tienda muestran "Desde S/ 0", badge de categoría y botón de compartir (PR feed-store-pdf-preview).

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -28,6 +28,29 @@ function showToast(message, options = {}) {
   new bootstrap.Toast(div).show();
 }
 
+function initPdfPreviews() {
+  if (typeof pdfjsLib === 'undefined') return;
+  document.querySelectorAll('canvas.pdf-thumb').forEach((canvas) => {
+    const url = canvas.dataset.pdf;
+    if (!url) return;
+    pdfjsLib
+      .getDocument(url)
+      .promise.then((pdf) => pdf.getPage(1))
+      .then((page) => {
+        const viewport = page.getViewport({ scale: 0.5 });
+        canvas.height = viewport.height;
+        canvas.width = viewport.width;
+        page.render({ canvasContext: canvas.getContext('2d'), viewport });
+      })
+      .catch(() => {
+        const div = document.createElement('div');
+        div.className = 'text-center text-muted small';
+        div.textContent = 'Vista previa no disponible';
+        canvas.replaceWith(div);
+      });
+  });
+}
+
 
 
 function updateThemeIcons() {
@@ -58,6 +81,8 @@ document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('.toast').forEach((t) => {
     new bootstrap.Toast(t).show();
   });
+
+  initPdfPreviews();
 
   // load feed on feed page
   if (typeof loadFeed === 'function' && document.getElementById('feed')) {

--- a/crunevo/templates/components/feed_sidebar.html
+++ b/crunevo/templates/components/feed_sidebar.html
@@ -1,9 +1,9 @@
 <div class="card shadow-sm border-0 mb-4 sidebar">
   <div class="card-body">
     <h6 class="text-uppercase text-muted mb-3">Filtros rápidos</h6>
-    <ul class="nav flex-column small">
-      <li class="nav-item mb-2"><a class="nav-link px-0" href="{{ url_for('feed.index') }}">Recientes</a></li>
-      <li class="nav-item mb-2"><a class="nav-link px-0" href="{{ url_for('feed.trending') }}">Más votados</a></li>
-    </ul>
+    <div class="d-grid gap-2">
+      <a class="btn btn-outline-primary btn-sm" href="{{ url_for('feed.index') }}"><i class="bi bi-clock-history"></i> Recientes</a>
+      <a class="btn btn-outline-primary btn-sm" href="{{ url_for('feed.trending') }}"><i class="bi bi-fire"></i> Más votados</a>
+    </div>
   </div>
 </div>

--- a/crunevo/templates/components/note_card.html
+++ b/crunevo/templates/components/note_card.html
@@ -1,9 +1,7 @@
 <article class="tw-rounded-2xl tw-shadow-sm tw-bg-white dark:tw-bg-gray-900 tw-p-4 tw-space-y-2 mb-6">
-  {% if note.thumbnail_url %}
-    <img src="{{ note.thumbnail_url }}" alt="preview" class="tw-rounded mb-4 tw-w-full">
-  {% else %}
-    <img src="{{ url_for('static', filename='img/placeholder.svg') }}" alt="preview" class="tw-rounded mb-4 tw-w-full">
-  {% endif %}
+  <div class="pdf-thumb-container">
+    <canvas class="pdf-thumb tw-w-full tw-rounded mb-3" data-pdf="{{ note.filename }}"></canvas>
+  </div>
   <h3 class="tw-text-lg tw-font-semibold mb-2">{{ note.title }}</h3>
   <ul class="tw-flex tw-flex-wrap tw-gap-1 tw-text-sm tw-text-gray-500 dark:tw-text-gray-400 mb-4">
     {% for tag in (note.tags or '').split(',') %}

--- a/crunevo/templates/components/sidebar_right.html
+++ b/crunevo/templates/components/sidebar_right.html
@@ -1,14 +1,6 @@
 <div class="card shadow-sm border-0 mb-4">
   <div class="card-body">
-    <h6 class="text-uppercase text-muted mb-3">📚 Últimos apuntes</h6>
-    <ul class="list-group list-group-flush mb-3">
-      {% for n in latest_notes or [] %}
-      <li class="list-group-item px-0">
-        <a href="{{ url_for('notes.view_note', id=n.id) }}">{{ n.title }}</a>
-      </li>
-      {% endfor %}
-    </ul>
-    <hr>
+  {# sección de últimos apuntes trasladada a /apuntes #}
     <h6 class="text-uppercase text-muted mb-3">🧩 Logros recientes</h6>
     <ul class="list-group list-group-flush mb-3">
       {% for username, badge_code, timestamp in recent_achievements or [] %}

--- a/crunevo/templates/feed/feed.html
+++ b/crunevo/templates/feed/feed.html
@@ -154,6 +154,8 @@
           <a href="{{ url_for('feed.view_post', post_id=p.id) }}">{{ p.content|truncate(40) }}</a>
           <span class="badge bg-primary">{{ p.likes or 0 }}</span>
         </li>
+        {% else %}
+        <li class="list-group-item text-muted text-center">Aún no hay publicaciones destacadas esta semana</li>
         {% endfor %}
       </ul>
     </div>
@@ -258,4 +260,9 @@
     </a>
   </div>
 </nav>
+<script src="{{ url_for('static', filename='pdfjs/pdf.min.js') }}"></script>
+<script>
+  pdfjsLib.GlobalWorkerOptions.workerSrc = "{{ url_for('static', filename='pdfjs/pdf.worker.min.js') }}";
+  initPdfPreviews();
+</script>
 {% endblock %}

--- a/crunevo/templates/feed/trending.html
+++ b/crunevo/templates/feed/trending.html
@@ -115,9 +115,10 @@
 {% endblock %}
 
 {% block body_end %}
+{{ super() }}
 <script>
   document.querySelectorAll('[data-trend-tab]').forEach(btn => {
-    btn.addEventListener('click', () => {
+  btn.addEventListener('click', () => {
       const target = btn.dataset.trendTab;
       document.querySelectorAll('.trend-section').forEach(section => {
         section.classList.toggle('d-none', section.dataset.section !== target);
@@ -126,5 +127,10 @@
       btn.classList.add('active');
     });
   });
+</script>
+<script src="{{ url_for('static', filename='pdfjs/pdf.min.js') }}"></script>
+<script>
+  pdfjsLib.GlobalWorkerOptions.workerSrc = "{{ url_for('static', filename='pdfjs/pdf.worker.min.js') }}";
+  initPdfPreviews();
 </script>
 {% endblock %}

--- a/crunevo/templates/feed/user_notes.html
+++ b/crunevo/templates/feed/user_notes.html
@@ -33,3 +33,12 @@
 {% endif %}
 {% endblock %}
 
+{% block body_end %}
+{{ super() }}
+<script src="{{ url_for('static', filename='pdfjs/pdf.min.js') }}"></script>
+<script>
+  pdfjsLib.GlobalWorkerOptions.workerSrc = "{{ url_for('static', filename='pdfjs/pdf.worker.min.js') }}";
+  initPdfPreviews();
+</script>
+{% endblock %}
+

--- a/crunevo/templates/notes/list.html
+++ b/crunevo/templates/notes/list.html
@@ -8,6 +8,7 @@
   <!-- Contenido central -->
   <div class="col-lg-7 col-md-12">
     <h2>Apuntes</h2>
+    <h5 class="text-muted">📚 Últimos apuntes</h5>
     <div class="d-flex justify-content-center gap-2 mb-3">
       <a href="{{ url_for('notes.list_notes', filter='recientes', tag=selected_tag) }}" class="btn btn-outline-primary {% if filter == 'recientes' %}active{% endif %}">📅 Recientes</a>
       <a href="{{ url_for('notes.list_notes', filter='vistos', tag=selected_tag) }}" class="btn btn-outline-primary {% if filter == 'vistos' %}active{% endif %}">🔥 Más vistos</a>
@@ -116,4 +117,13 @@ function createNoteCard(n) {
     {% include 'components/sidebar_right.html' %}
   </div>
 </div>
+{% endblock %}
+
+{% block body_end %}
+{{ super() }}
+<script src="{{ url_for('static', filename='pdfjs/pdf.min.js') }}"></script>
+<script>
+  pdfjsLib.GlobalWorkerOptions.workerSrc = "{{ url_for('static', filename='pdfjs/pdf.worker.min.js') }}";
+  initPdfPreviews();
+</script>
 {% endblock %}

--- a/crunevo/templates/store/product_card.html
+++ b/crunevo/templates/store/product_card.html
@@ -5,6 +5,7 @@
     <img src="{{ product.first_image or '/static/img/producto-default.png' }}" class="card-img-top img-fluid" style="max-height: 180px; object-fit: cover;" alt="imagen">
   </a>
   <div class="position-absolute top-0 start-0 m-2 tw-space-x-1">
+    {% if product.category %}<span class="badge bg-info text-dark">{{ product.category }}</span>{% endif %}
     {% if product.is_new %}<span class="badge bg-primary">Nuevo</span>{% endif %}
     {% if product.is_popular %}<span class="badge bg-warning text-dark">Popular</span>{% endif %}
     {% if product.credits_only %}<span class="badge bg-info text-dark">Solo con créditos</span>{% endif %}
@@ -16,7 +17,14 @@
         {{ product.name }}
       </a>
     </h5>
-    <p class="card-text">S/ {{ '%.2f'|format(product.price) }}{% if product.price_credits %} <br><small class="text-muted">o {{ product.price_credits }} créditos</small>{% endif %}</p>
+    <p class="card-text">
+      {% if product.price == 0 %}
+        Desde S/ 0
+      {% else %}
+        S/ {{ '%.2f'|format(product.price) }}
+      {% endif %}
+      {% if product.price_credits %} <br><small class="text-muted">o {{ product.price_credits }} créditos</small>{% endif %}
+    </p>
     {% if product.stock > 0 %}
       <span class="badge bg-success mb-2">En stock</span>
     {% else %}
@@ -40,5 +48,6 @@
     {% else %}
       <a href="{{ url_for('store.add_to_cart', product_id=product.id) }}" class="btn btn-outline-primary w-100">Comprar</a>
     {% endif %}
+    <button type="button" class="btn btn-outline-secondary btn-sm mt-2 share-btn" data-share-url="{{ url_for('store.view_product', product_id=product.id, _external=True) }}"><i class="bi bi-share"></i></button>
   </div>
 </div>

--- a/crunevo/templates/store/store.html
+++ b/crunevo/templates/store/store.html
@@ -97,7 +97,7 @@
                     {% if product.price is not none %}
                       <p class="mb-1 text-primary fw-bold">
                         {% if product.price == 0 %}
-                          S/ 0
+                          Desde S/ 0
                         {% else %}
                           S/ {{ '%.2f' | format(product.price) }}
                         {% endif %}
@@ -113,6 +113,7 @@
                       </p>
                     {% endif %}
                     <div class="mb-2">
+                      {% if product.category %}<span class="badge bg-info text-dark">{{ product.category }}</span>{% endif %}
                       {% if product.is_new %}<span class="badge bg-success">Nuevo</span>{% endif %}
                       {% if product.is_popular %}<span class="badge bg-danger">Popular</span>{% endif %}
                       {% if product.credits_only %}<span class="badge bg-warning text-dark">Solo créditos</span>{% endif %}
@@ -123,6 +124,7 @@
                       <a href="{{ product.download_url }}" class="btn btn-success w-100 mb-2" target="_blank">Descargar</a>
                     {% endif %}
                     <a href="{{ url_for('store.view_product', product_id=product.id) }}" class="btn btn-outline-primary mt-auto tw-whitespace-nowrap">Ver detalle</a>
+                    <button type="button" class="btn btn-outline-secondary btn-sm mt-2 share-btn" data-share-url="{{ url_for('store.view_product', product_id=product.id, _external=True) }}"><i class="bi bi-share"></i> Compartir</button>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- trim latest notes from sidebar and refine quick filter buttons
- load PDF.js previews for notes
- display missing post message in highlights
- show categories, share buttons and 'Desde S/ 0' in store
- document moved sections in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6858b4cf46c48325a9f07ab50f3ceb62