### PR TITLE
Implement delete post feature

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,3 +242,4 @@
 
 - Verificada ruta view_feed y plantillas para usar solo feed_items sin apuntes extra (QA feed-view-feed-admin-check).
 - Filtrado de "apuntes" en FeedItem: el feed y la API ahora omiten notas antiguas incluso para administradores (PR feed-skip-notes).
+- Se añadió opción para eliminar publicaciones propias en el feed, removiendo FeedItem y cache (PR post-delete).

--- a/crunevo/templates/feed/post_card.html
+++ b/crunevo/templates/feed/post_card.html
@@ -1,3 +1,4 @@
+{% import 'components/csrf.html' as csrf %}
 <article class="card shadow-sm mb-3">
   <div class="card-header bg-transparent d-flex align-items-center gap-2">
     {% set author = post.author %}
@@ -34,6 +35,12 @@
       <span id="likeCount{{ post.id }}">{{ post.likes or 0 }}</span>
       <button class="btn btn-outline-secondary btn-sm share-btn" data-share-url="{{ url_for('feed.view_post', post_id=post.id, _external=True) }}"><i class="bi bi-share"></i></button>
       <a href="{{ url_for('feed.view_post', post_id=post.id) }}" class="btn btn-outline-primary btn-sm">Ver publicación</a>
+      {% if post.author_id == current_user.id %}
+      <form action="{{ url_for('feed.eliminar_post', post_id=post.id) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar esta publicación?');">
+        {{ csrf.csrf_field() }}
+        <button type="submit" class="btn btn-outline-danger btn-sm">🗑️ Eliminar</button>
+      </form>
+      {% endif %}
     </div>
     <div id="comments{{ post.id }}">
       {% if post.comments %}


### PR DESCRIPTION
## Summary
- enable removing items from feed cache
- add `/feed/post/eliminar/<id>` route to delete posts
- show delete button on own posts in feed
- test deleting posts
- document new feature in AGENTS notes

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6859c4e2c2c0832597ca91b1da128393