### PR TITLE
Rediseño del feed con nueva barra lateral

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,3 +233,4 @@
 - Added ChatCrunevo page using OpenRouter API, shortcut /notes/populares and share link button on note detail (PR ia-chat-popular-notes).
 - Feed principal limpiado quitando secciones de apuntes, logros y ranking; /notes rediseñado como catálogo con tarjetas de vista previa, filtros por likes y ruta /notes/tag/<tag> (PR notes-catalog-redesign).
 - SEO meta description actualizada y ruta '/' muestra login o feed seg\u00fan autenticaci\u00f3n (PR root-login-seo-fix).
+- Rediseño del feed con barra lateral de iconos, filtros móviles y tarjetas de publicaciones mejoradas (PR feed-redesign-v2).

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -1,0 +1,23 @@
+.sidebar-left-feed .nav-link {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  white-space: nowrap;
+}
+.sidebar-left-feed .nav-link i {
+  width: 1rem;
+}
+#quickFilters {
+  overflow-x: auto;
+  white-space: nowrap;
+  z-index: 0;
+}
+#quickFilters button {
+  flex-shrink: 0;
+}
+[data-bs-theme="dark"] .sidebar-left-feed .nav-link:hover {
+  background-color: #333;
+}
+[data-bs-theme="light"] .sidebar-left-feed .nav-link:hover {
+  background-color: #f8f9fa;
+}

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -201,3 +201,19 @@ function initQuickFilters() {
   });
 }
 
