### PR TITLE
Add note editing and report feature

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,3 +246,4 @@
 - Añadida funcionalidad para que los usuarios eliminen sus propios apuntes desde /notes y /perfil (PR notes-delete-user).
 - Botón "Editar" agregado en publicaciones del feed con marca visual (Editado) y control de permisos (PR post-edit).
 - Estilo CSS actualizado para centrar imágenes del feed y mejorar visualización móvil (PR feed-image-center).
+- Se añadió botón "Reportar" en apuntes y publicaciones con modal y notificación al admin. Se habilitó ruta /notes/edit/<id> para editar título, descripción, categoría y etiquetas (PR note-edit-report).

--- a/crunevo/templates/components/note_card.html
+++ b/crunevo/templates/components/note_card.html
@@ -11,11 +11,16 @@
     <div class="mt-auto d-flex justify-content-between align-items-center">
       <div>
         <a href="{{ url_for('notes.view_note', id=note.id) }}" class="btn btn-primary btn-sm">Ver detalle</a>
-        {% if current_user.is_authenticated and note.user_id == current_user.id %}
-        <form action="{{ url_for('notes.delete_note', note_id=note.id) }}" method="post" class="d-inline" onsubmit="return confirm('¿Eliminar este apunte?');">
-          {{ csrf.csrf_field() }}
-          <button type="submit" class="btn btn-outline-danger btn-sm">🗑️</button>
-        </form>
+        {% if current_user.is_authenticated %}
+          {% if note.user_id == current_user.id %}
+          <a href="{{ url_for('notes.edit_note', note_id=note.id) }}" class="btn btn-outline-secondary btn-sm">Editar</a>
+          <form action="{{ url_for('notes.delete_note', note_id=note.id) }}" method="post" class="d-inline" onsubmit="return confirm('¿Eliminar este apunte?');">
+            {{ csrf.csrf_field() }}
+            <button type="submit" class="btn btn-outline-danger btn-sm">🗑️</button>
+          </form>
+          {% else %}
+          <button type="button" class="btn btn-outline-warning btn-sm" data-bs-toggle="modal" data-bs-target="#reportNote{{ note.id }}">Reportar</button>
+          {% endif %}
         {% endif %}
       </div>
       <div class="text-muted small">
@@ -25,3 +30,25 @@
     </div>
   </div>
 </article>
+{% if current_user.is_authenticated and note.user_id != current_user.id %}
+<div class="modal fade" id="reportNote{{ note.id }}" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form method="post" action="{{ url_for('notes.report_note', note_id=note.id) }}">
+        {{ csrf.csrf_field() }}
+        <div class="modal-header">
+          <h5 class="modal-title">Reportar apunte</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <textarea name="reason" class="form-control" rows="3" placeholder="Motivo" required></textarea>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+          <button type="submit" class="btn btn-primary">Enviar</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+{% endif %}

--- a/crunevo/templates/feed/post_card.html
+++ b/crunevo/templates/feed/post_card.html
@@ -41,6 +41,8 @@
         {{ csrf.csrf_field() }}
         <button type="submit" class="btn btn-outline-danger btn-sm">🗑️ Eliminar</button>
       </form>
+      {% else %}
+      <button type="button" class="btn btn-outline-warning btn-sm" data-bs-toggle="modal" data-bs-target="#reportPost{{ post.id }}">Reportar</button>
       {% endif %}
     </div>
     <div id="comments{{ post.id }}">
@@ -85,6 +87,28 @@
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
           <button type="submit" class="btn btn-primary">Guardar</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+{% endif %}
+{% if current_user.is_authenticated and post.author_id != current_user.id %}
+<div class="modal fade" id="reportPost{{ post.id }}" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form method="post" action="{{ url_for('feed.report_post', post_id=post.id) }}">
+        {{ csrf.csrf_field() }}
+        <div class="modal-header">
+          <h5 class="modal-title">Reportar publicación</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <textarea name="reason" class="form-control" rows="3" placeholder="Motivo" required></textarea>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+          <button type="submit" class="btn btn-primary">Enviar</button>
         </div>
       </form>
     </div>

--- a/crunevo/templates/notes/detalle.html
+++ b/crunevo/templates/notes/detalle.html
@@ -28,12 +28,14 @@
       </form>
       <button type="button" class="btn btn-outline-secondary btn-sm share-btn" data-share-url="{{ url_for('notes.view_note', id=note.id, _external=True) }}">Copiar enlace</button>
       {% if current_user.is_authenticated and note.user_id == current_user.id %}
