### PR TITLE
Remove admin featured product cap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,3 +255,4 @@
 - Límite de 3 productos destacados con aviso en add_edit_product y verificación al guardar (PR featured-limit).
 - Página de administración de tienda muestra badges de Destacado, Popular, Nuevo y Stock bajo en una columna "Etiquetas" con tooltips. Productos se ordenan por etiquetas (PR admin-store-badges-enhancement).
 - Sección de destacados en la tienda convertida en carrusel horizontal con scroll y sin límite de productos (PR store-featured-carousel).
+- Eliminado límite de 3 productos destacados en admin; ahora se pueden marcar todos los que se deseen (PR admin-featured-limit-removed).

--- a/crunevo/routes/admin_routes.py
+++ b/crunevo/routes/admin_routes.py
@@ -139,7 +139,6 @@ def manage_store():
 @activated_required
 @full_admin_required
 def add_product():
-    featured_count = Product.query.filter_by(is_featured=True).count()
     if request.method == "POST":
         name = request.form["name"]
         description = request.form.get("description")
@@ -147,9 +146,6 @@ def add_product():
         price_credits = request.form.get("price_credits", type=int)
         stock = int(request.form.get("stock", 0))
         is_featured = bool(request.form.get("is_featured"))
-        if is_featured and featured_count >= 3:
-            flash("Ya hay 3 productos destacados. Desmarca uno antes de añadir otro.")
-            return redirect(url_for("admin.add_product"))
         credits_only = bool(request.form.get("credits_only"))
         is_popular = bool(request.form.get("is_popular"))
         is_new = bool(request.form.get("is_new"))
@@ -195,14 +191,13 @@ def add_product():
         db.session.commit()
         flash("Producto agregado")
         return redirect(url_for("admin.manage_store"))
-    return render_template("admin/add_edit_product.html", featured_count=featured_count)
+    return render_template("admin/add_edit_product.html")
 
 
 @admin_bp.route("/products/<int:product_id>/edit", methods=["GET", "POST"])
 @full_admin_required
 def edit_product(product_id):
     product = Product.query.get_or_404(product_id)
-    featured_count = Product.query.filter_by(is_featured=True).count()
     if request.method == "POST":
         product.name = request.form["name"]
         product.description = request.form.get("description")
@@ -210,9 +205,6 @@ def edit_product(product_id):
         product.price_credits = request.form.get("price_credits", type=int)
         product.stock = int(request.form["stock"])
         new_featured = bool(request.form.get("is_featured"))
-        if new_featured and not product.is_featured and featured_count >= 3:
-            flash("Ya hay 3 productos destacados. Desmarca uno antes de añadir otro.")
-            return redirect(url_for("admin.edit_product", product_id=product.id))
         product.is_featured = new_featured
         product.credits_only = bool(request.form.get("credits_only"))
         product.is_popular = bool(request.form.get("is_popular"))
@@ -245,9 +237,7 @@ def edit_product(product_id):
         db.session.commit()
         flash("Producto actualizado correctamente")
         return redirect(url_for("admin.manage_store"))
-    return render_template(
-        "admin/add_edit_product.html", product=product, featured_count=featured_count
-    )
+    return render_template("admin/add_edit_product.html", product=product)
 
 
 @admin_bp.route("/products/<int:product_id>/delete", methods=["POST"])

--- a/crunevo/templates/admin/add_edit_product.html
+++ b/crunevo/templates/admin/add_edit_product.html
@@ -23,17 +23,10 @@
     <label class="form-label">Etiquetas</label>
     <div class="form-check form-switch">
       <input class="form-check-input" type="checkbox" name="is_featured" id="is_featured"
-        {% if product and product.is_featured %}checked{% endif %}
-        {% if featured_count >= 3 and not (product and product.is_featured) %}disabled{% endif %}>
+        {% if product and product.is_featured %}checked{% endif %}>
       <label class="form-check-label" for="is_featured">Destacado</label>
     </div>
-    {% if featured_count >= 3 and not (product and product.is_featured) %}
-    <div class="alert alert-warning small mt-2">
-      Ya hay 3 productos destacados. Desmarca uno para añadir otro.
-    </div>
-    {% else %}
-    <small class="text-muted">Actualmente hay {{ featured_count }} / 3 destacados</small>
-    {% endif %}
+    <small class="form-text text-muted">Los productos destacados se mostrarán en un carrusel especial dentro de la tienda.</small>
     <div class="form-check form-switch mt-2">
       <input class="form-check-input" type="checkbox" name="credits_only" id="credits_only" {% if product and product.credits_only %}checked{% endif %}>
       <label class="form-check-label" for="credits_only">Solo con créditos</label>


### PR DESCRIPTION
## Summary
- allow unlimited featured products in admin_routes
- clarify featured product info in admin product form
- record change in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685a535b20fc8325836870f658073efc