### PR TITLE
Feed restructure with notes sidebar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,3 +226,4 @@
 - Corrigio plantillas de tienda para usar `product.price` en lugar de `price_soles` evitando UndefinedError (PR store-price-fix).
 - Se movió la sección "Últimos apuntes" del feed a /apuntes y se mejoró el sidebar con botones. Las tarjetas de apuntes cargan vista previa PDF usando PDF.js. Productos de la tienda muestran "Desde S/ 0", badge de categoría y botón de compartir (PR feed-store-pdf-preview).
 - Implementado sistema completo de ranking y logros con página /ranking, asignación automática y panel admin (PR achievements-ranking-v1).
+- Reestructurado el feed con sección de apuntes en la barra lateral, logros con iconos y /trending mostrando publicaciones destacadas de la semana (PR feed-restructure-notes).

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -24,10 +24,18 @@ def create_app():
     @app.context_processor
     def inject_globals():
         from .constants import ACHIEVEMENT_DETAILS
+        from .models import Note
+
+        latest_sidebar_notes = (
+            Note.query.order_by(Note.created_at.desc()).limit(3).all()
+            if db.session
+            else []
+        )
 
         return {
             "PUBLIC_BASE_URL": app.config.get("PUBLIC_BASE_URL"),
             "ACHIEVEMENT_DETAILS": ACHIEVEMENT_DETAILS,
+            "SIDEBAR_LATEST_NOTES": latest_sidebar_notes,
         }
 
     from .utils.helpers import timesince

--- a/crunevo/constants/__init__.py
+++ b/crunevo/constants/__init__.py
@@ -1,5 +1,10 @@
 from .credit_reasons import CreditReasons
 from .achievement_codes import AchievementCodes
-from .achievement_details import ACHIEVEMENT_DETAILS
+from .achievement_details import ACHIEVEMENT_DETAILS, ACHIEVEMENT_CATEGORIES
 
-__all__ = ["CreditReasons", "AchievementCodes", "ACHIEVEMENT_DETAILS"]
+__all__ = [
+    "CreditReasons",
+    "AchievementCodes",
+    "ACHIEVEMENT_DETAILS",
+    "ACHIEVEMENT_CATEGORIES",
+]

--- a/crunevo/constants/achievement_details.py
+++ b/crunevo/constants/achievement_details.py
@@ -21,3 +21,16 @@ ACHIEVEMENT_DETAILS = {
         "description": "Ayudaste a otro usuario en el foro",
     },
 }
+
+# Mapping of achievement codes to simple categories used for filtering
+ACHIEVEMENT_CATEGORIES = {
+    "primer_apunte": "aportes",
+    "100_descargas": "aportes",
+    "100_likes": "aportes",
+    "100_creditos": "aportes",
+    "donador": "colaboracion",
+    "compartidor": "colaboracion",
+    "tutor_activo": "colaboracion",
+    "conectado_7d": "actividad",
+    "top_3": "actividad",
+}

--- a/crunevo/routes/auth_routes.py
+++ b/crunevo/routes/auth_routes.py
@@ -94,10 +94,26 @@ def perfil():
         db.session.commit()
         flash("Perfil actualizado")
     from crunevo.models import SavedPost, Post
+    from crunevo.constants import ACHIEVEMENT_CATEGORIES
 
     saved = SavedPost.query.filter_by(user_id=current_user.id).all()
     posts = [Post.query.get(sp.post_id) for sp in saved if Post.query.get(sp.post_id)]
-    return render_template("auth/perfil.html", saved_posts=posts)
+
+    ach_type = request.args.get("tipo")
+    achievements = current_user.achievements
+    if ach_type:
+        achievements = [
+            a
+            for a in achievements
+            if ACHIEVEMENT_CATEGORIES.get(a.badge_code) == ach_type
+        ]
+
+    return render_template(
+        "auth/perfil.html",
+        saved_posts=posts,
+        achievements=achievements,
+        ach_type=ach_type,
+    )
 
 
 @auth_bp.route("/user/<int:user_id>")