+      <a href="{{ url_for('notes.edit_note', note_id=note.id) }}" class="btn btn-outline-secondary btn-sm">Editar</a>
       <form action="{{ url_for('notes.delete_note', note_id=note.id) }}" method="post" class="d-inline" onsubmit="return confirm('¿Eliminar este apunte?');">
         {{ csrf.csrf_field() }}
         <button type="submit" class="btn btn-danger btn-sm">Eliminar</button>
       </form>
       {% endif %}
       {% if current_user.is_authenticated and current_user.id != note.author.id %}
+      <button type="button" class="btn btn-outline-warning btn-sm" data-bs-toggle="modal" data-bs-target="#reportNoteModal">Reportar</button>
       <form id="likeForm" method="post" action="{{ url_for('notes.like_note', note_id=note.id) }}" style="display:inline;">
         {{ csrf.csrf_field() }}
         <button class="btn btn-outline-success btn-sm" type="submit">👍 Me gusta</button>
@@ -66,6 +68,28 @@
     </form>
     {% endif %}
 </article>
+{% if current_user.is_authenticated and current_user.id != note.author.id %}
+<div class="modal fade" id="reportNoteModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form method="post" action="{{ url_for('notes.report_note', note_id=note.id) }}">
+        {{ csrf.csrf_field() }}
+        <div class="modal-header">
+          <h5 class="modal-title">Reportar apunte</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <textarea name="reason" class="form-control" rows="3" placeholder="Motivo" required></textarea>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+          <button type="submit" class="btn btn-primary">Enviar</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+{% endif %}
 <script>
 
 

--- a/crunevo/templates/notes/edit.html
+++ b/crunevo/templates/notes/edit.html
@@ -1,0 +1,42 @@
+{% extends 'base.html' %}
+{% import 'components/csrf.html' as csrf %}
+{% block content %}
+<div class="container py-5">
+  <div class="row justify-content-center">
+    <div class="col-md-8 col-lg-6">
+      <div class="card shadow-lg border-0">
+        <div class="card-body p-4 p-md-5">
+          <h3 class="card-title mb-4 text-center">Editar apunte</h3>
+          <form method="post" id="noteEditForm">
+            {{ csrf.csrf_field() }}
+
+            <div class="form-floating mb-3">
+              <input type="text" class="form-control" id="title" name="title" placeholder="Título" value="{{ note.title }}" required>
+              <label for="title">Título</label>
+            </div>
+
+            <div class="form-floating mb-3">
+              <textarea class="form-control" placeholder="Descripción" id="description" name="description" style="height: 120px">{{ note.description }}</textarea>
+              <label for="description">Descripción</label>
+            </div>
+
+            <div class="form-floating mb-3">
+              <input type="text" class="form-control" id="tags" name="tags" placeholder="Etiquetas (separadas por coma)" value="{{ note.tags }}">
+              <label for="tags">Etiquetas (ej. mate, física)</label>
+            </div>
+
+            <div class="form-floating mb-3">
+              <input type="text" class="form-control" id="category" name="category" placeholder="Categoría" value="{{ note.category }}">
+              <label for="category">Categoría</label>
+            </div>
+
+            <button type="submit" class="btn btn-primary w-100">Guardar cambios</button>
+          </form>
+        </div>
+      </div>
+</div>
+</div>
+</div>
+{% endblock %}
+
+

--- a/tests/test_report_edit.py
+++ b/tests/test_report_edit.py
@@ -1,0 +1,31 @@
+from crunevo.models import Note, Post, Report
+
+
+def login(client, username, password):
+    return client.post("/login", data={"username": username, "password": password})
+
+
+def test_edit_note(client, db_session, test_user):
+    note = Note(title="t", filename="file.pdf", author=test_user)
+    db_session.add(note)
+    db_session.commit()
+
+    login(client, test_user.username, "secret")
+    resp = client.post(
+        f"/notes/edit/{note.id}",
+        data={"title": "Nuevo", "description": "d", "category": "c", "tags": "x"},
+    )
+    assert resp.status_code == 302
+    db_session.refresh(note)
+    assert note.title == "Nuevo"
+
+
+def test_report_post(client, db_session, test_user, another_user):
+    post = Post(content="bad", author=test_user)
+    db_session.add(post)
+    db_session.commit()
+
+    login(client, another_user.username, "secret")
+    resp = client.post(f"/feed/post/reportar/{post.id}", data={"reason": "spam"})
+    assert resp.status_code == 302
+    assert Report.query.filter_by(user_id=another_user.id).count() == 1


### PR DESCRIPTION
## Summary
- allow authors to edit notes from `/notes/edit/<id>`
- add report modals for posts and notes
- notify admin when a report is filed
- add basic tests for editing notes and reporting posts
- document changes in AGENTS guidelines

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6859fac572588325851b0837f7e8dcc1