### PR TITLE
Improve mobile menus

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,3 +264,4 @@
 - Ajustado modo oscuro en tienda y feed: bg-light adaptativo, botones claros y navbar inferior con bg-body (PR dark-mode-fixes).
 - Feed mejorado: filtros por categoría, buscador interno y sidebar móvil en offcanvas con botón flotante. Animaciones desactivadas en dispositivos lentos y carga infinita usando categoría. (PR feed-mobile-overlay)
 - Corregido include en feed/index.html eliminando 'with categoria=categoria' para evitar TemplateSyntaxError (PR feed-sidebar-with-fix).
+- Menú móvil del navbar ahora usa fondo morado con clase `offcanvas-crunevo` y los dropdowns comparten ese color. Botones flotantes de sidebar móvil cambian a icono de filtro y clase `mobile-overlay-btn` (PR overlay-menu-color).

--- a/crunevo/static/css/navbar.css
+++ b/crunevo/static/css/navbar.css
@@ -17,3 +17,25 @@
   background-color: rgba(115, 86, 255, 0.4);
 }
 
+.offcanvas-crunevo {
+  background-color: var(--primary);
+  color: #fff;
+}
+.offcanvas-crunevo .btn-close {
+  filter: invert(1);
+}
+
+.navbar-crunevo .dropdown-menu {
+  background-color: var(--primary);
+  color: #fff;
+}
+.navbar-crunevo .dropdown-menu .dropdown-item {
+  color: #fff;
+}
+.navbar-crunevo .dropdown-menu .dropdown-divider {
+  border-color: rgba(255, 255, 255, 0.2);
+}
+.navbar-crunevo .dropdown-menu .dropdown-item:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -114,4 +114,8 @@ body[data-bs-theme="dark"] .message {
   transition: .15s ease;
 }
 
+.mobile-overlay-btn {
+  z-index: 1040;
+}
+
 

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -148,7 +148,7 @@
     {% endif %}
   </div>
 </div>
-<button class="btn btn-primary rounded-circle position-fixed bottom-0 start-0 m-3 d-lg-none" data-bs-toggle="offcanvas" data-bs-target="#profileSidebar"><i class="bi bi-list"></i></button>
+<button class="btn btn-primary rounded-circle position-fixed bottom-0 start-0 m-3 d-lg-none mobile-overlay-btn" data-bs-toggle="offcanvas" data-bs-target="#profileSidebar"><i class="bi bi-filter"></i></button>
 <div class="offcanvas offcanvas-start" tabindex="-1" id="profileSidebar" aria-labelledby="profileSidebarLabel">
   <div class="offcanvas-header">
     <h5 class="offcanvas-title" id="profileSidebarLabel">Menú</h5>

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -8,7 +8,7 @@
       <input class="form-control" type="search" placeholder="Buscar" aria-label="Buscar" id="globalSearchInput" autocomplete="off">
       <div id="searchSuggestions" class="position-absolute start-0 w-100 bg-white border rounded shadow"></div>
     </form>
-    <div class="offcanvas offcanvas-start d-md-none text-bg-dark" tabindex="-1" id="mobileMenu" aria-labelledby="mobileMenuLabel">
+    <div class="offcanvas offcanvas-start d-md-none offcanvas-crunevo text-white" tabindex="-1" id="mobileMenu" aria-labelledby="mobileMenuLabel">
       <div class="offcanvas-header">
         <h5 class="offcanvas-title" id="mobileMenuLabel">Menú</h5>
         <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>

--- a/crunevo/templates/feed/index.html
+++ b/crunevo/templates/feed/index.html
@@ -60,7 +60,7 @@
     {% include 'components/sidebar_right.html' %}
   </div>
 </div>
-<button class="btn btn-primary rounded-circle position-fixed bottom-0 start-0 m-3 d-lg-none" data-bs-toggle="offcanvas" data-bs-target="#mobileSidebar"><i class="bi bi-list"></i></button>
+<button class="btn btn-primary rounded-circle position-fixed bottom-0 start-0 m-3 d-lg-none mobile-overlay-btn" data-bs-toggle="offcanvas" data-bs-target="#mobileSidebar"><i class="bi bi-filter"></i></button>
 <div class="offcanvas offcanvas-start" tabindex="-1" id="mobileSidebar" aria-labelledby="mobileSidebarLabel">
   <div class="offcanvas-header">
     <h5 class="offcanvas-title" id="mobileSidebarLabel">Menú</h5>

--- a/crunevo/templates/store/favorites.html
+++ b/crunevo/templates/store/favorites.html
@@ -89,7 +89,7 @@
     <div class="col-lg-3 d-none d-lg-block"></div>
   </div>
 </div>
-<button class="btn btn-primary rounded-circle position-fixed bottom-0 start-0 m-3 d-lg-none" data-bs-toggle="offcanvas" data-bs-target="#storeSidebar"><i class="bi bi-list"></i></button>
+<button class="btn btn-primary rounded-circle position-fixed bottom-0 start-0 m-3 d-lg-none mobile-overlay-btn" data-bs-toggle="offcanvas" data-bs-target="#storeSidebar"><i class="bi bi-filter"></i></button>
 <div class="offcanvas offcanvas-start" tabindex="-1" id="storeSidebar" aria-labelledby="storeSidebarLabel">
   <div class="offcanvas-header">
     <h5 class="offcanvas-title" id="storeSidebarLabel">Menú</h5>

--- a/crunevo/templates/store/store.html
+++ b/crunevo/templates/store/store.html
@@ -122,7 +122,7 @@
 
   </div>
 </div>
-<button class="btn btn-primary rounded-circle position-fixed bottom-0 start-0 m-3 d-lg-none" data-bs-toggle="offcanvas" data-bs-target="#storeSidebar"><i class="bi bi-list"></i></button>
+<button class="btn btn-primary rounded-circle position-fixed bottom-0 start-0 m-3 d-lg-none mobile-overlay-btn" data-bs-toggle="offcanvas" data-bs-target="#storeSidebar"><i class="bi bi-filter"></i></button>
 <div class="offcanvas offcanvas-start" tabindex="-1" id="storeSidebar" aria-labelledby="storeSidebarLabel">
   <div class="offcanvas-header">
     <h5 class="offcanvas-title" id="storeSidebarLabel">Menú</h5>


### PR DESCRIPTION
## Summary
- recolor mobile navbar menu using `.offcanvas-crunevo`
- style navbar dropdown menu with the same purple tone
- add `.mobile-overlay-btn` and switch overlay buttons to a filter icon
- document changes in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685b245ff9008325978e4c3e838057f6