+function initImagePreview() {
+  const input = document.getElementById('postImageInput');
+  const preview = document.getElementById('postImagePreview');
+  if (!input || !preview) return;
+  input.addEventListener('change', () => {
+    const file = input.files[0];
+    if (file) {
+      preview.src = URL.createObjectURL(file);
+      preview.classList.remove('d-none');
+    } else {
+      preview.classList.add('d-none');
+      preview.removeAttribute('src');
+    }
+  });
+}
+

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -104,6 +104,9 @@ document.addEventListener('DOMContentLoaded', () => {
   if (typeof initQuickFilters === 'function') {
     initQuickFilters();
   }
+  if (typeof initImagePreview === 'function') {
+    initImagePreview();
+  }
 
   // simple AJAX search suggestions
   const input = document.getElementById('globalSearchInput');

--- a/crunevo/templates/components/post_card.html
+++ b/crunevo/templates/components/post_card.html
@@ -1,31 +1,63 @@
-<article class="tw-rounded-2xl tw-shadow-sm tw-bg-white dark:tw-bg-gray-900 tw-p-4 tw-space-y-2">
-  <div class="tw-flex tw-items-center tw-mb-2">
+<article class="card shadow-sm mb-3">
+  <div class="card-header bg-transparent d-flex align-items-center gap-2">
     {% set author = post.author %}
-    <img src="{{ (author and author.avatar_url) or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
-    {% if author %}
-    <a href="{{ url_for('auth.profile_by_username', username=author.username) }}" class="me-auto text-decoration-none"><strong>{{ author.username }}</strong></a>
-    {% else %}
-    <span class="me-auto text-muted">Usuario eliminado</span>
-    {% endif %}
-    <small class="text-muted">{{ post.created_at|timesince }}</small>
+    <img src="{{ (author and author.avatar_url) or url_for('static', filename='img/default.png') }}" class="rounded-circle" width="40" height="40" alt="avatar">
+    <div class="flex-grow-1">
+      {% if author %}
+      <a href="{{ url_for('auth.profile_by_username', username=author.username) }}" class="fw-bold text-decoration-none">{{ author.username }}</a><br>
+      {% else %}
+      <span class="text-muted">Usuario eliminado</span><br>
+      {% endif %}
+      <small class="text-muted">{{ post.created_at|timesince }}</small>
+    </div>
+    <div class="dropdown">
+      <button class="btn btn-sm btn-light" data-bs-toggle="dropdown" aria-expanded="false"><i class="bi bi-three-dots"></i></button>
+      <ul class="dropdown-menu dropdown-menu-end">
+        <li><a class="dropdown-item" href="{{ url_for('feed.view_post', post_id=post.id) }}">Ver publicación</a></li>
+      </ul>
+    </div>
   </div>
-  <p class="tw-text-base">{{ post.content }}</p>
-  {% if post.file_url %}
-    {% if post.file_url.endswith('.pdf') %}
-      <a href="{{ post.file_url }}" target="_blank" class="btn btn-sm btn-outline-primary">Ver PDF</a>
-    {% else %}
-      <img src="{{ post.file_url }}" alt="imagen" class="tw-rounded tw-w-full">
+  <div class="card-body">
+    <p class="mb-2">{{ post.content }}</p>
+    {% if post.file_url %}
+      {% if post.file_url.endswith('.pdf') %}
+        <a href="{{ post.file_url }}" target="_blank" class="btn btn-sm btn-outline-primary mb-2">Ver PDF</a>
+      {% else %}
+        <img src="{{ post.file_url }}" class="img-fluid rounded mb-2" style="object-fit: cover; width:100%; max-height:400px;" alt="imagen">
+      {% endif %}
     {% endif %}
-  {% endif %}
-  <a href="{{ url_for('feed.view_post', post_id=post.id) }}" class="btn btn-sm btn-outline-primary">Ver publicación</a>
-  {% if author %}
-  <a href="{{ url_for('auth.profile_by_username', username=author.username) }}" class="btn btn-sm btn-outline-info">Ver perfil</a>
-  {% endif %}
-  <div class="tw-flex tw-gap-3 tw-text-xs tw-text-gray-500 dark:tw-text-gray-400">
-    <span><i class="bi bi-star-fill"></i> {{ post.likes or 0 }}</span>
-    <span><i class="bi bi-chat"></i> {{ post.comments|length }}</span>
-    <button type="button" class="btn btn-sm btn-outline-secondary share-btn" data-share-url="{{ url_for('feed.view_post', post_id=post.id, _external=True) }}">
-      <i class="bi bi-share"></i>
-    </button>
+    <div class="d-flex align-items-center gap-2 mb-2">
+      <form class="like-form" method="post" action="{{ url_for('feed.like_post', post_id=post.id) }}" data-target="likeCount{{ post.id }}">
+        {{ csrf.csrf_field() }}
+        <button class="btn btn-outline-danger btn-sm" type="submit">🔥</button>
+      </form>
+      <span id="likeCount{{ post.id }}">{{ post.likes or 0 }}</span>
+      <button class="btn btn-outline-secondary btn-sm share-btn" data-share-url="{{ url_for('feed.view_post', post_id=post.id, _external=True) }}"><i class="bi bi-share"></i></button>
+      <a href="{{ url_for('feed.view_post', post_id=post.id) }}" class="btn btn-outline-primary btn-sm">Ver publicación</a>
+    </div>
+    <div id="comments{{ post.id }}">
+      {% if post.comments %}
+        {% for c in post.comments|sort(attribute='timestamp', reverse=True) %}
+        <div class="d-flex mb-2">
+          <img src="{{ c.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
+          <div>
+            <div class="small text-muted">
+              <a href="{{ url_for('auth.profile_by_username', username=c.author.username) }}" class="text-decoration-none">{{ c.author.username }}</a> • {{ c.timestamp|timesince }}
+            </div>
+            <div>{{ c.body }}</div>
+          </div>
+        </div>
+        {% endfor %}
+      {% else %}
+        <p class="text-muted" data-empty-msg>Sé el primero en comentar esta publicación.</p>
+      {% endif %}
+    </div>
+    <form class="comment-form" method="post" action="{{ url_for('feed.comment_post', post_id=post.id) }}" data-container="comments{{ post.id }}" data-avatar="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" data-username="{{ current_user.username }}">
+      {{ csrf.csrf_field() }}
+      <div class="input-group input-group-sm">
+        <input type="text" name="body" class="form-control" placeholder="Añadir comentario" required>
+        <button class="btn btn-primary" type="submit">Enviar</button>
+      </div>
+    </form>
   </div>
 </article>

--- a/crunevo/templates/components/sidebar_left_feed.html
+++ b/crunevo/templates/components/sidebar_left_feed.html
@@ -1,0 +1,32 @@
+<nav class="nav flex-column sidebar-left-feed">
+  <a class="nav-link d-flex align-items-center gap-2" href="{{ url_for('auth.perfil') }}" data-bs-toggle="tooltip" title="Mi perfil">
+    <i class="bi bi-person"></i><span>Mi perfil</span>
+  </a>
+  <a class="nav-link d-flex align-items-center gap-2" href="{{ url_for('notes.list_notes') }}" data-bs-toggle="tooltip" title="Mis apuntes">
+    <i class="bi bi-journal-text"></i><span>Mis apuntes</span>
+  </a>
+  <a class="nav-link d-flex align-items-center gap-2" href="{{ url_for('auth.favorites') if 'auth.favorites' in current_app.view_functions else '#' }}" data-bs-toggle="tooltip" title="Favoritos">
+    <i class="bi bi-star"></i><span>Favoritos</span>
+  </a>
+  <a class="nav-link d-flex align-items-center gap-2" href="#" data-bs-toggle="tooltip" title="Clubes">
+    <i class="bi bi-people"></i><span>Clubes</span>
+  </a>
+  <a class="nav-link d-flex align-items-center gap-2" href="{{ url_for('store.store_index') }}" data-bs-toggle="tooltip" title="Tienda">
+    <i class="bi bi-bag"></i><span>Tienda</span>
+  </a>
+  <a class="nav-link d-flex align-items-center gap-2" href="{{ url_for('ranking.index') if 'ranking.index' in current_app.view_functions else '#' }}" data-bs-toggle="tooltip" title="Ranking">
+    <i class="bi bi-bar-chart"></i><span>Ranking</span>
+  </a>
+  <a class="nav-link d-flex align-items-center gap-2" href="{{ url_for('missions.index') if 'missions.index' in current_app.view_functions else '#' }}" data-bs-toggle="tooltip" title="Misiones">
+    <i class="bi bi-bullseye"></i><span>Misiones</span>
+  </a>
+  <a class="nav-link d-flex align-items-center gap-2" href="{{ url_for('ia.chat') if 'ia.chat' in current_app.view_functions else '#' }}" data-bs-toggle="tooltip" title="Crubot">
+    <i class="bi bi-robot"></i><span>Crubot</span>
+  </a>
+  <a class="nav-link d-flex align-items-center gap-2" href="#" data-bs-toggle="tooltip" title="Foro">
+    <i class="bi bi-globe"></i><span>Foro</span>
+  </a>
+  <a class="nav-link d-flex align-items-center gap-2" href="#" data-bs-toggle="tooltip" title="Eventos">
+    <i class="bi bi-calendar-event"></i><span>Eventos</span>
+  </a>
+</nav>

--- a/crunevo/templates/feed/index.html
+++ b/crunevo/templates/feed/index.html
@@ -1,12 +1,60 @@
 {% extends 'base.html' %}
+{% import 'components/csrf.html' as csrf %}
+
+{% block head_extra %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/feed.css') }}">
+{% endblock %}
+
 {% block content %}
-{% for item in items %}
-  {% if item.item_type == "apunte" %}
-    {% include 'components/note_card.html' with context %}
-  {% elif item.item_type == "post" %}
-    {% include 'components/post_card.html' with context %}
-  {% elif item.item_type == "question" %}
-    {% include 'components/question_card.html' with context %}
-  {% endif %}
-{% endfor %}
+<div class="row">
+  <div class="col-lg-2 d-none d-lg-block">
+    {% include 'components/sidebar_left_feed.html' %}
+    {% include 'components/feed_sidebar.html' %}
+  </div>
+  <div class="col-lg-7">
+    <div class="card shadow-sm mb-3">
+      <div class="card-body">
+        <div class="d-flex mb-3">
+          <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
+          <textarea name="content" form="postForm" class="form-control" rows="2" placeholder="¿Qué deseas compartir?" required></textarea>
+        </div>
+        <form id="postForm" method="post" enctype="multipart/form-data">
+          {{ csrf.csrf_field() }}
+          <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
+            <div class="btn-group">
+              <a href="{{ url_for('notes.upload') }}" class="btn btn-outline-secondary btn-sm"><i class="bi bi-file-earmark-plus"></i> Apunte</a>
+              <label class="btn btn-outline-secondary btn-sm mb-0">
+                <i class="bi bi-image"></i> Imagen
+                <input type="file" name="file" id="postImageInput" accept="image/*,.pdf" class="d-none">
+              </label>
+              <button type="button" class="btn btn-outline-secondary btn-sm" disabled><i class="bi bi-trophy"></i> Logro</button>
+            </div>
+            <button class="btn btn-primary btn-sm" type="submit">Publicar</button>
+          </div>
+          <img id="postImagePreview" class="img-fluid mt-3 rounded d-none" alt="preview">
+        </form>
+      </div>
+    </div>
+    <div class="d-lg-none mb-3">
+      {% include 'components/feed_sidebar.html' %}
+    </div>
+    <div id="feed" class="tw-space-y-4">
+      {% for item in feed_items %}
+        {% if item.type == 'note' %}
+          {% set note = item.data %}
+          {% include 'components/feed_card.html' %}
+        {% elif item.type == 'post' %}
+          {% set post = item.data %}
+          {% include 'components/post_card.html' %}
+        {% endif %}
+      {% endfor %}
+    </div>
+    {% if not feed_items %}
+      <div class="text-center my-5 text-muted">No se encontraron resultados aquí aún.</div>
+    {% endif %}
+  </div>
+  <div class="col-lg-3 d-none d-lg-block">
+    {% include 'components/sidebar_right.html' %}
+  </div>
+</div>
 {% endblock %}

--- a/crunevo/templates/feed/list.html
+++ b/crunevo/templates/feed/list.html
@@ -1,55 +1,60 @@
 {% extends 'base.html' %}
 {% import 'components/csrf.html' as csrf %}
 
+{% block head_extra %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/feed.css') }}">
+{% endblock %}
+
 {% block content %}
-<div class="tw-rounded-2xl tw-shadow-sm tw-bg-white dark:tw-bg-gray-900 tw-p-4 tw-space-y-4">
-  <input type="text" class="tw-rounded tw-border tw-border-gray-300 dark:tw-border-gray-700 tw-w-full tw-px-3 tw-py-2 focus:tw-ring-2 focus:tw-ring-[var(--primary)] focus:tw-outline-none" placeholder="¿Qué deseas compartir hoy?" readonly>
-  <div class="tw-flex tw-gap-2">
-    <button id="toggleNote" type="button" class="tw-rounded tw-bg-gray-200 dark:tw-bg-gray-700 tw-text-gray-900 dark:tw-text-gray-100 tw-px-4 tw-py-2 tw-transition tw-duration-200 hover:tw-bg-gray-300 dark:hover:tw-bg-gray-600">Subir Apunte</button>
-    <button id="toggleImage" type="button" class="tw-rounded tw-bg-gray-200 dark:tw-bg-gray-700 tw-text-gray-900 dark:tw-text-gray-100 tw-px-4 tw-py-2 tw-transition tw-duration-200 hover:tw-bg-gray-300 dark:hover:tw-bg-gray-600">Compartir Imagen</button>
+<div class="row">
+  <div class="col-lg-2 d-none d-lg-block">
+    {% include 'components/sidebar_left_feed.html' %}
+    {% include 'components/feed_sidebar.html' %}
   </div>
-  <form id="noteForm" method="post" enctype="multipart/form-data" class="tw-space-y-2 tw-hidden">
-    {{ csrf.csrf_field() }}
-    <input type="hidden" name="form_type" value="note">
-    <input type="text" name="title" class="tw-rounded tw-border tw-border-gray-300 dark:tw-border-gray-700 tw-w-full tw-px-3 tw-py-2 focus:tw-ring-2 focus:tw-ring-[var(--primary)] focus:tw-outline-none" placeholder="Título" required>
-    <textarea name="summary" class="tw-rounded tw-border tw-border-gray-300 dark:tw-border-gray-700 tw-w-full tw-px-3 tw-py-2 focus:tw-ring-2 focus:tw-ring-[var(--primary)] focus:tw-outline-none" placeholder="Resumen"></textarea>
-    <input type="text" name="tags" class="tw-rounded tw-border tw-border-gray-300 dark:tw-border-gray-700 tw-w-full tw-px-3 tw-py-2 focus:tw-ring-2 focus:tw-ring-[var(--primary)] focus:tw-outline-none" placeholder="Etiquetas">
-    <input type="file" name="file" class="tw-rounded tw-border tw-border-gray-300 dark:tw-border-gray-700 tw-w-full tw-px-3 tw-py-2 focus:tw-ring-2 focus:tw-ring-[var(--primary)] focus:tw-outline-none">
-    <button type="submit" class="tw-rounded tw-bg-[var(--primary)] tw-text-white tw-px-4 tw-py-2 tw-transition tw-duration-200 hover:tw-bg-[var(--primary)]/80">Publicar</button>
-  </form>
-  <form id="imageForm" method="post" enctype="multipart/form-data" class="tw-space-y-2 tw-hidden">
-    {{ csrf.csrf_field() }}
-    <input type="hidden" name="form_type" value="image">
-    <input type="text" name="title" class="tw-rounded tw-border tw-border-gray-300 dark:tw-border-gray-700 tw-w-full tw-px-3 tw-py-2 focus:tw-ring-2 focus:tw-ring-[var(--primary)] focus:tw-outline-none" placeholder="Descripción">
-    <input type="file" name="image" class="tw-rounded tw-border tw-border-gray-300 dark:tw-border-gray-700 tw-w-full tw-px-3 tw-py-2 focus:tw-ring-2 focus:tw-ring-[var(--primary)] focus:tw-outline-none">
-    <button type="submit" class="tw-rounded tw-bg-[var(--primary)] tw-text-white tw-px-4 tw-py-2 tw-transition tw-duration-200 hover:tw-bg-[var(--primary)]/80">Compartir</button>
-  </form>
-</div>
-
-<div id="quickFilters" class="tw-flex tw-gap-2 tw-overflow-x-auto tw-my-4">
-  <button class="btn btn-primary btn-sm" data-filter="recientes" data-label="🆕 Recientes">🆕 Recientes <span class="badge bg-light text-dark ms-1 count tw-hidden"></span></button>
-  <button class="btn btn-outline-primary btn-sm" data-filter="populares" data-label="📈 Populares">📈 Populares <span class="badge bg-light text-dark ms-1 count tw-hidden"></span></button>
-  <button class="btn btn-outline-primary btn-sm" data-filter="relevantes" data-label="📌 Relevantes">📌 Relevantes <span class="badge bg-light text-dark ms-1 count tw-hidden"></span></button>
-  <button class="btn btn-outline-primary btn-sm" data-filter="apuntes" data-label="🧪 Apuntes">🧪 Apuntes <span class="badge bg-light text-dark ms-1 count tw-hidden"></span></button>
-  <button class="btn btn-outline-primary btn-sm" data-filter="publicaciones" data-label="🗨️ Publicaciones">🗨️ Publicaciones <span class="badge bg-light text-dark ms-1 count tw-hidden"></span></button>
-</div>
-
-<div id="feed" class="tw-mt-6 tw-grid tw-gap-6 md:tw-grid-cols-2">
-  {% for item in feed_items %}
-    {% if item.type == 'note' %}
-      {% set note = item.data %}
-      {% include 'components/feed_card.html' %}
-    {% elif item.type == 'post' %}
-      {% set post = item.data %}
-      {% include 'components/post_card.html' %}
+  <div class="col-lg-7">
+    <div class="card shadow-sm mb-3">
+      <div class="card-body">
+        <div class="d-flex mb-3">
+          <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
+          <textarea name="content" form="postForm" class="form-control" rows="2" placeholder="¿Qué deseas compartir?" required></textarea>
+        </div>
+        <form id="postForm" method="post" enctype="multipart/form-data">
+          {{ csrf.csrf_field() }}
+          <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
+            <div class="btn-group">
+              <a href="{{ url_for('notes.upload') }}" class="btn btn-outline-secondary btn-sm"><i class="bi bi-file-earmark-plus"></i> Apunte</a>
+              <label class="btn btn-outline-secondary btn-sm mb-0">
+                <i class="bi bi-image"></i> Imagen
+                <input type="file" name="file" id="postImageInput" accept="image/*,.pdf" class="d-none">
+              </label>
+              <button type="button" class="btn btn-outline-secondary btn-sm" disabled><i class="bi bi-trophy"></i> Logro</button>
+            </div>
+            <button class="btn btn-primary btn-sm" type="submit">Publicar</button>
+          </div>
+        <img id="postImagePreview" class="img-fluid mt-3 rounded d-none" alt="preview">
+        </form>
+      </div>
+    </div>
+    <div class="d-lg-none mb-3">
+      {% include 'components/feed_sidebar.html' %}
+    </div>
+    <div id="feed" class="tw-space-y-4">
+      {% for item in feed_items %}
+        {% if item.type == 'note' %}
+          {% set note = item.data %}
+          {% include 'components/feed_card.html' %}
+        {% elif item.type == 'post' %}
+          {% set post = item.data %}
+          {% include 'components/post_card.html' %}
+        {% endif %}
+      {% endfor %}
+    </div>
+    {% if not feed_items %}
+      <div class="text-center my-5 text-muted">No se encontraron resultados aquí aún.</div>
     {% endif %}
-  {% endfor %}
-</div>
-
-{% if not feed_items %}
-  <div class="tw-text-center tw-my-10">
-    <i class="bi bi-rss tw-text-4xl tw-text-gray-400"></i>
-    <p>No se encontraron resultados aquí aún.</p>
   </div>
-{% endif %}
+  <div class="col-lg-3 d-none d-lg-block">
+    {% include 'components/sidebar_right.html' %}
+  </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- create sidebar_left_feed component with icon navigation
- redesign feed/index.html and /feed layout with new sidebar and mobile filters
- add feed.css for sidebar and quick filter styles with dark mode support
- improve publication form with avatar preview and image preview functionality
- revamp post cards with headers, image styling and interaction buttons
- update scripts to initialize image previews
- document changes in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6858d5a3b10083258b310e23364b36bb