### PR TITLE
Improve store featured carousel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,3 +256,4 @@
 - Página de administración de tienda muestra badges de Destacado, Popular, Nuevo y Stock bajo en una columna "Etiquetas" con tooltips. Productos se ordenan por etiquetas (PR admin-store-badges-enhancement).
 - Sección de destacados en la tienda convertida en carrusel horizontal con scroll y sin límite de productos (PR store-featured-carousel).
 - Eliminado límite de 3 productos destacados en admin; ahora se pueden marcar todos los que se deseen (PR admin-featured-limit-removed).
+- Carrusel de destacados movido antes del título de tienda y tarjetas más compactas (PR store-featured-move-reduce).

--- a/crunevo/static/css/store.css
+++ b/crunevo/static/css/store.css
@@ -22,3 +22,21 @@
 .product-desc {
   -webkit-line-clamp: 2;
 }
+
+/* Featured products carousel */
+.featured-card {
+  min-width: 160px;
+}
+
+.featured-card .card-img-top {
+  height: 120px;
+  object-fit: cover;
+}
+
+.featured-title {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  font-size: 0.875rem;
+}

--- a/crunevo/templates/store/store.html
+++ b/crunevo/templates/store/store.html
@@ -63,41 +63,36 @@
 
     <!-- Contenido central -->
     <div class="col-lg-7">
-      <h2 class="mb-4">Tienda</h2>
       {% if featured_products %}
-        <div class="card p-3 shadow-sm mb-4">
+        <div class="mb-3 pb-2 border-bottom">
           <div class="d-flex justify-content-between align-items-center mb-2">
-            <h5 class="mb-0 text-primary fw-bold">🎖 Productos destacados</h5>
+            <h6 class="mb-0 fw-bold text-muted">🎖 Productos destacados</h6>
             <div class="carousel-controls d-none d-md-flex gap-2">
               <button id="scrollLeft" class="btn btn-sm btn-outline-secondary">&larr;</button>
               <button id="scrollRight" class="btn btn-sm btn-outline-secondary">&rarr;</button>
             </div>
           </div>
-          <div id="featured-carousel" class="d-flex overflow-auto gap-3" style="scroll-behavior: smooth;">
+          <div id="featured-carousel" class="row row-cols-auto g-2 overflow-auto flex-nowrap" style="scroll-behavior: smooth;">
             {% for product in featured_products %}
-              <div class="card border border-purple" style="min-width: 200px;">
-                <img src="{{ product.image if product.image else url_for('static', filename='img/default_product.png') }}" class="card-img-top" alt="{{ product.name }}">
-                <div class="card-body">
-                  <h6 class="card-title text-truncate">{{ product.name }}</h6>
-                  <p class="text-muted small">
-                    {% if product.price == 0 %}
-                      S/ 0
-                    {% else %}
-                      S/ {{ '%.2f'|format(product.price) }}
-                    {% endif %}
-                  </p>
-                  <a href="{{ url_for('store.view_product', product_id=product.id) }}" class="btn btn-sm btn-outline-primary w-100">Ver</a>
+              <div class="col">
+                <div class="card border-purple featured-card">
+                  <img src="{{ product.image if product.image else url_for('static', filename='img/default_product.png') }}" class="card-img-top" alt="{{ product.name }}">
+                  <div class="card-body p-2 text-center">
+                    <p class="featured-title mb-1">{{ product.name }}</p>
+                    <a href="{{ url_for('store.view_product', product_id=product.id) }}" class="btn btn-outline-primary btn-sm d-block mx-auto">Ver</a>
+                  </div>
                 </div>
               </div>
             {% endfor %}
           </div>
         </div>
       {% else %}
-        <div class="card p-3 shadow-sm mb-4">
-          <h5 class="mb-0 text-primary fw-bold mb-2">🎖 Productos destacados</h5>
+        <div class="mb-3 pb-2 border-bottom">
+          <h6 class="fw-bold text-muted mb-1">🎖 Productos destacados</h6>
           <p class="text-muted mb-0">Aún no hay destacados esta semana</p>
         </div>
       {% endif %}
+      <h2 class="mb-4">Tienda</h2>
       {% if request.args.get('free') %}
         <div class="alert alert-success">Recursos Gratuitos</div>
       {% endif %}


### PR DESCRIPTION
## Summary
- move featured products carousel before "Tienda" title
- reduce heading and card size for featured carousel
- add CSS for compact featured cards
- log change in AGENTS

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685a553a49ec8325a17044c3d02ef8fd