### PR TITLE
Improve dark mode and mobile UX

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,3 +260,4 @@
 - Corrección de ordenamiento en admin/manage_store para manejar valores None (PR admin-store-sort-none-fix).
 - Mejorado carrusel de destacados con tarjetas modernas, imágenes cuadradas y contenedor con sombra (PR store-featured-card-style).
 - Input de imagen del feed usa id "feedImageInput" y contenedor "previewContainer" con vista previa instantánea (PR feed-image-preview-fix).
+- Implementado modo oscuro en feed y tienda, scroll infinito e overlay móvil con offcanvas. Añadidas imágenes lazy (PR dark-scroll-overlay).

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -1,6 +1,6 @@
 let page = 1;
 const feed = document.getElementById('feed');
-const loadMore = document.getElementById('loadMore');
+const sentinel = document.getElementById('feedEnd');
 
 async function loadFeed() {
   const resp = await fetch(`/api/feed?page=${page}`);
@@ -24,8 +24,9 @@ async function loadFeed() {
       feed.insertAdjacentHTML('beforeend', html);
     }
   });
-  if (items.length < 10) {
-    loadMore.style.display = 'none';
+  if (items.length < 10 && observer) {
+    observer.disconnect();
+    sentinel.remove();
   }
   page++;
 }
@@ -82,8 +83,6 @@ function renderMensajeCard(data) {
   const highlight = data.is_highlight ? ' feed-card--highlight' : '';
   return `<div class="feed-card${highlight}">💬 ${data.text || ''}</div>`;
 }
