### PR TITLE
Redesign notes catalog and clean feed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,3 +231,4 @@
 - Mejora de subida de apuntes: admite imágenes, vista previa y spinner en el botón (PR notes-upload-preview).
 - Mejorados filtros rápidos del feed con botones toggle y carga AJAX (PR feed-toggle-filters)
 - Added ChatCrunevo page using OpenRouter API, shortcut /notes/populares and share link button on note detail (PR ia-chat-popular-notes).
+- Feed principal limpiado quitando secciones de apuntes, logros y ranking; /notes rediseñado como catálogo con tarjetas de vista previa, filtros por likes y ruta /notes/tag/<tag> (PR notes-catalog-redesign).

--- a/crunevo/routes/notes_routes.py
+++ b/crunevo/routes/notes_routes.py
@@ -30,6 +30,12 @@ def popular_notes():
     return redirect(url_for("notes.list_notes", filter="vistos"))
 
 
+@notes_bp.route("/tag/<string:tag>")
+@activated_required
+def notes_by_tag(tag):
+    return redirect(url_for("notes.list_notes", tag=tag))
+
+
 @notes_bp.route("/")
 @activated_required
 def list_notes():
@@ -42,6 +48,8 @@ def list_notes():
 
     if filter_opt == "vistos":
         query = query.order_by(Note.views.desc())
+    elif filter_opt == "gustados":
+        query = query.order_by(Note.likes.desc())
     else:  # recientes por defecto
         query = query.order_by(Note.created_at.desc())
 
@@ -79,6 +87,9 @@ def search_notes():
                 "title": n.title,
                 "description": n.description,
                 "tags": n.tags,
+                "filename": n.filename,
+                "views": n.views,
+                "likes": n.likes,
             }
             for n in results
         ]

--- a/crunevo/templates/components/note_card.html
+++ b/crunevo/templates/components/note_card.html
@@ -1,15 +1,18 @@
-<article class="tw-rounded-2xl tw-shadow-sm tw-bg-white dark:tw-bg-gray-900 tw-p-4 tw-space-y-2 mb-6">
-  <div class="pdf-thumb-container">
-    <canvas class="pdf-thumb tw-w-full tw-rounded mb-3" data-pdf="{{ note.filename }}"></canvas>
-  </div>
-  <h3 class="tw-text-lg tw-font-semibold mb-2">{{ note.title }}</h3>
-  <ul class="tw-flex tw-flex-wrap tw-gap-1 tw-text-sm tw-text-gray-500 dark:tw-text-gray-400 mb-4">
-    {% for tag in (note.tags or '').split(',') %}
-      <li>#{{ tag }}</li>
-    {% endfor %}
-  </ul>
-  <div class="tw-flex tw-gap-2">
-    <a href="{{ url_for('notes.view_note', id=note.id) }}" class="tw-inline-block tw-bg-[var(--primary)] tw-text-white tw-px-3 tw-py-1 tw-rounded">Ver apunte</a>
-    <button type="button" class="btn btn-sm btn-outline-secondary share-btn" data-share-url="{{ url_for('notes.view_note', id=note.id, _external=True) }}"><i class="bi bi-share"></i></button>
+<article class="card h-100 shadow-sm">
+  <canvas class="pdf-thumb card-img-top" data-pdf="{{ note.filename }}"></canvas>
+  <div class="card-body d-flex flex-column">
+    <h6 class="card-title">{{ note.title }}</h6>
+    <div class="mb-2">
+      {% for tag in (note.tags or '').split(',') %}
+      <span class="badge bg-secondary me-1">{{ tag }}</span>
+      {% endfor %}
+    </div>
+    <div class="mt-auto d-flex justify-content-between align-items-center">
+      <a href="{{ url_for('notes.view_note', id=note.id) }}" class="btn btn-primary btn-sm">Ver detalle</a>
+      <div class="text-muted small">
+        <i class="bi bi-eye"></i> {{ note.views }}
+        {% if note.likes %}&nbsp;<i class="bi bi-hand-thumbs-up"></i> {{ note.likes }}{% endif %}
+      </div>
+    </div>
   </div>
 </article>

--- a/crunevo/templates/feed/feed.html
+++ b/crunevo/templates/feed/feed.html
@@ -212,10 +212,6 @@
   </div>
 
   </div> <!-- Fin contenido central -->
-  <!-- Zona derecha (destacados, ranking, etc.) -->
-  <div class="col-lg-3 d-none d-lg-block">
-    {% include 'components/sidebar_right.html' %}
-  </div>
 </div>
 {% endblock %}
 

--- a/crunevo/templates/notes/list.html
+++ b/crunevo/templates/notes/list.html
@@ -7,14 +7,14 @@
   </div>
   <!-- Contenido central -->
   <div class="col-lg-7 col-md-12">
-    <h2>Apuntes</h2>
-    <h5 class="text-muted">📚 Últimos apuntes</h5>
-    <div class="d-flex justify-content-center gap-2 mb-3">
+    <h2 class="mb-3">Apuntes</h2>
+    <div class="d-flex flex-wrap gap-2 mb-3 justify-content-center">
       <a href="{{ url_for('notes.list_notes', filter='recientes', tag=selected_tag) }}" class="btn btn-outline-primary {% if filter == 'recientes' %}active{% endif %}">📅 Recientes</a>
       <a href="{{ url_for('notes.list_notes', filter='vistos', tag=selected_tag) }}" class="btn btn-outline-primary {% if filter == 'vistos' %}active{% endif %}">🔥 Más vistos</a>
