### PR TITLE
Fix dark mode styling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,3 +261,4 @@
 - Mejorado carrusel de destacados con tarjetas modernas, imágenes cuadradas y contenedor con sombra (PR store-featured-card-style).
 - Input de imagen del feed usa id "feedImageInput" y contenedor "previewContainer" con vista previa instantánea (PR feed-image-preview-fix).
 - Implementado modo oscuro en feed y tienda, scroll infinito e overlay móvil con offcanvas. Añadidas imágenes lazy (PR dark-scroll-overlay).
+- Ajustado modo oscuro en tienda y feed: bg-light adaptativo, botones claros y navbar inferior con bg-body (PR dark-mode-fixes).

--- a/crunevo/static/css/main.css
+++ b/crunevo/static/css/main.css
@@ -36,3 +36,12 @@
   color: #fff;
   border-color: #444;
 }
+[data-bs-theme="dark"] .bg-light {
+  background-color: #2c2c2c !important;
+  color: #f8f9fa !important;
+}
+[data-bs-theme="dark"] .btn-light {
+  background-color: #3a3a3a !important;
+  color: #fff !important;
+  border-color: #555 !important;
+}

--- a/crunevo/static/css/store.css
+++ b/crunevo/static/css/store.css
@@ -55,3 +55,6 @@
   -webkit-line-clamp: 2;
   min-height: 2.8em;
 }
+[data-bs-theme="dark"] .product-card.bg-light {
+  background-color: #1f1f1f !important;
+}

--- a/crunevo/templates/feed/feed.html
+++ b/crunevo/templates/feed/feed.html
@@ -192,7 +192,7 @@
     </div>
   </div>
 </div>
-<nav class="navbar fixed-bottom d-md-none navbar-light bg-light border-top">
+<nav class="navbar fixed-bottom d-md-none bg-body border-top">
   <div class="container-fluid justify-content-around">
     <a class="nav-link text-center" href="{{ url_for('feed.feed_home') }}">
       <i class="bi bi-house"></i><br>Feed

--- a/crunevo/templates/store/favorites.html
+++ b/crunevo/templates/store/favorites.html
@@ -60,7 +60,7 @@
           <div class="row row-cols-2 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 row-cols-xl-5 g-3">
             {% for product in products %}
               <div class="col">
-                <div class="card position-relative h-100 border border-primary p-2">
+                <div class="card product-card position-relative h-100 border border-primary p-2">
                   <img loading="lazy" src="{{ product.image_url or '/static/img/producto-default.png' }}" class="card-img-top rounded mb-2" alt="{{ product.name }}">
                   <form method="post" action="{{ url_for('store.toggle_favorite', product_id=product.id) }}" class="position-absolute top-0 end-0 m-2">
                     {{ csrf.csrf_field() }}

--- a/crunevo/templates/store/store.html
+++ b/crunevo/templates/store/store.html
@@ -101,7 +101,7 @@
           <div class="row row-cols-2 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 row-cols-xl-5 g-3">
             {% for product in products %}
               <div class="col">
-                <div class="card position-relative h-100 border border-primary p-2 {% if product.is_featured %}bg-light border-purple{% endif %} {% if product.category == 'Pack' %}tw-scale-[1.03]{% endif %}">
+                <div class="card product-card position-relative h-100 border border-primary p-2 {% if product.is_featured %}bg-light border-purple{% endif %} {% if product.category == 'Pack' %}tw-scale-[1.03]{% endif %}">
                   <img
                     src="{{ product.image if product.image else url_for('static', filename='img/default_product.png') }}"
                     class="card-img-top rounded mb-2"


### PR DESCRIPTION
## Summary
- adapt light components for dark mode
- add product-card class for store items
- tweak bottom navbar to use `bg-body`
- log tasks in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685af411845483258ad47bd662ef1a45