### PR TITLE
feed-image-preview-fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,3 +259,4 @@
 - Carrusel de destacados movido antes del título de tienda y tarjetas más compactas (PR store-featured-move-reduce).
 - Corrección de ordenamiento en admin/manage_store para manejar valores None (PR admin-store-sort-none-fix).
 - Mejorado carrusel de destacados con tarjetas modernas, imágenes cuadradas y contenedor con sombra (PR store-featured-card-style).
+- Input de imagen del feed usa id "feedImageInput" y contenedor "previewContainer" con vista previa instantánea (PR feed-image-preview-fix).

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -27,3 +27,11 @@
   margin-left: auto;
   margin-right: auto;
 }
+
+#previewContainer img {
+  border: 2px solid #6f42c1;
+  border-radius: 8px;
+  margin-top: 10px;
+  max-width: 100%;
+  object-fit: contain;
+}

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -202,17 +202,21 @@ function initQuickFilters() {
 }
 
 function initImagePreview() {
-  const input = document.getElementById('postImageInput');
-  const preview = document.getElementById('postImagePreview');
+  const input = document.getElementById('feedImageInput');
+  const preview = document.getElementById('previewContainer');
   if (!input || !preview) return;
   input.addEventListener('change', () => {
     const file = input.files[0];
-    if (file) {
-      preview.src = URL.createObjectURL(file);
-      preview.classList.remove('d-none');
+    if (file && file.type.startsWith('image/')) {
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        preview.innerHTML = `
+          <img src="${e.target.result}" alt="preview" class="img-fluid rounded" style="max-height: 300px;" />
+        `;
+      };
+      reader.readAsDataURL(file);
     } else {
-      preview.classList.add('d-none');
-      preview.removeAttribute('src');
+      preview.innerHTML = "<p class='text-danger'>Archivo no válido</p>";
     }
   });
 }

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -209,17 +209,21 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
-  const postInput = document.getElementById('postImageInput');
-  const postPreview = document.getElementById('postImagePreview');
-  if (postInput && postPreview) {
-    postInput.addEventListener('change', () => {
-      const file = postInput.files[0];
+  const imgInput = document.getElementById('feedImageInput');
+  const previewBox = document.getElementById('previewContainer');
+  if (imgInput && previewBox) {
+    imgInput.addEventListener('change', () => {
+      const file = imgInput.files[0];
       if (file && file.type.startsWith('image/')) {
-        postPreview.src = URL.createObjectURL(file);
-        postPreview.classList.remove('d-none');
+        const reader = new FileReader();
+        reader.onload = (e) => {
+          previewBox.innerHTML = `
+            <img src="${e.target.result}" alt="preview" class="img-fluid rounded" style="max-height: 300px;" />
+          `;
+        };
+        reader.readAsDataURL(file);
       } else {
-        postPreview.classList.add('d-none');
-        postPreview.removeAttribute('src');
+        previewBox.innerHTML = "<p class='text-danger'>Archivo no válido</p>";
       }
     });
   }

--- a/crunevo/templates/feed/index.html
+++ b/crunevo/templates/feed/index.html
@@ -25,13 +25,13 @@
               <a href="{{ url_for('notes.upload') }}" class="btn btn-outline-secondary btn-sm"><i class="bi bi-file-earmark-plus"></i> Apunte</a>
               <label class="btn btn-outline-secondary btn-sm mb-0">
                 <i class="bi bi-image"></i> Imagen
-                <input type="file" name="file" id="postImageInput" accept="image/*,.pdf" class="d-none">
+                <input type="file" name="file" id="feedImageInput" accept="image/*" class="d-none">
               </label>
               <button type="button" class="btn btn-outline-secondary btn-sm" disabled><i class="bi bi-trophy"></i> Logro</button>
             </div>
             <button id="postSubmitBtn" class="btn btn-primary btn-sm" type="submit">Publicar</button>
           </div>
-          <img id="postImagePreview" class="img-thumbnail mt-2 d-none" style="max-height: 150px;" alt="preview">
+          <div id="previewContainer" class="mt-2"></div>
         </form>
       </div>
     </div>

--- a/crunevo/templates/feed/list.html
+++ b/crunevo/templates/feed/list.html
@@ -25,13 +25,13 @@
               <a href="{{ url_for('notes.upload') }}" class="btn btn-outline-secondary btn-sm"><i class="bi bi-file-earmark-plus"></i> Apunte</a>
               <label class="btn btn-outline-secondary btn-sm mb-0">
                 <i class="bi bi-image"></i> Imagen
-                <input type="file" name="file" id="postImageInput" accept="image/*,.pdf" class="d-none">
+                <input type="file" name="file" id="feedImageInput" accept="image/*" class="d-none">
               </label>
               <button type="button" class="btn btn-outline-secondary btn-sm" disabled><i class="bi bi-trophy"></i> Logro</button>
             </div>
             <button class="btn btn-primary btn-sm" type="submit">Publicar</button>
           </div>
-        <img id="postImagePreview" class="img-thumbnail mt-2 d-none" style="max-height: 150px;" alt="preview">
+        <div id="previewContainer" class="mt-2"></div>
         </form>
       </div>
     </div>

--- a/crunevo/templates/feed/trending.html
+++ b/crunevo/templates/feed/trending.html
@@ -20,13 +20,13 @@
               <a href="{{ url_for('notes.upload') }}" class="btn btn-outline-secondary btn-sm"><i class="bi bi-file-earmark-plus"></i> Apunte</a>
               <label class="btn btn-outline-secondary btn-sm mb-0">
                 <i class="bi bi-image"></i> Imagen
-                <input type="file" name="file" id="postImageInput" accept="image/*,.pdf" class="d-none">
+                <input type="file" name="file" id="feedImageInput" accept="image/*" class="d-none">
               </label>
               <button type="button" class="btn btn-outline-secondary btn-sm" disabled><i class="bi bi-trophy"></i> Logro</button>
             </div>
             <button id="postSubmitBtn" class="btn btn-primary btn-sm" type="submit">Publicar</button>
           </div>
-          <img id="postImagePreview" class="img-thumbnail mt-2 d-none" style="max-height: 150px;" alt="preview">
+          <div id="previewContainer" class="mt-2"></div>
         </form>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add feed image preview container and input id
- show preview using FileReader in JS
- style preview image
- document change in AGENTS.md

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685ac86eb8088325af2e90bf79ca0e91