+      <a href="{{ url_for('notes.list_notes', filter='gustados', tag=selected_tag) }}" class="btn btn-outline-primary {% if filter == 'gustados' %}active{% endif %}">👍 Más gustados</a>
       <div class="dropdown">
         <button class="btn btn-outline-primary dropdown-toggle" type="button" data-bs-toggle="dropdown">
-          {% if selected_tag %}{{ selected_tag }}{% else %}🎓 Categorías{% endif %}
+          {% if selected_tag %}{{ selected_tag }}{% else %}🏷️ Etiquetas{% endif %}
         </button>
         <ul class="dropdown-menu">
           <li><a class="dropdown-item" href="{{ url_for('notes.list_notes', filter=filter) }}">Todas</a></li>
@@ -29,25 +29,13 @@
         <input type="text" id="noteSearch" class="form-control" placeholder="Buscar...">
       </div>
       <div class="col-auto">
-        <a href="{{ url_for('notes.upload_note') }}" class="btn btn-success">Subir nuevo</a>
+        <a href="{{ url_for('notes.upload_note') }}" class="btn btn-success">Subir apunte</a>
       </div>
     </div>
-    <div class="row row-cols-1 row-cols-md-2 g-3" id="notesList">
+    <div class="row row-cols-1 row-cols-md-2 row-cols-lg-4 g-3" id="notesList">
 {% for note in notes %}
   <div class="col">
-    <div class="card h-100 shadow-sm">
-      <div class="card-body d-flex flex-column">
-        <div class="text-center text-danger fs-2 mb-2"><i class="bi bi-file-earmark-pdf-fill"></i></div>
-        <h6 class="card-title">{{ note.title }}</h6>
-        <p class="card-text flex-grow-1">{{ note.description or '' }}</p>
-        <div class="mb-2">
-          {% for tag in (note.tags or '').split(',') %}
-          <span class="badge bg-secondary me-1">{{ tag }}</span>
-          {% endfor %}
-        </div>
-        <a href="{{ url_for('notes.view_note', id=note.id) }}" class="btn btn-primary mt-auto">Ver</a>
-      </div>
-    </div>
+    {% include 'components/note_card.html' %}
   </div>
 {% endfor %}
 </div>
@@ -68,23 +56,19 @@ function createNoteCard(n) {
   const col = document.createElement('div');
   col.className = 'col';
 
-  const card = document.createElement('div');
+  const card = document.createElement('article');
   card.className = 'card h-100 shadow-sm';
+
+  const canvas = document.createElement('canvas');
+  canvas.className = 'pdf-thumb card-img-top';
+  canvas.dataset.pdf = n.filename;
 
   const body = document.createElement('div');
   body.className = 'card-body d-flex flex-column';
 
-  const icon = document.createElement('div');
-  icon.className = 'text-center text-danger fs-2 mb-2';
-  icon.innerHTML = '<i class="bi bi-file-earmark-pdf-fill"></i>';
-
   const title = document.createElement('h6');
   title.className = 'card-title';
   title.textContent = n.title;
-
-  const desc = document.createElement('p');
-  desc.className = 'card-text flex-grow-1';
-  desc.textContent = n.description || '';
 
   const tagDiv = document.createElement('div');
   tagDiv.className = 'mb-2';
@@ -97,25 +81,32 @@ function createNoteCard(n) {
     tagDiv.appendChild(span);
   });
 
-  const link = document.createElement('a');
-  link.className = 'btn btn-primary mt-auto';
-  link.href = `/notes/${n.id}`;
-  link.textContent = 'Ver';
+  const footer = document.createElement('div');
+  footer.className = 'mt-auto d-flex justify-content-between align-items-center';
 
-  body.appendChild(icon);
+  const link = document.createElement('a');
+  link.className = 'btn btn-primary btn-sm';
+  link.href = `/notes/${n.id}`;
+  link.textContent = 'Ver detalle';
+
+  const info = document.createElement('div');
+  info.className = 'text-muted small';
+  info.innerHTML = `<i class="bi bi-eye"></i> ${n.views || 0}` + (n.likes ? ` &nbsp;<i class="bi bi-hand-thumbs-up"></i> ${n.likes}` : '');
+
+  footer.appendChild(link);
+  footer.appendChild(info);
+
   body.appendChild(title);
-  body.appendChild(desc);
   body.appendChild(tagDiv);
-  body.appendChild(link);
+  body.appendChild(footer);
+
+  card.appendChild(canvas);
   card.appendChild(body);
   col.appendChild(card);
   return col;
 }
 </script>
   </div> <!-- Fin contenido central -->
-  <div class="col-lg-3 d-none d-lg-block">
-    {% include 'components/sidebar_right.html' %}
-  </div>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- remove sidebar card from feed
- redesign note cards with preview, views and likes
- modernize `/notes` page with gallery layout and filters
- add `/notes/tag/<tag>` route and likes filter
- expand note search API
- document changes in AGENTS

## Testing
- `make fmt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858ce25786c8325920a644fcdee5df4