--- a/crunevo/routes/feed_routes.py
+++ b/crunevo/routes/feed_routes.py
@@ -243,26 +243,18 @@ def index():
 @feed_bp.route("/trending")
 @activated_required
 def trending():
-    page = request.args.get("page", 1, type=int)
-
-    # Mostrar publicaciones más populares (ordenadas por likes)
-    pagination = Post.query.order_by(Post.likes.desc()).paginate(page=page, per_page=10)
-    posts = pagination.items
-
-    # Cargar usuarios con más créditos y notas destacadas
+    weekly_posts = get_weekly_top_posts(limit=10)
     top_ranked, recent_achievements = get_weekly_ranking()
     top_notes, top_posts, top_users = get_featured_posts()
 
     return render_template(
         "feed/trending.html",
-        posts=posts,
-        pagination=pagination,
+        weekly_posts=weekly_posts,
         top_ranked=top_ranked,
         recent_achievements=recent_achievements,
         top_notes=top_notes,
         top_posts=top_posts,
         top_users=top_users,
-        trending=True,
     )
 
 

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -134,8 +134,14 @@
 
       <div class="col-12">
         <h4>🎖️ Logros e insignias</h4>
+        <div class="mb-3">
+          <a href="{{ url_for('auth.perfil') }}" class="btn btn-outline-primary btn-sm {% if not ach_type %}active{% endif %}">Todos</a>
+          <a href="{{ url_for('auth.perfil', tipo='aportes') }}" class="btn btn-outline-primary btn-sm {% if ach_type == 'aportes' %}active{% endif %}">Aportes</a>
+          <a href="{{ url_for('auth.perfil', tipo='colaboracion') }}" class="btn btn-outline-primary btn-sm {% if ach_type == 'colaboracion' %}active{% endif %}">Colaboración</a>
+          <a href="{{ url_for('auth.perfil', tipo='actividad') }}" class="btn btn-outline-primary btn-sm {% if ach_type == 'actividad' %}active{% endif %}">Actividad</a>
+        </div>
         <div class="row row-cols-2 row-cols-md-3 g-2">
-          {% for a in current_user.achievements %}
+          {% for a in achievements %}
             {% set info = ACHIEVEMENT_DETAILS.get(a.badge_code, {}) %}
             {% set icon = info.icon %}
             {% set title = info.title %}

--- a/crunevo/templates/components/achievement_card.html
+++ b/crunevo/templates/components/achievement_card.html
@@ -2,7 +2,7 @@
   <div class="card-body p-2">
     <i class="bi {{ icon }} fs-3"></i>
     <div class="fw-bold">{{ title }}</div>
-    {% if timestamp %}<small class="text-muted">{{ timestamp.strftime('%Y-%m-%d') }}</small>{% endif %}
+    {% if timestamp %}<small class="text-muted">{{ timestamp|timesince }}</small>{% endif %}
   </div>
 </div>
 

--- a/crunevo/templates/components/sidebar_right.html
+++ b/crunevo/templates/components/sidebar_right.html
@@ -1,11 +1,27 @@
 <div class="card shadow-sm border-0 mb-4">
   <div class="card-body">
