### PR TITLE
Add ChatCrunevo page and popular notes route

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,3 +230,4 @@
 - Añadido dropdown de notificaciones con actualización AJAX y botón "Marcar todo como leído" (PR dynamic-notifications).
 - Mejora de subida de apuntes: admite imágenes, vista previa y spinner en el botón (PR notes-upload-preview).
 - Mejorados filtros rápidos del feed con botones toggle y carga AJAX (PR feed-toggle-filters)
+- Added ChatCrunevo page using OpenRouter API, shortcut /notes/populares and share link button on note detail (PR ia-chat-popular-notes).

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -69,6 +69,7 @@ def create_app():
     from .routes.feed_routes import feed_bp
     from .routes.store_routes import store_bp
     from .routes.chat_routes import chat_bp
+    from .routes.ia_routes import ia_bp
     from .routes.admin_routes import admin_bp
     from .routes.admin_blocker import admin_blocker_bp
     from .routes.admin.email_routes import admin_email_bp
@@ -97,6 +98,7 @@ def create_app():
         app.register_blueprint(feed_bp)
         app.register_blueprint(store_bp)
         app.register_blueprint(chat_bp)
+        app.register_blueprint(ia_bp)
         app.register_blueprint(noti_bp)
         app.register_blueprint(missions_bp)
         app.register_blueprint(ranking_bp)

--- a/crunevo/routes/ia_routes.py
+++ b/crunevo/routes/ia_routes.py
@@ -1,0 +1,42 @@
+from flask import Blueprint, render_template, request, jsonify, current_app
+import requests
+
+from crunevo.utils.helpers import activated_required
+
+ia_bp = Blueprint("ia", __name__, url_prefix="/ia")
+
+
+@ia_bp.route("/")
+@activated_required
+def ia_chat():
+    return render_template("ia/chat.html")
+
+
+@ia_bp.route("/ask", methods=["POST"])
+@activated_required
+def ia_ask():
+    data = request.get_json() or {}
+    prompt = data.get("message", "")
+    if not prompt:
+        return jsonify({"error": "empty"}), 400
+    try:
+        resp = requests.post(
+            "https://openrouter.ai/deepseek/deepseek-chat-v3-0324:free/api",
+            json={
+                "model": "deepseek/deepseek-chat:free",
+                "api_key": "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",
+                "prompt": prompt,
+            },
+            timeout=15,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        answer = (
+            data.get("answer")
+            or data.get("choices", [{}])[0].get("message", {}).get("content")
+            or ""
+        )
+        return jsonify({"answer": answer})
+    except Exception:
+        current_app.logger.exception("AI request failed")
+        return jsonify({"error": "api"}), 500

--- a/crunevo/routes/notes_routes.py
+++ b/crunevo/routes/notes_routes.py
@@ -24,6 +24,12 @@ import cloudinary.uploader
 notes_bp = Blueprint("notes", __name__, url_prefix="/notes")
 
 
+@notes_bp.route("/populares")
+@activated_required
+def popular_notes():
+    return redirect(url_for("notes.list_notes", filter="vistos"))
+
+
 @notes_bp.route("/")
 @activated_required
 def list_notes():

--- a/crunevo/static/js/chatia.js
+++ b/crunevo/static/js/chatia.js
@@ -1,0 +1,52 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('aiForm');
+  const input = document.getElementById('aiInput');
+  const history = document.getElementById('aiHistory');
+
+  function append(author, text) {
+    const div = document.createElement('div');
+    div.innerHTML = `<strong>${author}:</strong> ${text}`;
+    history.appendChild(div);
+    history.scrollTop = history.scrollHeight;
+  }
+
+  function showTyping() {
+    const span = document.createElement('div');
+    span.id = 'typing';
+    span.className = 'text-muted fst-italic';
+    span.textContent = 'escribiendo...';
+    history.appendChild(span);
+    history.scrollTop = history.scrollHeight;
+  }
+
+  function hideTyping() {
+    document.getElementById('typing')?.remove();
+  }
+
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const msg = input.value.trim();
+    if (!msg) return;
+    append('Tú', msg);
+    input.value = '';
+    showTyping();
+    csrfFetch('/ia/ask', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: msg })
+    })
+      .then((r) => r.json())
+      .then((data) => {
+        hideTyping();
+        if (data.answer) {
+          append('ChatCrunevo', data.answer);
+        } else {
+          showToast('Error al recibir respuesta');
+        }
+      })
+      .catch(() => {
+        hideTyping();
+        showToast('Error de conexión');
+      });
+  });
+});

--- a/crunevo/templates/ia/chat.html
+++ b/crunevo/templates/ia/chat.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+{% import 'components/csrf.html' as csrf %}
+{% block content %}
+<div class="tw-bg-gray-900 d-flex justify-content-center align-items-center py-5" style="min-height: calc(100vh - 56px);">
+  <div class="card tw-bg-gray-800 text-white w-100" style="max-width: 600px;">
+    <div class="card-body">
+      <h4 class="card-title text-center mb-3">ChatCrunevo</h4>
+      <div id="aiHistory" class="border rounded p-3 mb-3" style="height: 300px; overflow-y:auto;"></div>
+      <form id="aiForm">
+        {{ csrf.csrf_field() }}
+        <div class="input-group">
+          <input id="aiInput" class="form-control" placeholder="Escribe tu pregunta..." autocomplete="off">
+          <button class="btn btn-primary" type="submit">Enviar</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}
+{% block body_end %}
+  {{ super() }}
+  <script src="{{ url_for('static', filename='js/chatia.js') }}"></script>
+{% endblock %}

--- a/crunevo/templates/notes/detalle.html
+++ b/crunevo/templates/notes/detalle.html
@@ -26,6 +26,7 @@
         {{ csrf.csrf_field() }}
         <button class="btn btn-outline-primary btn-sm" type="submit">🔗 Compartir</button>
       </form>
+      <button type="button" class="btn btn-outline-secondary btn-sm share-btn" data-share-url="{{ url_for('notes.view_note', id=note.id, _external=True) }}">Copiar enlace</button>
       {% if current_user.is_authenticated and current_user.id != note.author.id %}
       <form id="likeForm" method="post" action="{{ url_for('notes.like_note', note_id=note.id) }}" style="display:inline;">
         {{ csrf.csrf_field() }}

--- a/tests/test_ia.py
+++ b/tests/test_ia.py
@@ -1,0 +1,20 @@
+def login(client, username, password="secret"):
+    return client.post("/login", data={"username": username, "password": password})
+
+
+def test_ia_requires_login(client):
+    resp = client.get("/ia")
+    assert resp.status_code in (302, 308)
+
+
+def test_ia_access(client, test_user):
+    login(client, test_user.username)
+    resp = client.get("/ia/")
+    assert resp.status_code == 200
+    assert b"ChatCrunevo" in resp.data
+
+
+def test_notes_populares_redirect(client, test_user):
+    login(client, test_user.username)
+    resp = client.get("/notes/populares")
+    assert resp.status_code == 302


### PR DESCRIPTION
## Summary
- add ChatCrunevo AI chat page using OpenRouter API
- add /notes/populares redirect
- allow copying link on note detail
- register new blueprint and add tests
- document in AGENTS

## Testing
- `make fmt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858caaa59288325af0138b7966f7f0b