### PR TITLE
Fix navbar autohide on mobile and remove extra spacing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,3 +278,4 @@
 
 - Navbar ajustada a top:0 con CSS y botón de tema añadido en perfil (PR navbar-top-fix-theme).
 - Autohide del navbar funciona en todas las vistas y se quitó el botón de tema del navbar, moviéndolo solo al perfil (PR navbar-autohide-mobile).
+- Autohide del navbar reescrito para detectar scroll táctil y se limpiaron márgenes globales. Se añadió clase .navbar-hidden (PR navbar-autohide-touch-fix).

--- a/crunevo/static/css/navbar.css
+++ b/crunevo/static/css/navbar.css
@@ -5,7 +5,7 @@
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
   z-index: 1030;
   min-height: 64px;
-  transition: top 0.3s ease-in-out;
+  transition: transform 0.3s ease-in-out;
   top: 0 !important;
   position: sticky;
 }
@@ -36,5 +36,10 @@
 }
 .navbar-crunevo .dropdown-menu .dropdown-item:hover {
   background-color: rgba(255, 255, 255, 0.1);
+}
+
+
+.navbar-hidden {
+  transform: translateY(-100%);
 }
 

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -154,3 +154,16 @@ body[data-bs-theme='dark'] .bottom-nav-active {
     font-size: 1.2rem !important;
   }
 }
+body {
+  margin: 0 !important;
+  padding: 0 !important;
+  overflow-x: hidden;
+}
+
+body > .navbar {
+  margin-top: 0 !important;
+}
+
+html {
+  scroll-padding-top: 0 !important;
+}

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -264,18 +264,25 @@ document.addEventListener('DOMContentLoaded', () => {
   initNotifications();
 
   // Auto hide navbar on scroll for all viewports
-  let lastScrollTop = window.pageYOffset;
+  let lastScrollTop = 0;
   const navbar = document.querySelector('.navbar-crunevo');
-  window.addEventListener('scroll', () => {
+  const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+
+  function handleScroll() {
     if (!navbar) return;
-    const current = window.pageYOffset;
-    if (lastScrollTop > current || current <= 0) {
-      navbar.style.top = '0';
+    const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+    if (scrollTop > lastScrollTop) {
+      navbar.classList.add('navbar-hidden');
     } else {
-      navbar.style.top = '-100px';
+      navbar.classList.remove('navbar-hidden');
     }
-    lastScrollTop = current;
-  });
+    lastScrollTop = scrollTop <= 0 ? 0 : scrollTop;
+  }
+
+  window.addEventListener('scroll', handleScroll);
+  if (isMobile) {
+    window.addEventListener('touchmove', handleScroll, { passive: true });
+  }
 
   // Bootstrap collapse handles the mobile menu
 


### PR DESCRIPTION
## Summary
- apply global CSS reset for body and scroll padding
- support `.navbar-hidden` with transform transition
- rework autohide logic in `main.js` using scroll direction and touch events
- document update in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685c6e263f9c83258b1f9adafa5f723e