### PR TITLE
Implement notes deletion and post editing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,3 +243,6 @@
 - Verificada ruta view_feed y plantillas para usar solo feed_items sin apuntes extra (QA feed-view-feed-admin-check).
 - Filtrado de "apuntes" en FeedItem: el feed y la API ahora omiten notas antiguas incluso para administradores (PR feed-skip-notes).
 - Se añadió opción para eliminar publicaciones propias en el feed, removiendo FeedItem y cache (PR post-delete).
+- Añadida funcionalidad para que los usuarios eliminen sus propios apuntes desde /notes y /perfil (PR notes-delete-user).
+- Botón "Editar" agregado en publicaciones del feed con marca visual (Editado) y control de permisos (PR post-edit).
+- Estilo CSS actualizado para centrar imágenes del feed y mejorar visualización móvil (PR feed-image-center).

--- a/crunevo/models/post.py
+++ b/crunevo/models/post.py
@@ -10,4 +10,5 @@ class Post(db.Model):
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     likes = db.Column(db.Integer, default=0)
     type = db.Column(db.String(20))
+    edited = db.Column(db.Boolean, default=False)
     comments = db.relationship("PostComment", backref="post", lazy=True)

--- a/crunevo/routes/feed_routes.py
+++ b/crunevo/routes/feed_routes.py
@@ -391,6 +391,25 @@ def donate_post(post_id):
     return jsonify({"success": True})
 
 
+@feed_bp.route("/post/editar/<int:post_id>", methods=["POST"], endpoint="editar_post")
+@activated_required
+def editar_post(post_id):
+    """Edit a post's content if the current user is the author."""
+    post = Post.query.get_or_404(post_id)
+    if post.author_id != current_user.id:
+        abort(403)
+    content = request.form.get("content", "").strip()
+    if not content:
+        flash("El contenido no puede estar vacío", "danger")
+        return redirect(url_for("feed.view_post", post_id=post.id))
+    if content != post.content:
+        post.content = content
+        post.edited = True
+        db.session.commit()
+    flash("Publicación actualizada", "success")
+    return redirect(url_for("feed.view_post", post_id=post.id))
+
+
 @feed_bp.route("/post/eliminar/<int:post_id>", methods=["POST"])
 @activated_required
 def eliminar_post(post_id):

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -21,3 +21,9 @@
 [data-bs-theme="light"] .sidebar-left-feed .nav-link:hover {
   background-color: #f8f9fa;
 }
