### PR TITLE
Fix mobile offcanvas style

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,3 +267,5 @@
 - Menú móvil del navbar ahora usa fondo morado con clase `offcanvas-crunevo` y los dropdowns comparten ese color. Botones flotantes de sidebar móvil cambian a icono de filtro y clase `mobile-overlay-btn` (PR overlay-menu-color).
 - Tienda muestra precios en destacados, botón "+ Carrito" con AJAX y contador en el navbar y botón flotante (PR store-cart-indicators).
 - Fondo del offcanvas m\xc3\xb3vil del navbar ahora cubre todo el cuerpo y enlaces permanecen en blanco; clase ajustada en navbar.html (PR offcanvas-bg-full).
+
+- Menú móvil del navbar actualizado para cubrir toda la pantalla con fondo morado translúcido y texto legible; estilos en navbar.css. (PR mobile-offcanvas-fix)

--- a/crunevo/static/css/navbar.css
+++ b/crunevo/static/css/navbar.css
@@ -18,19 +18,32 @@
 }
 
 .offcanvas-crunevo {
-  background-color: #7356ff !important;
-  color: #fff;
+  width: 100vw;
+  height: 100vh;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 9999;
+  background-color: rgba(94, 45, 145, 0.95);
+  color: #f0f0f0;
+  transition: all 0.3s ease-in-out;
+  overflow-y: auto;
 }
 .offcanvas-crunevo .offcanvas-body {
-  background-color: #7356ff !important;
+  background-color: rgba(94, 45, 145, 0.95);
+  font-size: 1.1rem;
+  padding: 1rem 1.5rem;
 }
 .offcanvas-crunevo .nav-link,
 .offcanvas-crunevo .btn,
 .offcanvas-crunevo .offcanvas-title {
-  color: #fff !important;
+  color: #f0f0f0 !important;
 }
 .offcanvas-crunevo .btn-close {
   filter: invert(1);
+}
+.offcanvas-crunevo .navbar-nav .nav-item {
+  margin-bottom: 1rem;
 }
 
 .navbar-crunevo .dropdown-menu {


### PR DESCRIPTION
## Summary
- style the mobile menu offcanvas so it fills the screen with translucent purple background
- document the change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685ba5d66c6c8325be3cde7570b01d96