### PR TITLE
Add store cart badges and sidebar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,3 +265,4 @@
 - Feed mejorado: filtros por categoría, buscador interno y sidebar móvil en offcanvas con botón flotante. Animaciones desactivadas en dispositivos lentos y carga infinita usando categoría. (PR feed-mobile-overlay)
 - Corregido include en feed/index.html eliminando 'with categoria=categoria' para evitar TemplateSyntaxError (PR feed-sidebar-with-fix).
 - Menú móvil del navbar ahora usa fondo morado con clase `offcanvas-crunevo` y los dropdowns comparten ese color. Botones flotantes de sidebar móvil cambian a icono de filtro y clase `mobile-overlay-btn` (PR overlay-menu-color).
+- Tienda muestra precios en destacados, botón "+ Carrito" con AJAX y contador en el navbar y botón flotante (PR store-cart-indicators).

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -26,6 +26,7 @@ def create_app():
     def inject_globals():
         from .constants import ACHIEVEMENT_DETAILS
         from .models import Note, Notification
+        from flask import session
 
         latest_sidebar_notes = (
             Note.query.order_by(Note.created_at.desc()).limit(3).all()
@@ -39,6 +40,7 @@ def create_app():
             "SIDEBAR_LATEST_NOTES": latest_sidebar_notes,
             "Notification": Notification,
             "current_app": current_app,
+            "CART_COUNT": sum(session.get("cart", {}).values()),
         }
 
     from .utils.helpers import timesince

--- a/crunevo/static/css/store.css
+++ b/crunevo/static/css/store.css
@@ -14,7 +14,7 @@
 }
 
 .product-name {
-  -webkit-line-clamp: 3;
+  -webkit-line-clamp: 2;
   font-size: 1rem;
   text-overflow: ellipsis;
 }
@@ -35,6 +35,15 @@
 
 .featured-card:hover {
   transform: scale(1.03);
+}
+
+.product-card {
+  transition: transform 0.2s ease-in-out, box-shadow 0.2s;
+}
+
+.product-card:hover {
+  transform: scale(1.02);
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 }
 
 .featured-card .card-img-top {

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -247,6 +247,20 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  refreshCartCount();
+  document.querySelectorAll('.add-cart-btn').forEach((btn) => {
+    btn.addEventListener('click', (e) => {
+      e.preventDefault();
+      const pid = btn.dataset.productId;
+      fetch(`/store/add/${pid}`, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+        .then((r) => r.json())
+        .then((data) => {
+          showToast('Producto agregado');
+          updateCartBadge(data.count);
+        });
+    });
+  });
+
   initNotifications();
 
   // Bootstrap collapse handles the mobile menu
@@ -290,4 +304,17 @@ function initNotifications() {
       csrfFetch('/notifications/read_all', { method: 'POST' }).then(refresh);
     });
   }
+}
+
+function updateCartBadge(count) {
+  document.querySelectorAll('#cartBadge, #cartBadgeDesktop, #mobileCartBadge').forEach((b) => {
+    b.textContent = count;
+    b.classList.toggle('tw-hidden', count === 0);
+  });
+}
+
+function refreshCartCount() {
+  fetch('/store/api/cart_count')
+    .then((r) => r.json())
+    .then((data) => updateCartBadge(data.count));
 }

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -45,6 +45,12 @@
         {% block content %}{% endblock %}
     </div>
     <div class="toast-container position-fixed bottom-0 end-0 p-3"></div>
+    {% if request.path.startswith('/store') %}
+    <a href="{{ url_for('store.view_cart') }}" class="btn btn-primary rounded-circle position-fixed bottom-0 end-0 m-3 d-lg-none">
+      <i class="bi bi-cart"></i>
+      <span id="mobileCartBadge" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger {% if CART_COUNT == 0 %}tw-hidden{% endif %}">{{ CART_COUNT }}</span>
+    </a>
+    {% endif %}
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="{{ url_for('static', filename='js/feed_toggle.js') }}" defer></script>

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -21,6 +21,12 @@
           <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('store.store_index') }}"><i class="bi bi-bag me-1"></i>Tienda</a></li>
           <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('ranking.show_ranking') }}"><i class="bi bi-trophy me-1"></i>Ranking</a></li>
           <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('chat.chat_index') }}"><i class="bi bi-chat-dots me-1"></i>Chat</a></li>