-
-loadMore.addEventListener('click', loadFeed);
 
 function initFeedInteractions() {
   document.querySelectorAll('.like-form').forEach((form) => {
@@ -219,5 +218,16 @@ function initImagePreview() {
       preview.innerHTML = "<p class='text-danger'>Archivo no válido</p>";
     }
   });
+}
+
+let observer;
+function setupInfiniteScroll() {
+  if (!sentinel) return;
+  observer = new IntersectionObserver((entries) => {
+    if (entries[0].isIntersecting) {
+      loadFeed();
+    }
+  });
+  observer.observe(sentinel);
 }
 

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -93,6 +93,9 @@ document.addEventListener('DOMContentLoaded', () => {
   // load feed on feed page
   if (typeof loadFeed === 'function' && document.getElementById('feed')) {
     loadFeed();
+    if (typeof setupInfiniteScroll === 'function') {
+      setupInfiniteScroll();
+    }
   }
 
   if (typeof initFeedToggle === 'function') {

--- a/crunevo/templates/auth/login.html
+++ b/crunevo/templates/auth/login.html
@@ -31,7 +31,7 @@
     </div>
   </div>
   <div class="brand-block right-panel mt-lg-0">
-    <img src="https://res.cloudinary.com/dnp9trhfx/image/upload/v1750494930/a642d206-74ab-4361-adf4-0ec41cb013d2_nxqy63.png" alt="Logo CRUNEVO" class="brand-img">
+    <img loading="lazy" src="https://res.cloudinary.com/dnp9trhfx/image/upload/v1750494930/a642d206-74ab-4361-adf4-0ec41cb013d2_nxqy63.png" alt="Logo CRUNEVO" class="brand-img">
     <h1 class="brand-title">Bienvenido a CRUNEVO</h1>
     <p id="frase-bienvenida" class="welcome-phrase"></p>
   </div>

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -9,7 +9,7 @@
 <div class="row g-4">
   <div class="col-lg-4">
       <div class="card text-center">
-        <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle mx-auto mt-3" width="120" height="120" alt="avatar">
+        <img loading="lazy" src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle mx-auto mt-3" width="120" height="120" alt="avatar">
         <h3 class="mt-2">@{{ current_user.username }}
           {% if current_user.verification_level >= 2 %}
           <i class="bi bi-patch-check-fill ms-1" style="color:#4e7fff" data-bs-toggle="tooltip" title="Cuenta verificada por Crunevo"></i>

--- a/crunevo/templates/components/feed_card.html
+++ b/crunevo/templates/components/feed_card.html
@@ -1,20 +1,20 @@
-<article class="tw-rounded-2xl tw-shadow-sm tw-bg-white dark:tw-bg-gray-900 tw-p-4 tw-space-y-2">
+<article class="tw-rounded-2xl tw-shadow-sm bg-body text-body tw-p-4 tw-space-y-2">
   {% if note.thumbnail_url %}
-  <img src="{{ note.thumbnail_url }}" alt="vista previa" class="tw-rounded tw-w-full">
+  <img loading="lazy" src="{{ note.thumbnail_url }}" alt="vista previa" class="tw-rounded tw-w-full">
   {% else %}
-  <div class="tw-flex tw-items-center tw-justify-center tw-h-40 tw-bg-gray-100 dark:tw-bg-gray-800">
-    <i class="bi bi-file-earmark-text tw-text-4xl tw-text-gray-400"></i>
+  <div class="tw-flex tw-items-center tw-justify-center tw-h-40 bg-body-secondary">
+    <i class="bi bi-file-earmark-text tw-text-4xl text-body-secondary"></i>
   </div>
   {% endif %}
   <h3 class="tw-text-lg tw-font-semibold">{{ note.title }}</h3>
-  <p class="tw-text-sm tw-text-gray-600 dark:tw-text-gray-400">{{ note.description }}</p>
-  <ul class="tw-flex tw-flex-wrap tw-gap-1 tw-text-xs tw-text-gray-500 dark:tw-text-gray-400">
+  <p class="tw-text-sm text-body-secondary">{{ note.description }}</p>
+  <ul class="tw-flex tw-flex-wrap tw-gap-1 tw-text-xs text-body-secondary">
     {% for tag in (note.tags or '').split(',') if tag %}
     <li>#{{ tag }}</li>
     {% endfor %}
   </ul>
-  <div class="tw-text-xs tw-text-gray-500 dark:tw-text-gray-400">{{ note.author.username }} · {{ note.created_at|timesince }}</div>
-  <div class="tw-flex tw-gap-3 tw-text-xs tw-text-gray-500 dark:tw-text-gray-400">
+  <div class="tw-text-xs text-body-secondary">{{ note.author.username }} · {{ note.created_at|timesince }}</div>
+  <div class="tw-flex tw-gap-3 tw-text-xs text-body-secondary">
     <span><i class="bi bi-star-fill"></i> {{ note.downloads }}</span>
   </div>
   <a href="{{ url_for('notes.view_note', id=note.id) }}" class="tw-text-sm tw-underline">Ver detalle</a>

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-dark navbar-crunevo navbar-expand-md fixed-top">
   <div class="container-fluid">
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCrunevo" aria-controls="navbarCrunevo" aria-expanded="false" aria-label="Toggle navigation">
+    <button class="navbar-toggler d-md-none" type="button" data-bs-toggle="offcanvas" data-bs-target="#mobileMenu" aria-controls="mobileMenu" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
     <a class="navbar-brand ms-2" href="{{ url_for('feed.feed_home') }}">Crunevo</a>
@@ -8,6 +8,36 @@
       <input class="form-control" type="search" placeholder="Buscar" aria-label="Buscar" id="globalSearchInput" autocomplete="off">
       <div id="searchSuggestions" class="position-absolute start-0 w-100 bg-white border rounded shadow"></div>
     </form>
+    <div class="offcanvas offcanvas-start d-md-none text-bg-dark" tabindex="-1" id="mobileMenu" aria-labelledby="mobileMenuLabel">
+      <div class="offcanvas-header">
+        <h5 class="offcanvas-title" id="mobileMenuLabel">Menú</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+      </div>
+      <div class="offcanvas-body">
+        <ul class="navbar-nav flex-column gap-2">
+          <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('feed.feed_home') }}"><i class="bi bi-house-door me-1"></i>Inicio</a></li>
+          <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('feed.trending') }}"><i class="bi bi-fire me-1"></i>Tendencias</a></li>
+          <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('notes.list_notes') }}"><i class="bi bi-journal-text me-1"></i>Apuntes</a></li>
+          <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('store.store_index') }}"><i class="bi bi-bag me-1"></i>Tienda</a></li>
+          <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('ranking.show_ranking') }}"><i class="bi bi-trophy me-1"></i>Ranking</a></li>
+          <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('chat.chat_index') }}"><i class="bi bi-chat-dots me-1"></i>Chat</a></li>
+          {% if config.ADMIN_INSTANCE and current_user.is_authenticated and current_user.role == 'admin' %}
+          <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('admin.dashboard') }}"><i class="bi bi-speedometer2 me-1"></i>Admin</a></li>
+          {% endif %}
+          {% if current_user.is_authenticated %}
+          <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('auth.perfil') }}"><i class="bi bi-person-circle me-1"></i>Perfil</a></li>
+          <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('auth.logout') }}"><i class="bi bi-box-arrow-right me-1"></i>Salir</a></li>
+          <li class="nav-item text-white mx-2"><i class="bi bi-coin"></i> {{ current_user.credits }}</li>
+          {% else %}
+          <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('auth.login') }}"><i class="bi bi-box-arrow-in-right me-1"></i>Iniciar sesión</a></li>
+          <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('onboarding.register') }}"><i class="bi bi-person-plus me-1"></i>Registrarse</a></li>
+          {% endif %}
+          <li class="nav-item">
+            <button class="btn btn-sm btn-secondary" type="button" data-theme-toggle><i class="bi bi-moon"></i></button>
+          </li>
+        </ul>
+      </div>
+    </div>
     <div class="collapse navbar-collapse" id="navbarCrunevo">
       <ul class="navbar-nav ms-auto d-flex flex-column flex-md-row align-items-center gap-2">
         <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('feed.feed_home') }}"><i class="bi bi-house-door me-1"></i>Inicio</a></li>

