### PR TITLE
Improve SEO and login redirect

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,3 +232,4 @@
 - Mejorados filtros rápidos del feed con botones toggle y carga AJAX (PR feed-toggle-filters)
 - Added ChatCrunevo page using OpenRouter API, shortcut /notes/populares and share link button on note detail (PR ia-chat-popular-notes).
 - Feed principal limpiado quitando secciones de apuntes, logros y ranking; /notes rediseñado como catálogo con tarjetas de vista previa, filtros por likes y ruta /notes/tag/<tag> (PR notes-catalog-redesign).
+- SEO meta description actualizada y ruta '/' muestra login o feed seg\u00fan autenticaci\u00f3n (PR root-login-seo-fix).

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -1,4 +1,5 @@
 from flask import Flask, request, redirect, url_for, flash
+from flask_login import current_user
 import logging
 from logging.handlers import RotatingFileHandler
 import os
@@ -59,14 +60,14 @@ def create_app():
             force_https=True,
             strict_transport_security=True,
         )
-    login_manager.login_view = "onboarding.register"
+    login_manager.login_view = "auth.login"
 
     migrate.init_app(app, db)
 
     from .routes.onboarding_routes import bp as onboarding_bp
-    from .routes.auth_routes import auth_bp
+    from .routes.auth_routes import auth_bp, login as login_view
     from .routes.notes_routes import notes_bp
-    from .routes.feed_routes import feed_bp
+    from .routes.feed_routes import feed_bp, index as feed_index
     from .routes.store_routes import store_bp
     from .routes.chat_routes import chat_bp
     from .routes.ia_routes import ia_bp
@@ -78,6 +79,12 @@ def create_app():
     from .routes.errors import errors_bp
     from .routes.missions_routes import missions_bp
     from .routes.health_routes import health_bp
+
+    @app.route("/")
+    def home_redirect():
+        if current_user.is_authenticated:
+            return feed_index()
+        return login_view()
 
     is_admin = os.environ.get("ADMIN_INSTANCE") == "1"
     testing_env = os.environ.get("PYTEST_CURRENT_TEST") is not None

--- a/crunevo/routes/auth_routes.py
+++ b/crunevo/routes/auth_routes.py
@@ -27,6 +27,7 @@ auth_bp = Blueprint("auth", __name__)
 
 
 @auth_bp.route("/login", methods=["GET", "POST"])
+@auth_bp.route("/", methods=["GET", "POST"])
 @limiter.limit("5 per 15 minutes")
 def login():
     admin_mode = current_app.config.get("ADMIN_INSTANCE")

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -9,9 +9,9 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@600&family=JetBrains+Mono&display=swap" rel="stylesheet">
     <title>{% block title %}Crunevo{% endblock %}</title>
-    <meta name="description" content="{% block meta_description %}{% endblock %}">
+    <meta name="description" content="Crunevo une a jóvenes que se esfuerzan cada día por construir un futuro mejor. Comparte apuntes, gana créditos y forma parte de una red educativa única.">
     <meta property="og:title" content="Crunevo - Comunidad Educativa" />
-    <meta property="og:description" content="Comparte apuntes, publica ideas y gana créditos por ayudar. Únete a Crunevo hoy." />
+    <meta property="og:description" content="Crunevo une a jóvenes que se esfuerzan cada día por construir un futuro mejor. Comparte apuntes, gana créditos y forma parte de una red educativa única." />
     <meta property="og:image" content="{{ url_for('static', filename='img/opengraph.jpg') }}" />
     <meta property="og:url" content="{{ request.url }}" />
     <link rel="stylesheet" href="{{ url_for('static', filename='vendor/bootstrap.min.css') }}">


### PR DESCRIPTION
## Summary
- update meta description tags in `base.html`
- route `/` now shows login or feed depending on authentication state
- canonical login URL is `/`
- document change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6858d146f4e48325be9f67fa02e8364c