### PR TITLE
Add terms page with checkboxes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,3 +279,4 @@
 - Navbar ajustada a top:0 con CSS y botón de tema añadido en perfil (PR navbar-top-fix-theme).
 - Autohide del navbar funciona en todas las vistas y se quitó el botón de tema del navbar, moviéndolo solo al perfil (PR navbar-autohide-mobile).
 - Autohide del navbar reescrito para detectar scroll táctil y se limpiaron márgenes globales. Se añadió clase .navbar-hidden (PR navbar-autohide-touch-fix).
+- Se añadió página /terms con los Términos y Condiciones y checkboxes obligatorios en registro y subida de apuntes (PR terms-conditions).

--- a/crunevo/routes/main_routes.py
+++ b/crunevo/routes/main_routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint
+from flask import Blueprint, render_template
 from crunevo.routes.feed_routes import feed_home
 
 main_bp = Blueprint("main", __name__)
@@ -7,3 +7,8 @@ main_bp = Blueprint("main", __name__)
 @main_bp.route("/")
 def index():
     return feed_home()
+
+
+@main_bp.route("/terms")
+def terms():
+    return render_template("terms.html")

--- a/crunevo/templates/notes/upload.html
+++ b/crunevo/templates/notes/upload.html
@@ -37,6 +37,11 @@
             <canvas id="pdfPreview" class="w-100 border rounded shadow-sm mb-3 tw-hidden" style="max-height:400px;"></canvas>
             <img loading="lazy" id="imgPreview" class="img-fluid border rounded shadow-sm mb-3 tw-hidden" style="max-height:400px;" />
 
+            <div class="form-check mb-3">
+              <input class="form-check-input" type="checkbox" id="noteTerms" required>
+              <label class="form-check-label" for="noteTerms">Acepto los <a href="{{ url_for('main.terms') }}">Términos y Condiciones</a>, incluyendo que soy el autor del documento o tengo permiso para compartirlo.</label>
+            </div>
+
             <button type="submit" class="btn btn-primary w-100" id="uploadBtn">Subir</button>
           </form>
         </div>

--- a/crunevo/templates/onboarding/register.html
+++ b/crunevo/templates/onboarding/register.html
@@ -72,11 +72,15 @@
           </div>
         </div>
       </div>
+      <div class="form-check mb-3">
+        <input class="form-check-input" type="checkbox" id="acceptTerms" required>
+        <label class="form-check-label" for="acceptTerms">He leído y acepto los <a href="{{ url_for('main.terms') }}">Términos y Condiciones</a></label>
+      </div>
       <button type="submit" class="btn btn-crunevo w-100">Registrarte</button>
 
       <div class="legal-text mt-3">
         Es posible que las personas que usan nuestro servicio hayan subido tu información de contacto a CRUNEVO. <a href="#">Más información</a>.<br><br>
-        Al hacer clic en "Registrarte", aceptas nuestras <a href="/terminos">Condiciones</a>, la <a href="/privacidad">Política de privacidad</a> y la <a href="/cookies">Política de cookies</a>.
+        Al hacer clic en "Registrarte", aceptas nuestras <a href="{{ url_for('main.terms') }}">Condiciones</a>, la <a href="/privacidad">Política de privacidad</a> y la <a href="/cookies">Política de cookies</a>.
         Es posible que te enviemos notificaciones por correo o sistema, que puedes desactivar cuando quieras.
       </div>
 

--- a/crunevo/templates/terms.html
+++ b/crunevo/templates/terms.html
@@ -1,0 +1,29 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container my-5">
+  <h1 class="mb-4 text-center">TÉRMINOS Y CONDICIONES DE USO DE CRUNEVO</h1>
+  <p class="text-muted">Última actualización: 25 de junio de 2025</p>
+  <p><strong>1. INTRODUCCIÓN</strong></p>
+  <p>Bienvenido a Crunevo. Al registrarte, iniciar sesión o usar cualquier función de esta plataforma, aceptas cumplir con los presentes Términos y Condiciones. Este documento regula el uso de los servicios ofrecidos por Crunevo a estudiantes y usuarios en general.</p>
+  <p><strong>2. RESPONSABILIDAD SOBRE EL CONTENIDO</strong></p>
+  <p>Todo contenido subido por los usuarios (apuntes, comentarios, imágenes, etc.) es de exclusiva responsabilidad de quien lo publica. Al subir un documento, el usuario declara tener derechos sobre el material y/o contar con la debida autorización para compartirlo.</p>
+  <p>Queda prohibido subir contenido que infrinja derechos de autor, promueva el odio, la violencia, la discriminación, o que vulnere la ley.</p>
+  <p><strong>3. DERECHOS DE AUTOR Y USO DE DOCUMENTOS</strong></p>
+  <p>Crunevo es una plataforma de uso educativo. El contenido compartido por los usuarios es para fines formativos y no debe ser comercializado fuera del sitio sin autorización.</p>
+  <p>Los usuarios conservan los derechos de autor sobre sus documentos, pero otorgan a Crunevo una licencia no exclusiva para mostrar, almacenar y distribuir el contenido dentro de la plataforma.</p>
+  <p><strong>4. PRIVACIDAD Y PROTECCIÓN DE DATOS</strong></p>
+  <p>Crunevo protege tus datos personales conforme a la legislación peruana vigente. Al registrarte, aceptas que tus datos puedan ser usados para mejorar el servicio, enviar notificaciones o realizar estadísticas, sin ser compartidos con terceros sin tu consentimiento.</p>
+  <p>Puedes modificar tu información desde tu perfil o solicitar la eliminación total de tu cuenta.</p>
+  <p><strong>5. CONDICIONES DE USO DE LA PLATAFORMA</strong></p>
+  <p>Está prohibido el uso de bots o automatizaciones sin autorización.</p>
+  <p>Está prohibida la suplantación de identidad o el uso de perfiles falsos.</p>
+  <p>El incumplimiento de estas reglas podrá implicar la suspensión temporal o permanente de la cuenta.</p>
+  <p><strong>6. COMENTARIOS Y PARTICIPACIÓN</strong></p>
+  <p>Los comentarios y respuestas deben ser respetuosos. No se tolerará lenguaje ofensivo, insultos o ataques personales. Los administradores podrán eliminar contenido o suspender cuentas si se vulneran estas reglas.</p>
+  <p><strong>7. MODIFICACIONES Y AVISOS</strong></p>
+  <p>Crunevo podrá modificar estos Términos en cualquier momento. Se notificará a los usuarios sobre los cambios mediante la plataforma. El uso continuo de Crunevo implica la aceptación de las nuevas condiciones.</p>
+  <p><strong>8. CONTACTO</strong></p>
+  <p>Para dudas, consultas o denuncias, puedes escribirnos a <a href="mailto:soporte@crunevo.com">soporte@crunevo.com</a>.</p>
+  <a href="{{ request.referrer or url_for('feed.feed_home') }}" class="btn btn-secondary mt-4">Volver</a>
+</div>
+{% endblock %}

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -1,0 +1,4 @@
+def test_terms_page(client):
+    resp = client.get("/terms")
+    assert resp.status_code == 200
+    assert b"T\xc3\x89RMINOS Y CONDICIONES DE USO DE CRUNEVO" in resp.data


### PR DESCRIPTION
## Summary
- create /terms route and template with full Terms and Conditions
- require users to accept terms when registering or uploading notes
- document the change in AGENTS.md
- test that /terms is accessible

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685c76d188f4832581c8c3548190f1ab