### PR TITLE
Fix overlay button and navbar autohide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,4 +274,5 @@
 - Navbar inferior móvil mejorado con ícono activo, animación de toque y scroll horizontal en pantallas pequeñas (PR bottom-nav-enhanced).
 - Altura reducida y tooltips añadidos al navbar inferior, con espacio inferior global para que no tape contenido (PR bottom-nav-improvements).
 - Navbar superior ahora se oculta al hacer scroll y reaparece al subir, implementado en main.js y transición CSS (PR navbar-autohide).
+- Corregido selector de autohide para '.navbar-crunevo' y botón flotante movido sobre el navbar inferior con bottom:72px (PR overlay-autohide-fix).
 

--- a/crunevo/static/css/navbar.css
+++ b/crunevo/static/css/navbar.css
@@ -6,6 +6,8 @@
   z-index: 1030;
   min-height: 64px;
   transition: top 0.3s ease-in-out;
+  top: 0;
+  position: sticky;
 }
 
 @media (max-width: 768px) {

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -117,6 +117,7 @@ body[data-bs-theme="dark"] .message {
 
 .mobile-overlay-btn {
   z-index: 1040;
+  bottom: 72px !important;
 }
 
 

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -265,7 +265,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Auto hide navbar on scroll for md and up
   let prevScrollPos = window.pageYOffset;
-  const navbar = document.querySelector('.navbar');
+  const navbar = document.querySelector('.navbar-crunevo');
   window.addEventListener('scroll', () => {
     if (!navbar) return;
     if (window.innerWidth < 768) {


### PR DESCRIPTION
## Summary
- position the floating filter button above the bottom navbar
- ensure navbar auto-hide uses `.navbar-crunevo`
- set default top position for navbar
- document changes in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685bd53e851c832580c90e226dd94f8c