-  {# sección de últimos apuntes trasladada a /apuntes #}
+    {% if SIDEBAR_LATEST_NOTES %}
+    <h6 class="text-uppercase text-muted mb-3">📚 Últimos apuntes</h6>
+    <ul class="list-group list-group-flush mb-3">
+      {% for note in SIDEBAR_LATEST_NOTES %}
+      <li class="list-group-item px-0 d-flex align-items-center">
+        <canvas class="pdf-thumb me-2" data-pdf="{{ note.filename }}" width="40" height="40"></canvas>
+        <a href="{{ url_for('notes.view_note', id=note.id) }}" class="tw-truncate">{{ note.title }}</a>
+      </li>
+      {% endfor %}
+    </ul>
+    {% endif %}
+
     <h6 class="text-uppercase text-muted mb-3">🧩 Logros recientes</h6>
     <ul class="list-group list-group-flush mb-3">
       {% for username, badge_code, timestamp in recent_achievements or [] %}
-      <li class="list-group-item px-0">
-        <strong>{{ username }}</strong> – {{ badge_code }}
+      {% set info = ACHIEVEMENT_DETAILS.get(badge_code, {}) %}
+      <li class="list-group-item px-0 d-flex align-items-center" data-bs-toggle="tooltip" title="{{ info.description }}">
+        <i class="bi {{ info.icon }} me-2"></i>
+        <div>
+          <strong>{{ username }}</strong> – {{ info.title }}<br>
+          <small class="text-muted">{{ timestamp|timesince }}</small>
+        </div>
       </li>
       {% endfor %}
     </ul>

--- a/crunevo/templates/feed/trending.html
+++ b/crunevo/templates/feed/trending.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% import 'components/csrf.html' as csrf %}
-{% block title %}Tendencias{% endblock %}
+{% block title %}Publicaciones destacadas{% endblock %}
 {% block content %}
 <div class="row">
   <div class="col-lg-2 d-none d-lg-block">
@@ -8,73 +8,61 @@
     {% include 'components/feed_sidebar.html' %}
   </div>
   <div class="col-lg-7 col-md-12">
-    <h2 class="mb-4"><i class="bi bi-fire"></i> Publicaciones populares esta semana</h2>
-    <ul class="nav nav-pills justify-content-center mb-3">
-      <li class="nav-item">
-        <button class="nav-link active" data-trend-tab="posts">🔥 Publicaciones</button>
-      </li>
-      <li class="nav-item">
-        <button class="nav-link" data-trend-tab="notes">📘 Apuntes</button>
-      </li>
-      <li class="nav-item">
-        <button class="nav-link" data-trend-tab="users">🏅 Usuarios</button>
-      </li>
-    </ul>
-
-    <div data-section="posts" class="trend-section">
-      {% for post in posts %}
-      <div class="card mb-3 position-relative">
-        <span class="position-absolute top-0 start-0 tw-bg-red-600 tw-text-white tw-px-2 tw-rounded-bottom-right">🔥 Tendencia</span>
-        <div class="card-body">
-          <div class="d-flex align-items-center mb-2">
-            {% set author = post.author %}
-            {% if author %}
-            <img src="{{ author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
-            <a href="{{ url_for('auth.profile_by_username', username=author.username) }}" class="me-auto text-decoration-none"><strong>{{ author.username }}</strong></a>
-            {% else %}
-            <img src="{{ url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
-            <span class="me-auto text-muted">Usuario eliminado</span>
-            {% endif %}
-            <small class="text-muted">{{ post.created_at|timesince }}</small>
-          </div>
-          <p class="card-text">{{ post.content }}</p>
-          {% if post.file_url %}
-            {% if post.file_url.endswith('.pdf') %}
-            <a href="{{ post.file_url }}" target="_blank" class="btn btn-sm btn-outline-primary mb-2">Ver PDF</a>
-            {% else %}
-            <img src="{{ post.file_url }}" class="img-fluid rounded mb-2">
-            {% endif %}
-          {% endif %}
+    <h2 class="mb-4">💡 Publicaciones destacadas</h2>
+    {% for post in weekly_posts %}
+    <div class="card mb-3 position-relative">
+      <span class="position-absolute top-0 start-0 tw-bg-red-600 tw-text-white tw-px-2 tw-rounded-bottom-right">🔥 Tendencia</span>
+      <div class="card-body">
+        <div class="d-flex align-items-center mb-2">
+          {% set author = post.author %}
           {% if author %}
-          <a href="{{ url_for('auth.profile_by_username', username=author.username) }}" class="btn btn-sm btn-outline-info mb-2">Ver perfil</a>
-          <a href="{{ url_for('feed.view_post', post_id=post.id) }}" class="btn btn-sm btn-outline-primary mb-2">Ver publicación</a>
+          <img src="{{ author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
+          <a href="{{ url_for('auth.profile_by_username', username=author.username) }}" class="me-auto text-decoration-none"><strong>{{ author.username }}</strong></a>
+          {% else %}
+          <img src="{{ url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
+          <span class="me-auto text-muted">Usuario eliminado</span>
           {% endif %}