+          <li class="nav-item">
+            <a class="nav-link text-white position-relative" href="{{ url_for('store.view_cart') }}">
+              <i class="bi bi-cart"></i>
+              <span id="cartBadge" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger {% if CART_COUNT == 0 %}tw-hidden{% endif %}">{{ CART_COUNT }}</span>
+            </a>
+          </li>
           {% if config.ADMIN_INSTANCE and current_user.is_authenticated and current_user.role == 'admin' %}
           <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('admin.dashboard') }}"><i class="bi bi-speedometer2 me-1"></i>Admin</a></li>
           {% endif %}
@@ -74,6 +80,12 @@
             <li><a class="dropdown-item text-center" href="{{ url_for('noti.ver_notificaciones') }}">Ver todas</a></li>
             <li><a id="markAllRead" class="dropdown-item text-center" href="#">Marcar todo como leído</a></li>
           </ul>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link text-white position-relative" href="{{ url_for('store.view_cart') }}">
+            <i class="bi bi-cart"></i>
+            <span id="cartBadgeDesktop" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger {% if CART_COUNT == 0 %}tw-hidden{% endif %}">{{ CART_COUNT }}</span>
+          </a>
         </li>
         {% else %}
         <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('auth.login') }}"><i class="bi bi-box-arrow-in-right me-1"></i>Iniciar sesión</a></li>

--- a/crunevo/templates/store/product_card.html
+++ b/crunevo/templates/store/product_card.html
@@ -13,7 +13,7 @@
   </div>
   <div class="card-body d-flex flex-column">
     <h5 class="card-title product-name">
-      <a href="{{ url_for('store.view_product', product_id=product.id) }}" class="text-decoration-none text-body">
+      <a href="{{ url_for('store.view_product', product_id=product.id) }}" class="text-decoration-none text-body" title="{{ product.name }}">
         {{ product.name }}
       </a>
     </h5>

--- a/crunevo/templates/store/store.html
+++ b/crunevo/templates/store/store.html
@@ -30,6 +30,13 @@
                   <img loading="lazy" src="{{ product.image if product.image else url_for('static', filename='img/default_product.png') }}" class="card-img-top" alt="{{ product.name }}">
                   <div class="card-body p-2 text-center">
                     <p class="featured-title mb-1">{{ product.name }}</p>
+                    {% if product.price is not none %}
+                      <span class="badge bg-info text-dark d-block mb-1">S/ {{ '%.2f'|format(product.price) }}</span>
+                    {% endif %}
+                    {% if product.price_credits is not none %}
+                      <span class="badge bg-warning text-dark d-block mb-1">{{ product.price_credits }} créditos</span>
+                    {% endif %}
+                    <button class="btn btn-sm btn-primary add-cart-btn d-block mx-auto mb-1" data-product-id="{{ product.id }}">+ Carrito</button>
                     <a href="{{ url_for('store.view_product', product_id=product.id) }}" class="btn btn-outline-primary btn-sm d-block mx-auto">Ver</a>
                   </div>
                 </div>
@@ -67,7 +74,7 @@
                     </button>
                   </form>
                   <div class="card-body d-flex flex-column">
-                    <h5 class="card-title product-name">{{ product.name }}</h5>
+                    <h5 class="card-title product-name" title="{{ product.name }}">{{ product.name }}</h5>
                     {% set r = ratings.get(product.id, 0) %}
                     <div class="mb-1">
                       {% for _ in range(r|round(0,'floor')|int) %}<i class="bi bi-star-fill text-warning"></i>{% endfor %}
@@ -113,10 +120,24 @@
               </div>
             {% endfor %}
           </div>
-          <div class="mt-4 text-end">
-            {{ btn.button('Ver Carrito', href=url_for('store.view_cart'), variant='secondary') }}
+          <div class="mt-4 text-center">
+            {{ btn.button('<i class="bi bi-cart-fill me-1"></i> Ver carrito', href=url_for('store.view_cart'), variant='secondary') }}
           </div>
         </div>
+      </div>
+    </div>
+
+    <!-- Sidebar derecho -->
+    <div class="col-lg-3 d-none d-lg-block">
+      <div class="card mb-3">
+        <div class="card-header">🔥 Top más vendidos</div>
+        <ul class="list-group list-group-flush">
+          {% for p in top_sellers %}
+          <li class="list-group-item py-1">
+            <a href="{{ url_for('store.view_product', product_id=p.id) }}">{{ p.name }}</a>
+          </li>
+          {% endfor %}
+        </ul>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- show prices and quick add buttons in featured carousel
- add cart badge in navbar and floating mobile button
- add right sidebar with top sellers
- JS helpers update cart count via AJAX

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685b278dd21083259f740c81bd0cbdfc