### PR TITLE
Implement modern feed redesign

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,3 +234,4 @@
 - Feed principal limpiado quitando secciones de apuntes, logros y ranking; /notes rediseñado como catálogo con tarjetas de vista previa, filtros por likes y ruta /notes/tag/<tag> (PR notes-catalog-redesign).
 - SEO meta description actualizada y ruta '/' muestra login o feed seg\u00fan autenticaci\u00f3n (PR root-login-seo-fix).
 - Rediseño del feed con barra lateral de iconos, filtros móviles y tarjetas de publicaciones mejoradas (PR feed-redesign-v2).
+- Feed index moved to /feed with new sidebar and post card templates (PR modern-feed).

--- a/crunevo/routes/auth_routes.py
+++ b/crunevo/routes/auth_routes.py
@@ -58,7 +58,7 @@ def login():
                 return redirect(url_for("admin.dashboard"))
             next_page = request.args.get("next")
             if not next_page or urlparse(next_page).netloc != "":
-                next_page = url_for("feed.index")
+                next_page = url_for("feed.feed_home")
             return redirect(next_page)
         record_auth_event(user, "login_fail", extra=json.dumps({"username": username}))
         flash("Credenciales inválidas")

--- a/crunevo/routes/main_routes.py
+++ b/crunevo/routes/main_routes.py
@@ -1,9 +1,9 @@
 from flask import Blueprint
-from crunevo.routes.feed_routes import index as feed_index
+from crunevo.routes.feed_routes import feed_home
 
 main_bp = Blueprint("main", __name__)
 
 
 @main_bp.route("/")
 def index():
-    return feed_index()
+    return feed_home()

--- a/crunevo/routes/onboarding_routes.py
+++ b/crunevo/routes/onboarding_routes.py
@@ -111,7 +111,7 @@ def finish():
             current_user.avatar_url = avatar_url
         current_user.about = request.form.get("bio")
         db.session.commit()
-        return redirect(url_for("feed.index"))
+        return redirect(url_for("feed.feed_home"))
     return render_template("onboarding/finish.html")
 
 
@@ -119,7 +119,7 @@ def finish():
 @login_required
 def pending():
     if current_user.activated:
-        return redirect(url_for("feed.index"))
+        return redirect(url_for("feed.feed_home"))
     return render_template("onboarding/pending.html")
 
 
@@ -130,7 +130,7 @@ def pending():
 )
 def resend():
     if current_user.activated:
-        return redirect(url_for("feed.index"))
+        return redirect(url_for("feed.feed_home"))
     if not send_confirmation_email(current_user):
         flash(
             "No se pudo enviar el correo de confirmación. Inténtalo más tarde.",

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -3,14 +3,14 @@
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCrunevo" aria-controls="navbarCrunevo" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
-    <a class="navbar-brand ms-2" href="{{ url_for('feed.index') }}">Crunevo</a>
+    <a class="navbar-brand ms-2" href="{{ url_for('feed.feed_home') }}">Crunevo</a>
     <form class="d-none d-md-flex mx-3 flex-grow-1 position-relative" id="globalSearchForm">
       <input class="form-control" type="search" placeholder="Buscar" aria-label="Buscar" id="globalSearchInput" autocomplete="off">
       <div id="searchSuggestions" class="position-absolute start-0 w-100 bg-white border rounded shadow"></div>
     </form>
     <div class="collapse navbar-collapse" id="navbarCrunevo">
       <ul class="navbar-nav ms-auto d-flex flex-column flex-md-row align-items-center gap-2">
-        <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('feed.index') }}"><i class="bi bi-house-door me-1"></i>Inicio</a></li>
+        <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('feed.feed_home') }}"><i class="bi bi-house-door me-1"></i>Inicio</a></li>
         <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('feed.trending') }}"><i class="bi bi-fire me-1"></i>Tendencias</a></li>
         <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('notes.list_notes') }}"><i class="bi bi-journal-text me-1"></i>Apuntes</a></li>
         <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('store.store_index') }}"><i class="bi bi-bag me-1"></i>Tienda</a></li>

--- a/crunevo/templates/components/navbar_crunevo_fixed.html
+++ b/crunevo/templates/components/navbar_crunevo_fixed.html
@@ -5,7 +5,7 @@
       <button id="mobileMenuToggle" class="btn btn-link text-white d-md-none" type="button" aria-label="Menú">
         <i class="bi bi-list"></i>
       </button>
-      <a class="navbar-brand ms-2" href="{{ url_for('feed.index') }}">Crunevo</a>
+      <a class="navbar-brand ms-2" href="{{ url_for('feed.feed_home') }}">Crunevo</a>
     </div>
 
     <form class="d-none d-md-flex mx-3 flex-grow-1 position-relative" id="globalSearchForm">