-          <p class="fs-5 fw-bold text-danger mb-0"><i class="bi bi-heart-fill me-1"></i>{{ post.likes or 0 }}</p>
+          <small class="text-muted">{{ post.created_at|timesince }}</small>
         </div>
+        <p class="card-text">{{ post.content }}</p>
+        {% if post.file_url %}
+          {% if post.file_url.endswith('.pdf') %}
+          <a href="{{ post.file_url }}" target="_blank" class="btn btn-sm btn-outline-primary mb-2">Ver PDF</a>
+          {% else %}
+          <img src="{{ post.file_url }}" class="img-fluid rounded mb-2">
+          {% endif %}
+        {% endif %}
+        {% if author %}
+        <a href="{{ url_for('auth.profile_by_username', username=author.username) }}" class="btn btn-sm btn-outline-info mb-2">Ver perfil</a>
+        <a href="{{ url_for('feed.view_post', post_id=post.id) }}" class="btn btn-sm btn-outline-primary mb-2">Ver publicación</a>
+        {% endif %}
+        <p class="fs-5 fw-bold text-danger mb-0"><i class="bi bi-heart-fill me-1"></i>{{ post.likes or 0 }}</p>
+      </div>
+    </div>
+    {% endfor %}
+
+    <div class="alert alert-primary text-center my-4" role="banner">
+      Crunevo une a jóvenes que se esfuerzan cada día por construir un futuro mejor
+    </div>
+
+    <h3 class="mb-3">🔥 Apuntes más vistos</h3>
+    <div class="row mb-4">
+      {% for note in top_notes %}
+      <div class="col-md-6 mb-3">
+        {% include 'components/note_card.html' %}
       </div>
       {% endfor %}
     </div>
 
-    <div data-section="notes" class="trend-section d-none">
-      <div class="row">
-        {% for note in top_notes %}
-        <div class="col-md-6 mb-3">
-          {% include 'components/note_card.html' %}
-        </div>
-        {% endfor %}
-      </div>
-    </div>
-
-    <div data-section="users" class="trend-section d-none">
-      <ul class="list-group mb-3">
-        {% for u in top_users %}
-        <li class="list-group-item d-flex justify-content-between align-items-start">
-          <span>{{ u.username }}</span>
-          <span class="badge bg-success">{{ u.credits }}</span>
-        </li>
-        {% endfor %}
-      </ul>
-    </div>
+    <h3 class="mb-3">📈 Usuarios más activos</h3>
+    <ul class="list-group mb-3">
+      {% for u in top_users %}
+      <li class="list-group-item d-flex justify-content-between align-items-start">
+        <span>{{ u.username }}</span>
+        <span class="badge bg-success">{{ u.credits }}</span>
+      </li>
+      {% endfor %}
+    </ul>
   </div>
 
   <div class="col-lg-3 d-none d-lg-block">
@@ -116,18 +104,6 @@
 
 {% block body_end %}
 {{ super() }}
-<script>
-  document.querySelectorAll('[data-trend-tab]').forEach(btn => {
-  btn.addEventListener('click', () => {
-      const target = btn.dataset.trendTab;
-      document.querySelectorAll('.trend-section').forEach(section => {
-        section.classList.toggle('d-none', section.dataset.section !== target);
-      });
-      document.querySelectorAll('[data-trend-tab]').forEach(tab => tab.classList.remove('active'));
-      btn.classList.add('active');
-    });
-  });
-</script>
 <script src="{{ url_for('static', filename='pdfjs/pdf.min.js') }}"></script>
 <script>
   pdfjsLib.GlobalWorkerOptions.workerSrc = "{{ url_for('static', filename='pdfjs/pdf.worker.min.js') }}";


### PR DESCRIPTION
## Summary
- add achievement categories constant
- inject latest notes in global context
- filter profile achievements by type
- show latest notes and styled achievements in sidebar
- redesign /trending page and weekly posts route

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6858bbf4fbb483258e717caa5248bc0e