+
+.feed-image {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/crunevo/templates/components/note_card.html
+++ b/crunevo/templates/components/note_card.html
@@ -1,3 +1,4 @@
+{% import 'components/csrf.html' as csrf %}
 <article class="card h-100 shadow-sm">
   <canvas class="pdf-thumb card-img-top" data-pdf="{{ note.filename }}"></canvas>
   <div class="card-body d-flex flex-column">
@@ -8,7 +9,15 @@
       {% endfor %}
     </div>
     <div class="mt-auto d-flex justify-content-between align-items-center">
-      <a href="{{ url_for('notes.view_note', id=note.id) }}" class="btn btn-primary btn-sm">Ver detalle</a>
+      <div>
+        <a href="{{ url_for('notes.view_note', id=note.id) }}" class="btn btn-primary btn-sm">Ver detalle</a>
+        {% if current_user.is_authenticated and note.user_id == current_user.id %}
+        <form action="{{ url_for('notes.delete_note', note_id=note.id) }}" method="post" class="d-inline" onsubmit="return confirm('¿Eliminar este apunte?');">
+          {{ csrf.csrf_field() }}
+          <button type="submit" class="btn btn-outline-danger btn-sm">🗑️</button>
+        </form>
+        {% endif %}
+      </div>
       <div class="text-muted small">
         <i class="bi bi-eye"></i> {{ note.views }}
         {% if note.likes %}&nbsp;<i class="bi bi-hand-thumbs-up"></i> {{ note.likes }}{% endif %}

--- a/crunevo/templates/feed/feed.html
+++ b/crunevo/templates/feed/feed.html
@@ -80,7 +80,7 @@
           {% if post.file_url.endswith('.pdf') %}
           <a href="{{ post.file_url }}" target="_blank" class="btn btn-sm btn-outline-primary mb-2">Ver PDF</a>
           {% else %}
-          <img src="{{ post.file_url }}" class="img-fluid rounded mb-2">
+          <img src="{{ post.file_url }}" class="feed-image img-fluid rounded mb-2">
           {% endif %}
         {% endif %}
         <a href="{{ url_for('feed.view_post', post_id=post.id) }}" class="btn btn-sm btn-outline-primary mb-2">Ver publicación</a>

--- a/crunevo/templates/feed/post_card.html
+++ b/crunevo/templates/feed/post_card.html
@@ -9,7 +9,7 @@
       {% else %}
       <span class="text-muted">Usuario eliminado</span><br>
       {% endif %}
-      <small class="text-muted">{{ post.created_at|timesince }}</small>
+      <small class="text-muted">{{ post.created_at|timesince }}{% if post.edited %} • Editado{% endif %}</small>
     </div>
     <div class="dropdown">
       <button class="btn btn-sm btn-light" data-bs-toggle="dropdown" aria-expanded="false"><i class="bi bi-three-dots"></i></button>
@@ -24,7 +24,7 @@
       {% if post.file_url.endswith('.pdf') %}
         <a href="{{ post.file_url }}" target="_blank" class="btn btn-sm btn-outline-primary mb-2">Ver PDF</a>
       {% else %}
-        <img src="{{ post.file_url }}" class="img-fluid rounded mt-2" style="max-height: 400px; width: auto;" alt="imagen">
+        <img src="{{ post.file_url }}" class="feed-image img-fluid rounded mt-2" style="max-height: 400px; width: auto;" alt="imagen">
       {% endif %}
     {% endif %}
     <div class="d-flex align-items-center gap-2 mb-2">
@@ -36,6 +36,7 @@
       <button class="btn btn-outline-secondary btn-sm share-btn" data-share-url="{{ url_for('feed.view_post', post_id=post.id, _external=True) }}"><i class="bi bi-share"></i></button>
       <a href="{{ url_for('feed.view_post', post_id=post.id) }}" class="btn btn-outline-primary btn-sm">Ver publicación</a>
       {% if post.author_id == current_user.id %}
+      <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#editModal{{ post.id }}">Editar</button>
       <form action="{{ url_for('feed.eliminar_post', post_id=post.id) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar esta publicación?');">
         {{ csrf.csrf_field() }}
         <button type="submit" class="btn btn-outline-danger btn-sm">🗑️ Eliminar</button>
@@ -68,3 +69,25 @@
     </form>
   </div>
 </article>
+{% if post.author_id == current_user.id %}
+<div class="modal fade" id="editModal{{ post.id }}" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form method="post" action="{{ url_for('feed.editar_post', post_id=post.id) }}">
+        {{ csrf.csrf_field() }}
+        <div class="modal-header">
+          <h5 class="modal-title">Editar publicación</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <textarea name="content" class="form-control" rows="3" required>{{ post.content }}</textarea>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+          <button type="submit" class="btn btn-primary">Guardar</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+{% endif %}

--- a/crunevo/templates/feed/post_detail.html
+++ b/crunevo/templates/feed/post_detail.html
@@ -14,14 +14,14 @@
       <img src="{{ url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
       <span class="me-auto text-muted">Usuario eliminado</span>
       {% endif %}
-      <small class="text-muted">{{ post.created_at.strftime('%Y-%m-%d') }}</small>
+      <small class="text-muted">{{ post.created_at.strftime('%Y-%m-%d') }}{% if post.edited %} • Editado{% endif %}</small>
     </div>
     <p class="card-text">{{ post.content }}</p>
       {% if post.file_url %}
         {% if post.file_url.endswith('.pdf') %}
         <a href="{{ post.file_url }}" target="_blank" class="btn btn-outline-primary mb-2">Ver PDF</a>
         {% else %}
-        <img src="{{ post.file_url }}" class="img-fluid rounded mb-2">
+        <img src="{{ post.file_url }}" class="feed-image img-fluid rounded mb-2">
         {% endif %}
       {% endif %}
       <p class="text-muted small mb-2">

--- a/crunevo/templates/feed/trending.html
+++ b/crunevo/templates/feed/trending.html
@@ -29,7 +29,7 @@
           {% if post.file_url.endswith('.pdf') %}
           <a href="{{ post.file_url }}" target="_blank" class="btn btn-sm btn-outline-primary mb-2">Ver PDF</a>
           {% else %}
-          <img src="{{ post.file_url }}" class="img-fluid rounded mb-2">
+          <img src="{{ post.file_url }}" class="feed-image img-fluid rounded mb-2">
           {% endif %}
         {% endif %}
         {% if author %}

--- a/crunevo/templates/notes/detalle.html
+++ b/crunevo/templates/notes/detalle.html
@@ -27,6 +27,12 @@
         <button class="btn btn-outline-primary btn-sm" type="submit">🔗 Compartir</button>
       </form>
       <button type="button" class="btn btn-outline-secondary btn-sm share-btn" data-share-url="{{ url_for('notes.view_note', id=note.id, _external=True) }}">Copiar enlace</button>
+      {% if current_user.is_authenticated and note.user_id == current_user.id %}
+      <form action="{{ url_for('notes.delete_note', note_id=note.id) }}" method="post" class="d-inline" onsubmit="return confirm('¿Eliminar este apunte?');">
+        {{ csrf.csrf_field() }}
+        <button type="submit" class="btn btn-danger btn-sm">Eliminar</button>
+      </form>
+      {% endif %}
       {% if current_user.is_authenticated and current_user.id != note.author.id %}
       <form id="likeForm" method="post" action="{{ url_for('notes.like_note', note_id=note.id) }}" style="display:inline;">
         {{ csrf.csrf_field() }}

--- a/migrations/versions/8f4f51464309_add_post_edited_flag.py
+++ b/migrations/versions/8f4f51464309_add_post_edited_flag.py
@@ -1,0 +1,27 @@
+"""add post edited flag
+
+Revision ID: 8f4f51464309
+Revises: 8728b618b1f9
+Create Date: 2025-06-24 00:16:28.906872
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "8f4f51464309"
+down_revision = "8728b618b1f9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("post", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("edited", sa.Boolean(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("post", schema=None) as batch_op:
+        batch_op.drop_column("edited")

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -1,0 +1,31 @@
+from crunevo.models import Note, FeedItem
+from crunevo.utils.feed import create_feed_item_for_all
+
+
+def login(client, username, password):
+    return client.post("/login", data={"username": username, "password": password})
+
+
+def test_delete_own_note(client, db_session, test_user):
+    note = Note(title="n", filename="file.pdf", author=test_user)
+    db_session.add(note)
+    db_session.commit()
+    create_feed_item_for_all("apunte", note.id)
+
+    login(client, test_user.username, "secret")
+    resp = client.post(f"/notes/delete/{note.id}")
+    assert resp.status_code == 302
+    assert Note.query.get(note.id) is None
+    assert not any(i.get("ref_id") == note.id for i in FeedItem.query.all())
+
+
+def test_delete_note_forbidden(client, db_session, test_user, another_user):
+    note = Note(title="n", filename="file.pdf", author=test_user)
+    db_session.add(note)
+    db_session.commit()
+    create_feed_item_for_all("apunte", note.id)
+
+    login(client, another_user.username, "secret")
+    resp = client.post(f"/notes/delete/{note.id}")
+    assert resp.status_code == 403
+    assert Note.query.get(note.id) is not None


### PR DESCRIPTION
## Summary
- allow authors to delete their own notes and remove feed items
- enable post editing with modal and edited flag
- center feed images with CSS utility
- add regression tests for note deletion
- document changes in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6859ecffa7f48325ae1e835b65e9ebc9