--- a/crunevo/templates/components/post_card.html
+++ b/crunevo/templates/components/post_card.html
@@ -1,7 +1,7 @@
 <article class="card shadow-sm mb-3">
   <div class="card-header bg-transparent d-flex align-items-center gap-2">
     {% set author = post.author %}
-    <img src="{{ (author and author.avatar_url) or url_for('static', filename='img/default.png') }}" class="rounded-circle" width="40" height="40" alt="avatar">
+    <img loading="lazy" src="{{ (author and author.avatar_url) or url_for('static', filename='img/default.png') }}" class="rounded-circle" width="40" height="40" alt="avatar">
     <div class="flex-grow-1">
       {% if author %}
       <a href="{{ url_for('auth.profile_by_username', username=author.username) }}" class="fw-bold text-decoration-none">{{ author.username }}</a><br>
@@ -23,7 +23,7 @@
       {% if post.file_url.endswith('.pdf') %}
         <a href="{{ post.file_url }}" target="_blank" class="btn btn-sm btn-outline-primary mb-2">Ver PDF</a>
       {% else %}
-        <img src="{{ post.file_url }}" class="img-fluid rounded mb-2" style="object-fit: cover; width:100%; max-height:400px;" alt="imagen">
+        <img loading="lazy" src="{{ post.file_url }}" class="img-fluid rounded mb-2" style="object-fit: cover; width:100%; max-height:400px;" alt="imagen">
       {% endif %}
     {% endif %}
     <div class="d-flex align-items-center gap-2 mb-2">
@@ -39,7 +39,7 @@
       {% if post.comments %}
         {% for c in post.comments|sort(attribute='timestamp', reverse=True) %}
         <div class="d-flex mb-2">
-          <img src="{{ c.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
+          <img loading="lazy" src="{{ c.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
           <div>
             <div class="small text-muted">
               <a href="{{ url_for('auth.profile_by_username', username=c.author.username) }}" class="text-decoration-none">{{ c.author.username }}</a> • {{ c.timestamp|timesince }}

--- a/crunevo/templates/emails/confirm.html
+++ b/crunevo/templates/emails/confirm.html
@@ -46,7 +46,7 @@
 </head>
 <body>
     <div class="container">
-        <img src="https://res.cloudinary.com/dnp9trhfx/image/upload/v1750493478/ChatGPT_Image_21_jun_2025_03_10_48_a.m._orljvz.png" alt="CRUNEVO Logo" class="logo">
+        <img loading="lazy" src="https://res.cloudinary.com/dnp9trhfx/image/upload/v1750493478/ChatGPT_Image_21_jun_2025_03_10_48_a.m._orljvz.png" alt="CRUNEVO Logo" class="logo">
         <h1>¡Estás a un paso de unirte a CRUNEVO!</h1>
         <p>Gracias por registrarte en <strong>CRUNEVO</strong>, la comunidad educativa donde compartes, aprendes y avanzas.</p>
         <p>Para completar tu registro y activar tu cuenta, haz clic en el siguiente botón:</p>

--- a/crunevo/templates/feed/feed.html
+++ b/crunevo/templates/feed/feed.html
@@ -33,7 +33,7 @@
       <form method="post" enctype="multipart/form-data" class="mb-4">
       {{ csrf.csrf_field() }}
       <div class="d-flex mb-2">
-        <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
+        <img loading="lazy" src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
         <textarea name="content" class="form-control" rows="3" placeholder="¿Qué deseas compartir?" required></textarea>
       </div>
       <div class="d-flex justify-content-between align-items-center gap-2">
@@ -65,12 +65,12 @@
           {% endif %}
           {% set author = post.author %}
           {% if author %}
-          <img src="{{ author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
+          <img loading="lazy" src="{{ author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
           <a href="{{ url_for('auth.profile_by_username', username=author.username) }}" class="me-auto text-decoration-none">
             <strong>{{ author.username }}</strong>
           </a>
           {% else %}
-          <img src="{{ url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
+          <img loading="lazy" src="{{ url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
           <span class="me-auto text-muted">Usuario eliminado</span>
           {% endif %}
           <small class="text-muted">{{ post.created_at|timesince }}</small>