@@ -14,7 +14,7 @@
     </form>
 
     <ul id="navLinks" class="navbar-nav flex-row align-items-center gap-3 d-none d-md-flex">
-      <li class="nav-item"><a class="nav-link" href="{{ url_for('feed.index') }}"><i class="bi bi-house-door"></i></a></li>
+      <li class="nav-item"><a class="nav-link" href="{{ url_for('feed.feed_home') }}"><i class="bi bi-house-door"></i></a></li>
       <li class="nav-item"><a class="nav-link" href="{{ url_for('feed.trending') }}"><i class="bi bi-fire"></i></a></li>
       <li class="nav-item"><a class="nav-link" href="{{ url_for('notes.list_notes') }}"><i class="bi bi-journal-text"></i></a></li>
       <li class="nav-item"><a class="nav-link" href="{{ url_for('store.store_index') }}"><i class="bi bi-bag"></i></a></li>

--- a/crunevo/templates/feed/_posts.html
+++ b/crunevo/templates/feed/_posts.html
@@ -1,5 +1,5 @@
 {% for post in posts %}
-  {% include 'components/post_card.html' %}
+  {% include 'feed/post_card.html' %}
 {% else %}
   <p class="tw-text-center tw-text-muted">No se encontraron publicaciones.</p>
 {% endfor %}

--- a/crunevo/templates/feed/feed.html
+++ b/crunevo/templates/feed/feed.html
@@ -242,7 +242,7 @@
 </div>
 <nav class="navbar fixed-bottom d-md-none navbar-light bg-light border-top">
   <div class="container-fluid justify-content-around">
-    <a class="nav-link text-center" href="{{ url_for('feed.index') }}">
+    <a class="nav-link text-center" href="{{ url_for('feed.feed_home') }}">
       <i class="bi bi-house"></i><br>Feed
     </a>
     <a class="nav-link text-center" href="{{ url_for('notes.list_notes') }}">

--- a/crunevo/templates/feed/index.html
+++ b/crunevo/templates/feed/index.html
@@ -8,7 +8,7 @@
 {% block content %}
 <div class="row">
   <div class="col-lg-2 d-none d-lg-block">
-    {% include 'components/sidebar_left_feed.html' %}
+    {% include 'feed/sidebar_left_feed.html' %}
     {% include 'components/feed_sidebar.html' %}
   </div>
   <div class="col-lg-7">
@@ -45,7 +45,7 @@
           {% include 'components/feed_card.html' %}
         {% elif item.type == 'post' %}
           {% set post = item.data %}
-          {% include 'components/post_card.html' %}
+          {% include 'feed/post_card.html' %}
         {% endif %}
       {% endfor %}
     </div>

--- a/crunevo/templates/feed/list.html
+++ b/crunevo/templates/feed/list.html
@@ -8,7 +8,7 @@
 {% block content %}
 <div class="row">
   <div class="col-lg-2 d-none d-lg-block">
-    {% include 'components/sidebar_left_feed.html' %}
+    {% include 'feed/sidebar_left_feed.html' %}
     {% include 'components/feed_sidebar.html' %}
   </div>
   <div class="col-lg-7">
@@ -45,7 +45,7 @@
           {% include 'components/feed_card.html' %}
         {% elif item.type == 'post' %}
           {% set post = item.data %}
-          {% include 'components/post_card.html' %}
+          {% include 'feed/post_card.html' %}
         {% endif %}
       {% endfor %}
     </div>

