### PR TITLE
Improve store featured display

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,3 +251,4 @@
 - Ajustado ancho de detalle de apunte con container-xl y botón de descarga centrado (PR note-detail-width-fix).
 - Actualizado diseño de la tienda con grilla responsiva y tarjetas con borde morado; footer incluye acciones de detalle y compartir (PR store-grid)
 - Mejorado layout de tienda y favoritos usando container-fluid, textos truncados con line-clamp y tarjetas pulidas (PR store-layout-polish)
+- Nombres de productos con hasta 3 líneas y tamaño 1rem; sección derecha muestra tarjetas de destacados con mensaje vacío y botón "Ver" (PR store-featured-redesign)

--- a/crunevo/routes/store_routes.py
+++ b/crunevo/routes/store_routes.py
@@ -85,6 +85,7 @@ def store_index():
     favorite_ids = [fav.product_id for fav in favorites]
     purchased = Purchase.query.filter_by(user_id=current_user.id).all()
     purchased_ids = [p.product_id for p in purchased]
+    featured_products = Product.query.filter_by(is_featured=True).limit(3).all()
     return render_template(
         "store/store.html",
         products=products,
@@ -94,6 +95,7 @@ def store_index():
         categoria=categoria,
         precio_max=precio_max,
         ratings=ratings,
+        featured_products=featured_products,
     )
 
 

--- a/crunevo/static/css/store.css
+++ b/crunevo/static/css/store.css
@@ -10,6 +10,15 @@
 .product-desc {
   overflow: hidden;
   display: -webkit-box;
-  -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
+}
+
+.product-name {
+  -webkit-line-clamp: 3;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+}
+
+.product-desc {
+  -webkit-line-clamp: 2;
 }

--- a/crunevo/templates/store/favorites.html
+++ b/crunevo/templates/store/favorites.html
@@ -93,7 +93,7 @@
                     {% else %}
                       <span class="text-muted small">Sin stock</span>
                     {% endif %}
-                    <a href="{{ url_for('store.view_product', product_id=product.id) }}" class="btn btn-outline-primary btn-sm tw-whitespace-nowrap">Ver detalle</a>
+                    <a href="{{ url_for('store.view_product', product_id=product.id) }}" class="btn btn-outline-primary btn-sm tw-whitespace-nowrap"><i class="bi bi-search me-1"></i>Ver detalle</a>
                   </div>
                 </div>
               </div>

--- a/crunevo/templates/store/product_card.html
+++ b/crunevo/templates/store/product_card.html
@@ -32,7 +32,7 @@
     {% endif %}
   </div>
   <div class="card-footer bg-white border-0 pt-0 d-flex justify-content-between align-items-center">
-    <a href="{{ url_for('store.view_product', product_id=product.id) }}" class="btn btn-outline-primary btn-sm tw-whitespace-nowrap">Ver detalle</a>
-    <button type="button" class="btn btn-outline-secondary btn-sm share-btn" data-share-url="{{ url_for('store.view_product', product_id=product.id, _external=True) }}"><i class="bi bi-share"></i></button>
+    <a href="{{ url_for('store.view_product', product_id=product.id) }}" class="btn btn-outline-primary btn-sm tw-whitespace-nowrap"><i class="bi bi-search me-1"></i>Ver detalle</a>
+    <button type="button" class="btn btn-outline-secondary btn-sm share-btn" data-share-url="{{ url_for('store.view_product', product_id=product.id, _external=True) }}" title="Compartir este producto"><i class="bi bi-share"></i></button>
   </div>
 </div>

--- a/crunevo/templates/store/store.html
+++ b/crunevo/templates/store/store.html
@@ -125,8 +125,8 @@
                     {% if product.id in purchased_ids and product.download_url %}
                       <a href="{{ product.download_url }}" class="btn btn-success btn-sm" target="_blank">Descargar</a>
                     {% endif %}
-                    <a href="{{ url_for('store.view_product', product_id=product.id) }}" class="btn btn-outline-primary btn-sm tw-whitespace-nowrap">Ver detalle</a>
-                    <button type="button" class="btn btn-outline-secondary btn-sm share-btn" data-share-url="{{ url_for('store.view_product', product_id=product.id, _external=True) }}"><i class="bi bi-share"></i></button>
+                    <a href="{{ url_for('store.view_product', product_id=product.id) }}" class="btn btn-outline-primary btn-sm tw-whitespace-nowrap"><i class="bi bi-search me-1"></i>Ver detalle</a>
+                    <button type="button" class="btn btn-outline-secondary btn-sm share-btn" data-share-url="{{ url_for('store.view_product', product_id=product.id, _external=True) }}" title="Compartir este producto"><i class="bi bi-share"></i></button>
                   </div>
                 </div>
               </div>
@@ -144,11 +144,30 @@
       <div class="card">
         <div class="card-body">
           <h5 class="card-title">Productos destacados</h5>
-          <ul class="list-unstyled">
-            <li><a href="#">Pack estudiante</a></li>
-            <li><a href="#">Más vendidos</a></li>
-            <li><a href="#">Ofertas de la semana</a></li>
-          </ul>
+          {% if featured_products %}
+            <div class="row row-cols-1 row-cols-sm-2 g-2">
+              {% for fp in featured_products %}
+                <div class="col">
+                  <div class="card h-100">
+                    <img src="{{ fp.image if fp.image else url_for('static', filename='img/default_product.png') }}" class="card-img-top" alt="{{ fp.name }}">
+                    <div class="card-body p-2">
+                      <h6 class="product-name mb-1">{{ fp.name }}</h6>
+                      <p class="mb-1 text-primary fw-bold">
+                        {% if fp.price == 0 %}
+                          S/ 0
+                        {% else %}
+                          S/ {{ '%.2f' | format(fp.price) }}
+                        {% endif %}
+                      </p>
+                      <a href="{{ url_for('store.view_product', product_id=fp.id) }}" class="btn btn-primary btn-sm">Ver</a>
+                    </div>
+                  </div>
+                </div>
+              {% endfor %}
+            </div>
+          {% else %}
+            <p class="text-muted">Aún no hay destacados esta semana</p>
+          {% endif %}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- let product names span 3 lines and increase font size
- add view icon and share tooltip to product actions
- redesign featured products card with mini grid
- fetch featured products on store homepage
- document changes

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685a42af66488325b370d3cedbc1f79a