@@ -80,7 +80,7 @@
           {% if post.file_url.endswith('.pdf') %}
           <a href="{{ post.file_url }}" target="_blank" class="btn btn-sm btn-outline-primary mb-2">Ver PDF</a>
           {% else %}
-          <img src="{{ post.file_url }}" class="feed-image img-fluid rounded mb-2">
+          <img loading="lazy" src="{{ post.file_url }}" class="feed-image img-fluid rounded mb-2">
           {% endif %}
         {% endif %}
         <a href="{{ url_for('feed.view_post', post_id=post.id) }}" class="btn btn-sm btn-outline-primary mb-2">Ver publicación</a>
@@ -114,7 +114,7 @@
             {% if post.comments %}
               {% for c in post.comments|sort(attribute='timestamp', reverse=True) %}
               <div class="d-flex mb-3 comment">
-                <img src="{{ c.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
+                <img loading="lazy" src="{{ c.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
                 <div>
                   <div class="small text-muted">
                     <a href="{{ url_for('auth.profile_by_username', username=c.author.username) }}" class="text-decoration-none">{{ c.author.username }}</a> • {{ c.timestamp|timesince }}

--- a/crunevo/templates/feed/index.html
+++ b/crunevo/templates/feed/index.html
@@ -15,7 +15,7 @@
     <div class="card shadow-sm mb-3">
       <div class="card-body">
         <div class="d-flex mb-3">
-          <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
+          <img loading="lazy" loading="lazy" src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
           <textarea name="content" form="postForm" class="form-control" rows="2" placeholder="¿Qué deseas compartir?" required></textarea>
         </div>
         <form id="postForm" method="post" enctype="multipart/form-data">
@@ -48,6 +48,9 @@
           {% include 'feed/post_card.html' %}
         {% endif %}
       {% endfor %}
+    </div>
+    <div id="feedEnd" class="my-3 text-center">
+      <div class="spinner-border" role="status"></div>
     </div>
     {% if not feed_items %}
       <div class="text-center my-5 text-muted">Aún no hay publicaciones. Sé el primero en compartir algo con la comunidad.</div>

--- a/crunevo/templates/feed/list.html
+++ b/crunevo/templates/feed/list.html
@@ -15,7 +15,7 @@
     <div class="card shadow-sm mb-3">
       <div class="card-body">
         <div class="d-flex mb-3">
-          <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
+          <img loading="lazy" src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
           <textarea name="content" form="postForm" class="form-control" rows="2" placeholder="¿Qué deseas compartir?" required></textarea>
         </div>
         <form id="postForm" method="post" enctype="multipart/form-data">

--- a/crunevo/templates/feed/post_card.html
+++ b/crunevo/templates/feed/post_card.html
@@ -2,7 +2,7 @@
 <article class="card shadow-sm mb-3">
   <div class="card-header bg-transparent d-flex align-items-center gap-2">
     {% set author = post.author %}
-    <img src="{{ (author and author.avatar_url) or url_for('static', filename='img/default.png') }}" class="rounded-circle" width="40" height="40" alt="avatar">
+    <img loading="lazy" src="{{ (author and author.avatar_url) or url_for('static', filename='img/default.png') }}" class="rounded-circle" width="40" height="40" alt="avatar">
     <div class="flex-grow-1">
       {% if author %}
       <a href="{{ url_for('auth.profile_by_username', username=author.username) }}" class="fw-bold text-decoration-none">{{ author.username }}</a><br>
@@ -24,7 +24,7 @@
       {% if post.file_url.endswith('.pdf') %}
         <a href="{{ post.file_url }}" target="_blank" class="btn btn-sm btn-outline-primary mb-2">Ver PDF</a>
       {% else %}
-        <img src="{{ post.file_url }}" class="feed-image img-fluid rounded mt-2" style="max-height: 400px; width: auto;" alt="imagen">
+        <img loading="lazy" src="{{ post.file_url }}" class="feed-image img-fluid rounded mt-2" style="max-height: 400px; width: auto;" alt="imagen">
       {% endif %}
     {% endif %}
     <div class="d-flex align-items-center gap-2 mb-2">
@@ -49,7 +49,7 @@
       {% if post.comments %}
         {% for c in post.comments|sort(attribute='timestamp', reverse=True) %}
         <div class="d-flex mb-2">
-          <img src="{{ c.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
+          <img loading="lazy" src="{{ c.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
           <div>
             <div class="small text-muted">
               <a href="{{ url_for('auth.profile_by_username', username=c.author.username) }}" class="text-decoration-none">{{ c.author.username }}</a> • {{ c.timestamp|timesince }}

--- a/crunevo/templates/feed/post_detail.html
+++ b/crunevo/templates/feed/post_detail.html
@@ -6,12 +6,12 @@
     <div class="d-flex align-items-center mb-2">
       {% set author = post.author %}
       {% if author %}
