### PR TITLE
Fix offcanvas background coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,3 +266,4 @@
 - Corregido include en feed/index.html eliminando 'with categoria=categoria' para evitar TemplateSyntaxError (PR feed-sidebar-with-fix).
 - Menú móvil del navbar ahora usa fondo morado con clase `offcanvas-crunevo` y los dropdowns comparten ese color. Botones flotantes de sidebar móvil cambian a icono de filtro y clase `mobile-overlay-btn` (PR overlay-menu-color).
 - Tienda muestra precios en destacados, botón "+ Carrito" con AJAX y contador en el navbar y botón flotante (PR store-cart-indicators).
+- Fondo del offcanvas m\xc3\xb3vil del navbar ahora cubre todo el cuerpo y enlaces permanecen en blanco; clase ajustada en navbar.html (PR offcanvas-bg-full).

--- a/crunevo/static/css/navbar.css
+++ b/crunevo/static/css/navbar.css
@@ -18,8 +18,16 @@
 }
 
 .offcanvas-crunevo {
-  background-color: var(--primary);
+  background-color: #7356ff !important;
   color: #fff;
+}
+.offcanvas-crunevo .offcanvas-body {
+  background-color: #7356ff !important;
+}
+.offcanvas-crunevo .nav-link,
+.offcanvas-crunevo .btn,
+.offcanvas-crunevo .offcanvas-title {
+  color: #fff !important;
 }
 .offcanvas-crunevo .btn-close {
   filter: invert(1);

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -8,7 +8,7 @@
       <input class="form-control" type="search" placeholder="Buscar" aria-label="Buscar" id="globalSearchInput" autocomplete="off">
       <div id="searchSuggestions" class="position-absolute start-0 w-100 bg-white border rounded shadow"></div>
     </form>
-    <div class="offcanvas offcanvas-start d-md-none offcanvas-crunevo text-white" tabindex="-1" id="mobileMenu" aria-labelledby="mobileMenuLabel">
+    <div class="offcanvas offcanvas-start offcanvas-crunevo d-md-none text-white" tabindex="-1" id="mobileMenu" aria-labelledby="mobileMenuLabel">
       <div class="offcanvas-header">
         <h5 class="offcanvas-title" id="mobileMenuLabel">Menú</h5>
         <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>


### PR DESCRIPTION
## Summary
- ensure navbar offcanvas body uses the purple background
- keep links and title in white
- update navbar template to apply `offcanvas-crunevo` class consistently
- document the change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685ba11c321483258c4be725dd355ca7