--- a/crunevo/templates/feed/post_card.html
+++ b/crunevo/templates/feed/post_card.html
@@ -1,0 +1,63 @@
+<article class="card shadow-sm mb-3">
+  <div class="card-header bg-transparent d-flex align-items-center gap-2">
+    {% set author = post.author %}
+    <img src="{{ (author and author.avatar_url) or url_for('static', filename='img/default.png') }}" class="rounded-circle" width="40" height="40" alt="avatar">
+    <div class="flex-grow-1">
+      {% if author %}
+      <a href="{{ url_for('auth.profile_by_username', username=author.username) }}" class="fw-bold text-decoration-none">{{ author.username }}</a><br>
+      {% else %}
+      <span class="text-muted">Usuario eliminado</span><br>
+      {% endif %}
+      <small class="text-muted">{{ post.created_at|timesince }}</small>
+    </div>
+    <div class="dropdown">
+      <button class="btn btn-sm btn-light" data-bs-toggle="dropdown" aria-expanded="false"><i class="bi bi-three-dots"></i></button>
+      <ul class="dropdown-menu dropdown-menu-end">
+        <li><a class="dropdown-item" href="{{ url_for('feed.view_post', post_id=post.id) }}">Ver publicación</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="card-body">
+    <p class="mb-2">{{ post.content }}</p>
+    {% if post.file_url %}
+      {% if post.file_url.endswith('.pdf') %}
+        <a href="{{ post.file_url }}" target="_blank" class="btn btn-sm btn-outline-primary mb-2">Ver PDF</a>
+      {% else %}
+        <img src="{{ post.file_url }}" class="img-fluid rounded mb-2" style="object-fit: cover; width:100%; max-height:400px;" alt="imagen">
+      {% endif %}
+    {% endif %}
+    <div class="d-flex align-items-center gap-2 mb-2">
+      <form class="like-form" method="post" action="{{ url_for('feed.like_post', post_id=post.id) }}" data-target="likeCount{{ post.id }}">
+        {{ csrf.csrf_field() }}
+        <button class="btn btn-outline-danger btn-sm" type="submit">🔥</button>
+      </form>
+      <span id="likeCount{{ post.id }}">{{ post.likes or 0 }}</span>
+      <button class="btn btn-outline-secondary btn-sm share-btn" data-share-url="{{ url_for('feed.view_post', post_id=post.id, _external=True) }}"><i class="bi bi-share"></i></button>
+      <a href="{{ url_for('feed.view_post', post_id=post.id) }}" class="btn btn-outline-primary btn-sm">Ver publicación</a>
+    </div>
+    <div id="comments{{ post.id }}">
+      {% if post.comments %}
+        {% for c in post.comments|sort(attribute='timestamp', reverse=True) %}
+        <div class="d-flex mb-2">
+          <img src="{{ c.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
+          <div>
+            <div class="small text-muted">
+              <a href="{{ url_for('auth.profile_by_username', username=c.author.username) }}" class="text-decoration-none">{{ c.author.username }}</a> • {{ c.timestamp|timesince }}
+            </div>
+            <div>{{ c.body }}</div>
+          </div>
+        </div>
+        {% endfor %}
+      {% else %}
+        <p class="text-muted" data-empty-msg>Sé el primero en comentar esta publicación.</p>
+      {% endif %}
+    </div>
+    <form class="comment-form" method="post" action="{{ url_for('feed.comment_post', post_id=post.id) }}" data-container="comments{{ post.id }}" data-avatar="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" data-username="{{ current_user.username }}">
+      {{ csrf.csrf_field() }}
+      <div class="input-group input-group-sm">
+        <input type="text" name="body" class="form-control" placeholder="Añadir comentario" required>
+        <button class="btn btn-primary" type="submit">Enviar</button>
+      </div>
+    </form>
+  </div>
+</article>

--- a/crunevo/templates/feed/sidebar_left_feed.html
+++ b/crunevo/templates/feed/sidebar_left_feed.html
@@ -1,0 +1,32 @@
+<nav class="nav flex-column sidebar-left-feed">
+  <a class="nav-link d-flex align-items-center gap-2" href="{{ url_for('auth.perfil') }}" data-bs-toggle="tooltip" title="Mi perfil">
+    <i class="bi bi-person"></i><span>Mi perfil</span>
+  </a>
+  <a class="nav-link d-flex align-items-center gap-2" href="{{ url_for('notes.list_notes') }}" data-bs-toggle="tooltip" title="Mis apuntes">
+    <i class="bi bi-journal-text"></i><span>Mis apuntes</span>
+  </a>
+  <a class="nav-link d-flex align-items-center gap-2" href="{{ url_for('auth.favorites') if 'auth.favorites' in current_app.view_functions else '#' }}" data-bs-toggle="tooltip" title="Favoritos">
+    <i class="bi bi-star"></i><span>Favoritos</span>
+  </a>
+  <a class="nav-link d-flex align-items-center gap-2" href="#" data-bs-toggle="tooltip" title="Clubes">
+    <i class="bi bi-people"></i><span>Clubes</span>
+  </a>
+  <a class="nav-link d-flex align-items-center gap-2" href="{{ url_for('store.store_index') }}" data-bs-toggle="tooltip" title="Tienda">
+    <i class="bi bi-bag"></i><span>Tienda</span>
+  </a>
+  <a class="nav-link d-flex align-items-center gap-2" href="{{ url_for('ranking.index') if 'ranking.index' in current_app.view_functions else '#' }}" data-bs-toggle="tooltip" title="Ranking">
+    <i class="bi bi-bar-chart"></i><span>Ranking</span>
+  </a>
+  <a class="nav-link d-flex align-items-center gap-2" href="{{ url_for('missions.index') if 'missions.index' in current_app.view_functions else '#' }}" data-bs-toggle="tooltip" title="Misiones">
+    <i class="bi bi-bullseye"></i><span>Misiones</span>
+  </a>
+  <a class="nav-link d-flex align-items-center gap-2" href="{{ url_for('ia.chat') if 'ia.chat' in current_app.view_functions else '#' }}" data-bs-toggle="tooltip" title="Crubot">
+    <i class="bi bi-robot"></i><span>Crubot</span>
+  </a>
+  <a class="nav-link d-flex align-items-center gap-2" href="#" data-bs-toggle="tooltip" title="Foro">
+    <i class="bi bi-globe"></i><span>Foro</span>
+  </a>
+  <a class="nav-link d-flex align-items-center gap-2" href="#" data-bs-toggle="tooltip" title="Eventos">
+    <i class="bi bi-calendar-event"></i><span>Eventos</span>
+  </a>
+</nav>