-      <img src="{{ author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
+      <img loading="lazy" src="{{ author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
       <a href="{{ url_for('auth.profile_by_username', username=author.username) }}" class="me-auto text-decoration-none">
         <strong>{{ author.username }}</strong>
       </a>
       {% else %}
-      <img src="{{ url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
+      <img loading="lazy" src="{{ url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
       <span class="me-auto text-muted">Usuario eliminado</span>
       {% endif %}
       <small class="text-muted">{{ post.created_at.strftime('%Y-%m-%d') }}{% if post.edited %} • Editado{% endif %}</small>
@@ -21,7 +21,7 @@
         {% if post.file_url.endswith('.pdf') %}
         <a href="{{ post.file_url }}" target="_blank" class="btn btn-outline-primary mb-2">Ver PDF</a>
         {% else %}
-        <img src="{{ post.file_url }}" class="feed-image img-fluid rounded mb-2">
+        <img loading="lazy" src="{{ post.file_url }}" class="feed-image img-fluid rounded mb-2">
         {% endif %}
       {% endif %}
       <p class="text-muted small mb-2">
@@ -55,7 +55,7 @@
         {% if post.comments %}
           {% for c in post.comments|sort(attribute='timestamp', reverse=True) %}
           <div class="d-flex mb-3 comment">
-            <img src="{{ c.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
+            <img loading="lazy" src="{{ c.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
             <div>
               <div class="small text-muted">
                 <a href="{{ url_for('auth.profile_by_username', username=c.author.username) }}" class="text-decoration-none">{{ c.author.username }}</a> • {{ c.timestamp.strftime('%Y-%m-%d %H:%M') }}

--- a/crunevo/templates/feed/trending.html
+++ b/crunevo/templates/feed/trending.html
@@ -10,7 +10,7 @@
     <div class="card shadow-sm mb-3">
       <div class="card-body">
         <div class="d-flex mb-3">
-          <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
+          <img loading="lazy" src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
           <textarea name="content" form="postForm" class="form-control" rows="2" placeholder="¿Qué deseas compartir?" required></textarea>
         </div>
         <form id="postForm" method="post" action="{{ url_for('feed.view_feed') }}" enctype="multipart/form-data">
@@ -41,10 +41,10 @@
         <div class="d-flex align-items-center mb-2">
           {% set author = post.author %}
           {% if author %}
-          <img src="{{ author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
+          <img loading="lazy" src="{{ author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
           <a href="{{ url_for('auth.profile_by_username', username=author.username) }}" class="me-auto text-decoration-none"><strong>{{ author.username }}</strong></a>
           {% else %}
-          <img src="{{ url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
+          <img loading="lazy" src="{{ url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
           <span class="me-auto text-muted">Usuario eliminado</span>
           {% endif %}
           <small class="text-muted">{{ post.created_at|timesince }}</small>
@@ -54,7 +54,7 @@
           {% if post.file_url.endswith('.pdf') %}
           <a href="{{ post.file_url }}" target="_blank" class="btn btn-sm btn-outline-primary mb-2">Ver PDF</a>
           {% else %}
-          <img src="{{ post.file_url }}" class="feed-image img-fluid rounded mb-2">
+          <img loading="lazy" src="{{ post.file_url }}" class="feed-image img-fluid rounded mb-2">
           {% endif %}
         {% endif %}
         {% if author %}

--- a/crunevo/templates/notes/detalle.html
+++ b/crunevo/templates/notes/detalle.html
@@ -5,7 +5,7 @@
 <div class="container-xl my-4">
   <article class="card mx-auto p-4">
     <div class="d-flex align-items-center mb-3">
-      <img src="{{ note.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
+      <img loading="lazy" src="{{ note.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
       <div>
         <a href="{{ url_for('auth.profile_by_username', username=note.author.username) }}" class="text-decoration-none">
           <strong>{{ note.author.username }}</strong>
@@ -51,7 +51,7 @@
     <div id="comments">
       {% for c in note.comments|sort(attribute='created_at', reverse=True) %}
       <div class="d-flex mb-3 comment">
-        <img src="{{ c.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
+        <img loading="lazy" src="{{ c.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
         <div>
           <div class="small text-muted">
             <a href="{{ url_for('auth.profile_by_username', username=c.author.username) }}" class="text-decoration-none">{{ c.author.username }}</a> • {{ c.created_at.strftime('%Y-%m-%d %H:%M') }}
