### PR TITLE
Verify feed route for admins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,3 +239,6 @@
 - Navbar cleaned removing missions link and verification badge; missions now reside under /perfil with new tab and verification check shown next to usernames (PR profile-missions-verification).
 - Mejorada subida de imágenes en el feed con vista previa y spinner; filtros rápidos rediseñados y se eliminó HTML obsoleto al final del feed (PR feed-todo-fix).
 - Corregido tamaño del preview de imágenes, se ajustaron las publicadas y se limpiaron restos de HTML en el feed (PR feed-image-preview-fix).
+
+- Verificada ruta view_feed y plantillas para usar solo feed_items sin apuntes extra (QA feed-view-feed-admin-check).
+- Filtrado de "apuntes" en FeedItem: el feed y la API ahora omiten notas antiguas incluso para administradores (PR feed-skip-notes).

--- a/crunevo/utils/feed.py
+++ b/crunevo/utils/feed.py
@@ -39,14 +39,15 @@ def create_feed_item_for_all(
     if items:
         db.session.add_all(items)
         db.session.commit()
-        for it in items:
-            push_items(
-                it.owner_id,
-                [
-                    {
-                        "score": it.score,
-                        "created_at": it.created_at,
-                        "payload": it.to_dict(),
-                    }
-                ],
-            )
+        if item_type != "apunte":
+            for it in items:
+                push_items(
+                    it.owner_id,
+                    [
+                        {
+                            "score": it.score,
+                            "created_at": it.created_at,
+                            "payload": it.to_dict(),
+                        }
+                    ],
+                )


### PR DESCRIPTION
## Summary
- filter notes from feed queries so admins don't see old notes
- keep achievements and events intact
- update `create_feed_item_for_all` to avoid caching note items
- revise feed tests for posts only and maintain cache stubbing
- document skip-notes rule in `AGENTS.md`

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6859a58b940c8325930c76d6ee73563e