--- a/crunevo/templates/feed/user_posts.html
+++ b/crunevo/templates/feed/user_posts.html
@@ -3,12 +3,12 @@
 {% block content %}
 <h2 class="mb-4">Publicaciones de {{ user.username }}</h2>
 <div class="mb-3">
-  <a href="{{ url_for('feed.index') }}" class="btn btn-sm btn-secondary">&larr; Volver al feed</a>
+  <a href="{{ url_for('feed.feed_home') }}" class="btn btn-sm btn-secondary">&larr; Volver al feed</a>
 </div>
 <div class="row row-cols-1 g-3">
   {% for post in posts %}
   <div class="col">
-    {% include 'components/post_card.html' %}
+    {% include 'feed/post_card.html' %}
   </div>
   {% else %}
   <p class="text-muted">No hay publicaciones.</p>

--- a/crunevo/templates/onboarding/finish.html
+++ b/crunevo/templates/onboarding/finish.html
@@ -26,7 +26,7 @@
             </div>
             <button class="btn btn-primary w-100 mt-3" type="submit">Guardar mi perfil</button>
           </form>
-          <a class="btn btn-secondary w-100 mt-3" href="{{ url_for('feed.index') }}">Ir al feed</a>
+          <a class="btn btn-secondary w-100 mt-3" href="{{ url_for('feed.feed_home') }}">Ir al feed</a>
         </div>
       </div>
     </div>

--- a/crunevo/templates/onboarding/pending.html
+++ b/crunevo/templates/onboarding/pending.html
@@ -8,6 +8,6 @@
     {{ csrf.csrf_field() }}
     {{ btn.button('Reenviar correo', type='submit') }}
   </form>
-  {{ btn.button('Volver al inicio', href=url_for('feed.index')) }}
+  {{ btn.button('Volver al inicio', href=url_for('feed.feed_home')) }}
 </div>
 {% endblock %}

--- a/crunevo/templates/perfil_publico.html
+++ b/crunevo/templates/perfil_publico.html
@@ -30,7 +30,7 @@
         {% for p in user.posts|sort(attribute='created_at', reverse=True) %}
         {% set post = p %}
         <div class="col">
-          {% include 'components/post_card.html' %}
+          {% include 'feed/post_card.html' %}
         </div>
         {% else %}
         <p class="text-muted">Aún no ha publicado.</p>

--- a/crunevo/utils/helpers.py
+++ b/crunevo/utils/helpers.py
@@ -9,7 +9,7 @@ def admin_required(f):
     @login_required
     def decorated_function(*args, **kwargs):
         if current_user.role not in ("admin", "moderator"):
-            return redirect(url_for("feed.index"))
+            return redirect(url_for("feed.feed_home"))
         return f(*args, **kwargs)
 
     return decorated_function
@@ -20,7 +20,7 @@ def full_admin_required(f):
     @login_required
     def decorated_function(*args, **kwargs):
         if current_user.role != "admin":
-            return redirect(url_for("feed.index"))
+            return redirect(url_for("feed.feed_home"))
         return f(*args, **kwargs)
 
     return decorated_function
@@ -50,7 +50,7 @@ def verified_required(f):
                 "Necesitas verificación de estudiante para descargar apuntes",
                 "warning",
             )
-            return redirect(url_for("feed.index"))
+            return redirect(url_for("feed.feed_home"))
         return f(*args, **kwargs)
 
     return decorated


### PR DESCRIPTION
## Summary
- move sidebar and post card partials into feed templates
- route `/feed` now renders `feed/index.html`
- add application-level aliases for API and post interactions
- ensure templates reference new partial locations
- document feed index move in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6858dab28b6083258ce652bde85d49fa