### PR TITLE
Implement AJAX quick filters on feed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,3 +229,4 @@
 - Reestructurado el feed con sección de apuntes en la barra lateral, logros con iconos y /trending mostrando publicaciones destacadas de la semana (PR feed-restructure-notes).
 - Añadido dropdown de notificaciones con actualización AJAX y botón "Marcar todo como leído" (PR dynamic-notifications).
 - Mejora de subida de apuntes: admite imágenes, vista previa y spinner en el botón (PR notes-upload-preview).
+- Mejorados filtros rápidos del feed con botones toggle y carga AJAX (PR feed-toggle-filters)

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -172,3 +172,32 @@ function initFeedInteractions() {
   });
 }
 
+function initQuickFilters() {
+  const container = document.getElementById('quickFilters');
+  const feedBox = document.getElementById('feed');
+  if (!container || !feedBox) return;
+  container.querySelectorAll('button[data-filter]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const filter = btn.dataset.filter;
+      container.querySelectorAll('button[data-filter]').forEach((b) => {
+        b.classList.remove('btn-primary', 'active');
+        b.classList.add('btn-outline-primary');
+      });
+      btn.classList.add('btn-primary', 'active');
+      btn.classList.remove('btn-outline-primary');
+
+      fetch(`/api/quickfeed?filter=${filter}`)
+        .then((r) => r.json())
+        .then((data) => {
+          feedBox.innerHTML = data.html;
+          const countSpan = btn.querySelector('.count');
+          if (countSpan) {
+            countSpan.textContent = data.count;
+            countSpan.classList.toggle('tw-hidden', data.count === 0);
+          }
+          initFeedInteractions();
+        });
+    });
+  });
+}
+

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -101,6 +101,9 @@ document.addEventListener('DOMContentLoaded', () => {
   if (typeof initFeedInteractions === 'function') {
     initFeedInteractions();
   }
+  if (typeof initQuickFilters === 'function') {
+    initQuickFilters();
+  }
 
   // simple AJAX search suggestions
   const input = document.getElementById('globalSearchInput');

--- a/crunevo/templates/components/feed_sidebar.html
+++ b/crunevo/templates/components/feed_sidebar.html
@@ -1,9 +1,12 @@
 <div class="card shadow-sm border-0 mb-4 sidebar">
   <div class="card-body">
     <h6 class="text-uppercase text-muted mb-3">Filtros rápidos</h6>
-    <div class="d-grid gap-2">
-      <a class="btn btn-outline-primary btn-sm" href="{{ url_for('feed.index') }}"><i class="bi bi-clock-history"></i> Recientes</a>
-      <a class="btn btn-outline-primary btn-sm" href="{{ url_for('feed.trending') }}"><i class="bi bi-fire"></i> Más votados</a>
+    <div id="quickFilters" class="d-flex gap-2 overflow-auto">
+      <button class="btn btn-primary btn-sm" data-filter="recientes" data-label="🆕 Recientes">🆕 Recientes <span class="badge bg-light text-dark ms-1 count tw-hidden"></span></button>
+      <button class="btn btn-outline-primary btn-sm" data-filter="populares" data-label="📈 Populares">📈 Populares <span class="badge bg-light text-dark ms-1 count tw-hidden"></span></button>
+      <button class="btn btn-outline-primary btn-sm" data-filter="relevantes" data-label="📌 Relevantes">📌 Relevantes <span class="badge bg-light text-dark ms-1 count tw-hidden"></span></button>
+      <button class="btn btn-outline-primary btn-sm" data-filter="apuntes" data-label="🧪 Apuntes">🧪 Apuntes <span class="badge bg-light text-dark ms-1 count tw-hidden"></span></button>
+      <button class="btn btn-outline-primary btn-sm" data-filter="publicaciones" data-label="🗨️ Publicaciones">🗨️ Publicaciones <span class="badge bg-light text-dark ms-1 count tw-hidden"></span></button>
     </div>
   </div>
 </div>

--- a/crunevo/templates/feed/_notes.html
+++ b/crunevo/templates/feed/_notes.html
@@ -1,0 +1,5 @@
+{% for note in notes %}
+  {% include 'components/note_card.html' %}
+{% else %}
+  <p class="tw-text-center tw-text-muted">No se encontraron apuntes.</p>
+{% endfor %}

--- a/crunevo/templates/feed/_posts.html
+++ b/crunevo/templates/feed/_posts.html
@@ -1,0 +1,5 @@
+{% for post in posts %}
+  {% include 'components/post_card.html' %}
+{% else %}
+  <p class="tw-text-center tw-text-muted">No se encontraron publicaciones.</p>
+{% endfor %}

--- a/crunevo/templates/feed/list.html
+++ b/crunevo/templates/feed/list.html
@@ -26,6 +26,14 @@
   </form>
 </div>
 
+<div id="quickFilters" class="tw-flex tw-gap-2 tw-overflow-x-auto tw-my-4">
+  <button class="btn btn-primary btn-sm" data-filter="recientes" data-label="🆕 Recientes">🆕 Recientes <span class="badge bg-light text-dark ms-1 count tw-hidden"></span></button>
+  <button class="btn btn-outline-primary btn-sm" data-filter="populares" data-label="📈 Populares">📈 Populares <span class="badge bg-light text-dark ms-1 count tw-hidden"></span></button>
+  <button class="btn btn-outline-primary btn-sm" data-filter="relevantes" data-label="📌 Relevantes">📌 Relevantes <span class="badge bg-light text-dark ms-1 count tw-hidden"></span></button>
+  <button class="btn btn-outline-primary btn-sm" data-filter="apuntes" data-label="🧪 Apuntes">🧪 Apuntes <span class="badge bg-light text-dark ms-1 count tw-hidden"></span></button>
+  <button class="btn btn-outline-primary btn-sm" data-filter="publicaciones" data-label="🗨️ Publicaciones">🗨️ Publicaciones <span class="badge bg-light text-dark ms-1 count tw-hidden"></span></button>
+</div>
+
 <div id="feed" class="tw-mt-6 tw-grid tw-gap-6 md:tw-grid-cols-2">
   {% for item in feed_items %}
     {% if item.type == 'note' %}


### PR DESCRIPTION
## Summary
- add `/api/quickfeed` route
- create partial templates for posts and notes
- insert horizontal toggle buttons in feed list and sidebar
- add JS to load filtered feed via AJAX
- document change in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6858c43541bc8325aeddbf42ed709137