### PR TITLE
admin store badges enhancement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,3 +253,4 @@
 - Mejorado layout de tienda y favoritos usando container-fluid, textos truncados con line-clamp y tarjetas pulidas (PR store-layout-polish)
 - Nombres de productos con hasta 3 líneas y tamaño 1rem; sección derecha muestra tarjetas de destacados con mensaje vacío y botón "Ver" (PR store-featured-redesign)
 - Límite de 3 productos destacados con aviso en add_edit_product y verificación al guardar (PR featured-limit).
+- Página de administración de tienda muestra badges de Destacado, Popular, Nuevo y Stock bajo en una columna "Etiquetas" con tooltips. Productos se ordenan por etiquetas (PR admin-store-badges-enhancement).

--- a/crunevo/routes/admin_routes.py
+++ b/crunevo/routes/admin_routes.py
@@ -128,6 +128,10 @@ def manage_users():
 @activated_required
 def manage_store():
     products = Product.query.all()
+    products.sort(
+        key=lambda p: (p.is_featured, p.is_popular, p.is_new),
+        reverse=True,
+    )
     return render_template("admin/manage_store.html", products=products)
 
 

--- a/crunevo/templates/admin/manage_store.html
+++ b/crunevo/templates/admin/manage_store.html
@@ -18,6 +18,7 @@
         <tr>
           <th>ID</th>
           <th>Nombre</th>
+          <th>Etiquetas</th>
           <th>Precio S/</th>
           <th>Créditos</th>
           <th>Stock</th>
@@ -28,11 +29,23 @@
       {% for product in products %}
       <tr>
         <td>{{ product.id }}</td>
+        <td>{{ product.name }}</td>
         <td>
-          {{ product.name }}
-          {% if product.is_popular %}<span class="badge bg-warning text-dark ms-1">Popular</span>{% endif %}
-          {% if product.is_new %}<span class="badge bg-success ms-1">Nuevo</span>{% endif %}
-          {% if product.credits_only %}<span class="badge bg-info text-dark ms-1">Solo créditos</span>{% endif %}
+          {% if product.is_popular %}
+            <span class="badge bg-warning text-dark me-1" data-bs-toggle="tooltip" title="Muy solicitado por los estudiantes">Popular</span>
+          {% endif %}
+          {% if product.is_new %}
+            <span class="badge bg-success me-1" data-bs-toggle="tooltip" title="Producto recientemente agregado">Nuevo</span>
+          {% endif %}
+          {% if product.is_featured %}
+            <span class="badge bg-purple text-white me-1" data-bs-toggle="tooltip" title="Aparece en la sección de productos destacados">Destacado</span>
+          {% endif %}
+          {% if product.credits_only %}
+            <span class="badge bg-info text-dark me-1" data-bs-toggle="tooltip" title="No se puede comprar con dinero">Solo créditos</span>
+          {% endif %}
+          {% if product.stock <= 3 %}
+            <span class="badge bg-danger me-1" data-bs-toggle="tooltip" title="Stock bajo">Stock bajo</span>
+          {% endif %}
         </td>
         <td>{{ '%.2f'|format(product.price) }}</td>
         <td>{{ product.price_credits or '' }}</td>


### PR DESCRIPTION
## Summary
- feature highlight badge and tooltips on admin store
- add tags column with badges for various product states
- order products by featured, popular and new
- update agent instructions

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685a4bcdfddc83258430966992362c80