@@ -108,7 +108,7 @@
     }).then(r => r.json()).then(c => {
       const div = document.createElement('div');
       div.className = 'd-flex mb-3 comment';
-      div.innerHTML = `<img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar"><div><div class=\"small text-muted\">${c.author} • ${c.timestamp}</div><div>${c.body}</div></div>`;
+      div.innerHTML = `<img loading="lazy" src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar"><div><div class=\"small text-muted\">${c.author} • ${c.timestamp}</div><div>${c.body}</div></div>`;
       document.getElementById('comments').prepend(div);
       e.target.reset();
       showToast('Comentario agregado');

--- a/crunevo/templates/notes/upload.html
+++ b/crunevo/templates/notes/upload.html
@@ -35,7 +35,7 @@
               <input class="form-control" type="file" id="file" name="file" accept="application/pdf,image/*" required>
             </div>
             <canvas id="pdfPreview" class="w-100 border rounded shadow-sm mb-3 tw-hidden" style="max-height:400px;"></canvas>
-            <img id="imgPreview" class="img-fluid border rounded shadow-sm mb-3 tw-hidden" style="max-height:400px;" />
+            <img loading="lazy" id="imgPreview" class="img-fluid border rounded shadow-sm mb-3 tw-hidden" style="max-height:400px;" />
 
             <button type="submit" class="btn btn-primary w-100" id="uploadBtn">Subir</button>
           </form>

--- a/crunevo/templates/onboarding/finish.html
+++ b/crunevo/templates/onboarding/finish.html
@@ -19,7 +19,7 @@
               <span class="form-text">o pega un enlace de imagen:</span>
               <input class="form-control" type="url" id="avatarUrlInput" name="avatar_url" placeholder="https://...">
             </div>
-            <img id="avatarPreview" src="#" alt="Preview" class="tw-hidden mb-2 rounded-circle" width="96" height="96">
+            <img loading="lazy" id="avatarPreview" src="#" alt="Preview" class="tw-hidden mb-2 rounded-circle" width="96" height="96">
             <div class="mb-3">
               <label for="bioInput" class="form-label">Biografía</label>
               <textarea class="form-control" id="bioInput" name="bio" rows="3" placeholder="Cuéntanos sobre ti"></textarea>

--- a/crunevo/templates/perfil_publico.html
+++ b/crunevo/templates/perfil_publico.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="container my-4">
   <div class="text-center mb-5">
-    <img src="{{ user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle mb-3" width="120" height="120" alt="avatar">
+    <img loading="lazy" src="{{ user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle mb-3" width="120" height="120" alt="avatar">
     <h1 class="fw-bold mb-0">@{{ user.username }}
       {% if user.verification_level >= 2 %}
       <i class="bi bi-patch-check-fill ms-1" style="color:#4e7fff" data-bs-toggle="tooltip" title="Cuenta verificada por Crunevo"></i>

--- a/crunevo/templates/ranking/index.html
+++ b/crunevo/templates/ranking/index.html
@@ -28,7 +28,7 @@
         {% if loop.index == 1 %}<i class="bi bi-trophy-fill text-warning"></i>{% elif loop.index == 2 %}<i class="bi bi-trophy-fill text-secondary"></i>{% elif loop.index == 3 %}<i class="bi bi-trophy-fill text-brown"></i>{% else %}{{ loop.index }}{% endif %}
       </td>
       <td>
-        <img src="{{ user.avatar_url or url_for('static', filename='img/default.png') }}" width="32" height="32" class="rounded-circle me-1">
+        <img loading="lazy" src="{{ user.avatar_url or url_for('static', filename='img/default.png') }}" width="32" height="32" class="rounded-circle me-1">
         {{ user.username }}
       </td>
       <td class="text-end"><strong>{{ '%.0f'|format(total) }}</strong></td>

--- a/crunevo/templates/store/carrito.html
+++ b/crunevo/templates/store/carrito.html
@@ -25,7 +25,7 @@
           <tr>
             <td>
               <div class="d-flex align-items-center">
-                <img src="{{ item.product.first_image or '/static/img/producto-default.png' }}" alt="{{ item.product.name }}" class="me-3 rounded" width="60">
+                <img loading="lazy" src="{{ item.product.first_image or '/static/img/producto-default.png' }}" alt="{{ item.product.name }}" class="me-3 rounded" width="60">
                 <div>
                   <strong>{{ item.product.name }}</strong><br>
                   <small class="text-muted">{{ item.product.description[:60] }}</small>

--- a/crunevo/templates/store/compras.html
+++ b/crunevo/templates/store/compras.html
@@ -12,7 +12,7 @@
     <div class="card mb-3">
       <div class="row g-0">
         <div class="col-md-2 text-center">
-          <img src="{{ compra.product.image_url or '/static/img/producto-default.png' }}" class="img-fluid rounded-start">
+          <img loading="lazy" src="{{ compra.product.image_url or '/static/img/producto-default.png' }}" class="img-fluid rounded-start">
         </div>
         <div class="col-md-10">
           <div class="card-body">

--- a/crunevo/templates/store/favorites.html
+++ b/crunevo/templates/store/favorites.html
@@ -61,7 +61,7 @@
             {% for product in products %}
               <div class="col">
                 <div class="card position-relative h-100 border border-primary p-2">
-                  <img src="{{ product.image_url or '/static/img/producto-default.png' }}" class="card-img-top rounded mb-2" alt="{{ product.name }}">
+                  <img loading="lazy" src="{{ product.image_url or '/static/img/producto-default.png' }}" class="card-img-top rounded mb-2" alt="{{ product.name }}">
                   <form method="post" action="{{ url_for('store.toggle_favorite', product_id=product.id) }}" class="position-absolute top-0 end-0 m-2">
                     {{ csrf.csrf_field() }}
                     <button class="btn btn-sm btn-light border-0" type="submit">
@@ -80,12 +80,12 @@
                     <div class="mb-2">
                       {% if product.is_new %}<span class="badge bg-success">Nuevo</span>{% endif %}
                       {% if product.is_popular %}<span class="badge bg-danger">Popular</span>{% endif %}
-                      {% if product.credits_only %}<span class="badge bg-warning text-dark">Solo créditos</span>{% endif %}
+                      {% if product.credits_only %}<span class="badge bg-warning text-body">Solo créditos</span>{% endif %}
                       {% if product.is_featured %}<span class="badge bg-purple text-white">Destacado</span>{% endif %}
                       {% if product.id in purchased_ids %}<span class="badge bg-secondary">Adquirido</span>{% endif %}
                     </div>
                   </div>
-                  <div class="card-footer bg-white border-0 pt-0 d-flex justify-content-between align-items-center">
+                  <div class="card-footer bg-body border-0 pt-0 d-flex justify-content-between align-items-center">
                     {% if product.id in purchased_ids and product.download_url %}
                       <a href="{{ product.download_url }}" class="btn btn-success btn-sm" target="_blank">Descargar</a>
                     {% elif product.stock > 0 %}

--- a/crunevo/templates/store/product_card.html
+++ b/crunevo/templates/store/product_card.html
@@ -2,18 +2,18 @@
 {% import 'components/csrf.html' as csrf %}
 <div class="card h-100 border border-primary p-2 position-relative">
   <a href="{{ url_for('store.view_product', product_id=product.id) }}">
-    <img src="{{ product.first_image or '/static/img/producto-default.png' }}" class="card-img-top rounded mb-2 img-fluid" style="max-height: 180px; object-fit: cover;" alt="imagen">
+    <img loading="lazy" src="{{ product.first_image or '/static/img/producto-default.png' }}" class="card-img-top rounded mb-2 img-fluid" style="max-height: 180px; object-fit: cover;" alt="imagen">
   </a>
   <div class="position-absolute top-0 start-0 m-2 tw-space-x-1">
-    {% if product.category %}<span class="badge bg-info text-dark">{{ product.category }}</span>{% endif %}
+    {% if product.category %}<span class="badge bg-info text-body">{{ product.category }}</span>{% endif %}
     {% if product.is_new %}<span class="badge bg-primary">Nuevo</span>{% endif %}
-    {% if product.is_popular %}<span class="badge bg-warning text-dark">Popular</span>{% endif %}
-    {% if product.credits_only %}<span class="badge bg-info text-dark">Solo con créditos</span>{% endif %}
+    {% if product.is_popular %}<span class="badge bg-warning text-body">Popular</span>{% endif %}
+    {% if product.credits_only %}<span class="badge bg-info text-body">Solo con créditos</span>{% endif %}
     {% if product.is_featured %}<span class="badge bg-success">Destacado</span>{% endif %}
   </div>
   <div class="card-body d-flex flex-column">
     <h5 class="card-title product-name">
-      <a href="{{ url_for('store.view_product', product_id=product.id) }}" class="text-decoration-none text-dark">
+      <a href="{{ url_for('store.view_product', product_id=product.id) }}" class="text-decoration-none text-body">
         {{ product.name }}
       </a>
     </h5>
@@ -31,7 +31,7 @@
       <span class="badge bg-secondary mb-2">Próximamente</span>
     {% endif %}
   </div>
-  <div class="card-footer bg-white border-0 pt-0 d-flex justify-content-between align-items-center">
+  <div class="card-footer bg-body border-0 pt-0 d-flex justify-content-between align-items-center">
     <a href="{{ url_for('store.view_product', product_id=product.id) }}" class="btn btn-outline-primary btn-sm tw-whitespace-nowrap"><i class="bi bi-search me-1"></i>Ver detalle</a>
     <button type="button" class="btn btn-outline-secondary btn-sm share-btn" data-share-url="{{ url_for('store.view_product', product_id=product.id, _external=True) }}" title="Compartir este producto"><i class="bi bi-share"></i></button>
   </div>

--- a/crunevo/templates/store/producto.html
+++ b/crunevo/templates/store/producto.html
@@ -9,7 +9,7 @@
 <div class="container my-5">
   <div class="row g-4 align-items-start">
     <div class="col-lg-6 text-center">
-      <img src="{{ product.image_url or product.image or '/static/img/producto-default.png' }}" class="img-fluid rounded shadow-sm big-product-img" alt="{{ product.name }}">
+      <img loading="lazy" src="{{ product.image_url or product.image or '/static/img/producto-default.png' }}" class="img-fluid rounded shadow-sm big-product-img" alt="{{ product.name }}">
     </div>
     <div class="col-lg-6">
       <h1 class="h3 fw-bold mb-3">{{ product.name }}

--- a/crunevo/templates/store/store.html
+++ b/crunevo/templates/store/store.html
@@ -64,7 +64,7 @@
     <!-- Contenido central -->
     <div class="col-lg-7">
       {% if featured_products %}
-        <div class="card shadow-sm border-0 mb-4 px-3 py-2 bg-white">
+        <div class="card shadow-sm border-0 mb-4 px-3 py-2 bg-body">
           <div class="d-flex justify-content-between align-items-center mb-2">
             <h6 class="mb-0 fw-bold text-muted">🎖 Productos destacados</h6>
             <div class="carousel-controls d-none d-md-flex gap-2">
@@ -76,7 +76,7 @@
             {% for product in featured_products %}
               <div class="col">
                 <div class="card border-purple featured-card">
-                  <img src="{{ product.image if product.image else url_for('static', filename='img/default_product.png') }}" class="card-img-top" alt="{{ product.name }}">
+                  <img loading="lazy" src="{{ product.image if product.image else url_for('static', filename='img/default_product.png') }}" class="card-img-top" alt="{{ product.name }}">
                   <div class="card-body p-2 text-center">
                     <p class="featured-title mb-1">{{ product.name }}</p>
                     <a href="{{ url_for('store.view_product', product_id=product.id) }}" class="btn btn-outline-primary btn-sm d-block mx-auto">Ver</a>
@@ -87,7 +87,7 @@
           </div>
         </div>
       {% else %}
-        <div class="card shadow-sm border-0 mb-4 px-3 py-2 bg-white">
+        <div class="card shadow-sm border-0 mb-4 px-3 py-2 bg-body">
           <h6 class="fw-bold text-muted mb-1">🎖 Productos destacados</h6>
           <p class="text-muted mb-0">Aún no hay destacados esta semana</p>
         </div>
@@ -150,7 +150,7 @@
                       {% if product.id in purchased_ids %}<span class="badge bg-secondary">Adquirido</span>{% endif %}
                     </div>
                   </div>
-                  <div class="card-footer bg-white border-0 pt-0 d-flex justify-content-between align-items-center">
+                  <div class="card-footer bg-body border-0 pt-0 d-flex justify-content-between align-items-center">
                     {% if product.id in purchased_ids and product.download_url %}
                       <a href="{{ product.download_url }}" class="btn btn-success btn-sm" target="_blank">Descargar</a>
                     {% endif %}

--- a/crunevo/templates/store/view_product.html
+++ b/crunevo/templates/store/view_product.html
@@ -6,11 +6,11 @@
 <div class="container py-4">
   <div class="row">
     <div class="col-md-6">
-      <img id="mainImage" src="{{ product.first_image or '/static/img/producto-default.png' }}" class="img-fluid rounded shadow-sm mb-2" alt="{{ product.name }}">
+      <img loading="lazy" id="mainImage" src="{{ product.first_image or '/static/img/producto-default.png' }}" class="img-fluid rounded shadow-sm mb-2" alt="{{ product.name }}">
       {% if product.image_urls %}
         <div class="d-flex gap-2">
           {% for url in product.image_urls %}
-            <img src="{{ url }}" data-src="{{ url }}" class="img-thumbnail product-thumb" style="width: 70px; cursor: pointer;">
+            <img loading="lazy" src="{{ url }}" data-src="{{ url }}" class="img-thumbnail product-thumb" style="width: 70px; cursor: pointer;">
           {% endfor %}
         </div>
       {% endif %}


### PR DESCRIPTION
## Summary
- fix feed card colors for dark mode
- add mobile offcanvas menu
- implement infinite scroll on feed
- use Bootstrap variables in store page
- add lazy loading on all templates
- document recent work in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685af0c0dda48325afcebf4cfbd52ff8