### PR TITLE
Improve note detail viewer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,3 +283,4 @@
 - Mejorado formulario de subida de apuntes con categoría, nivel académico, privacidad y etiquetas con sugerencias (PR notes-upload-enhanced).
 
 - wsgi.py importa create_app desde el paquete crunevo nuevamente y se actualiz\xF3 wsgi_admin para mantener consistencia.
+- Redesigned note detail with two-column layout, PDF/image viewer via viewer.js and file type detection in notes_routes (PR note-detail-redesign).

--- a/crunevo/routes/notes_routes.py
+++ b/crunevo/routes/notes_routes.py
@@ -1,4 +1,5 @@
 import os
+from urllib.parse import urlparse
 from flask import (
     Blueprint,
     render_template,
@@ -196,7 +197,22 @@ def detail(note_id):
     note = Note.query.get_or_404(note_id)
     note.views += 1
     db.session.commit()
-    return render_template("notes/detalle.html", note=note)
+
+    def get_ext(path):
+        if path.startswith("http"):
+            path = urlparse(path).path
+        path = path.split("?")[0]
+        return os.path.splitext(path)[1].lower()
+
+    ext = get_ext(note.filename)
+    if ext == ".pdf":
+        ftype = "pdf"
+    elif ext in {".jpg", ".jpeg", ".png", ".webp"}:
+        ftype = "image"
+    else:
+        ftype = "other"
+
+    return render_template("notes/detalle.html", note=note, file_type=ftype)
 
 
 # Alias endpoint for backward compatibility with templates using

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -86,6 +86,9 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   initPdfPreviews();
+  if (typeof initNoteViewer === 'function') {
+    initNoteViewer();
+  }
 
   document.querySelectorAll('.achievement-card').forEach((el) => {
     if (el.title && !bootstrap.Tooltip.getInstance(el)) {

--- a/crunevo/static/js/viewer.js
+++ b/crunevo/static/js/viewer.js
@@ -1,0 +1,65 @@
+function initNoteViewer() {
+  const container = document.getElementById('noteViewer');
+  if (!container) return;
+  const type = container.dataset.type;
+  const url = container.dataset.url;
+  if (type === 'pdf' && typeof pdfjsLib !== 'undefined') {
+    let pdfDoc = null;
+    let pageNum = 1;
+    let scale = 1;
+    const canvas = document.createElement('canvas');
+    canvas.className = 'border rounded w-100 mb-2';
+    const ctx = canvas.getContext('2d');
+    const controls = document.createElement('div');
+    controls.className = 'd-flex justify-content-between align-items-center mb-2';
+    controls.innerHTML = `
+      <div>
+        <button class="btn btn-outline-secondary btn-sm me-1" id="prevPage">&#x25C0;</button>
+        <button class="btn btn-outline-secondary btn-sm" id="nextPage">&#x25B6;</button>
+      </div>
+      <div>
+        <button class="btn btn-outline-secondary btn-sm me-1" id="zoomOut">-</button>
+        <button class="btn btn-outline-secondary btn-sm" id="zoomIn">+</button>
+      </div>
+    `;
+    container.appendChild(controls);
+    container.appendChild(canvas);
+    function renderPage(num) {
+      pdfDoc.getPage(num).then((page) => {
+        const viewport = page.getViewport({ scale });
+        canvas.height = viewport.height;
+        canvas.width = viewport.width;
+        page.render({ canvasContext: ctx, viewport });
+      });
+    }
+    pdfjsLib.getDocument(url).promise.then((pdf) => {
+      pdfDoc = pdf;
+      renderPage(pageNum);
+    });
+    container.addEventListener('click', (e) => {
+      if (e.target.id === 'prevPage' && pageNum > 1) {
+        pageNum--;
+        renderPage(pageNum);
+      } else if (e.target.id === 'nextPage' && pdfDoc && pageNum < pdfDoc.numPages) {
+        pageNum++;
+        renderPage(pageNum);
+      } else if (e.target.id === 'zoomIn') {
+        scale = Math.min(scale + 0.25, 3);
+        renderPage(pageNum);
+      } else if (e.target.id === 'zoomOut') {
+        scale = Math.max(scale - 0.25, 0.5);
+        renderPage(pageNum);
+      }
+    });
+  } else if (type === 'image') {
+    const img = document.createElement('img');
+    img.src = url;
+    img.className = 'img-fluid rounded shadow-sm';
+    container.appendChild(img);
+  } else {
+    const p = document.createElement('p');
+    p.className = 'alert alert-info';
+    p.textContent = 'Este archivo no tiene vista previa. Desc\u00e1rgalo para revisarlo.';
+    container.appendChild(p);
+  }
+}

--- a/crunevo/templates/notes/detalle.html
+++ b/crunevo/templates/notes/detalle.html
@@ -1,76 +1,77 @@
 {% extends 'base.html' %}
-{% import 'components/button.html' as btn %}
 {% import 'components/csrf.html' as csrf %}
 {% block content %}
 <div class="container-xl my-4">
-  <article class="card mx-auto p-4">
-    <div class="d-flex align-items-center mb-3">
-      <img loading="lazy" src="{{ note.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
-      <div>
-        <a href="{{ url_for('auth.profile_by_username', username=note.author.username) }}" class="text-decoration-none">
-          <strong>{{ note.author.username }}</strong>
-        </a><br>
-        <small class="text-muted">{{ note.created_at.strftime('%Y-%m-%d') }}</small>
+  <div class="row g-4">
+    <div class="col-md-9 order-md-2">
+      <div id="noteViewer" data-url="{{ note.filename }}" data-type="{{ file_type }}"></div>
+      <p class="text-muted small mt-2"><a href="{{ url_for('notes.download_note', note_id=note.id) }}">Descargar archivo</a></p>
+    </div>
+    <div class="col-md-3 order-md-1">
+      <h1 class="h5">{{ note.title }}</h1>
+      <p class="mb-1">por <a href="{{ url_for('auth.profile_by_username', username=note.author.username) }}">{{ note.author.username }}</a></p>
+      {% if note.category %}<p class="mb-1"><span class="badge bg-info text-dark">{{ note.category }}</span></p>{% endif %}
+      <div class="mb-2">
+        {% for tag in (note.tags or '').split(',') %}
+          {% set t = tag.strip() %}
+          {% if t %}<a href="{{ url_for('notes.list_notes', tag=t) }}" class="badge bg-secondary text-decoration-none me-1">{{ t }}</a>{% endif %}
+        {% endfor %}
       </div>
-      <span class="badge bg-secondary ms-auto"><i class="bi bi-eye"></i> {{ note.views }}</span>
-    </div>
-    <h3>{{ note.title }}</h3>
-    <p>{{ note.description or '' }}</p>
-    <div class="mb-2">
-      {% if note.category %}<span class="badge bg-info text-dark me-1">{{ note.category }}</span>{% endif %}
-      {% for tag in (note.tags or '').split(',') %}
-      <span class="badge bg-secondary me-1">{{ tag }}</span>
-      {% endfor %}
-    </div>
-    <div class="text-center mb-3">
-      <a class="btn btn-primary" href="{{ note.filename }}" target="_blank">Descargar</a>
-    </div>
-      <form id="shareForm" action="{{ url_for('notes.share_note', note_id=note.id) }}" method="post" style="display:inline;">
-        {{ csrf.csrf_field() }}
-        <button class="btn btn-outline-primary btn-sm" type="submit">🔗 Compartir</button>
-      </form>
-      <button type="button" class="btn btn-outline-secondary btn-sm share-btn" data-share-url="{{ url_for('notes.view_note', id=note.id, _external=True) }}">Copiar enlace</button>
+      <div class="text-muted small mb-2">
+        <span class="me-2"><i class="bi bi-eye"></i> {{ note.views }}</span>
+        <span class="me-2"><i class="bi bi-download"></i> {{ note.downloads }}</span>
+        <span class="me-2"><i class="bi bi-chat-left"></i> {{ note.comments_count }}</span>
+      </div>
+      {% if note.requires_credits %}
+      <div class="alert alert-warning text-center">
+        Este apunte requiere {{ note.credit_cost }} créditos para visualizar o descargar.
+        <a href="#" class="btn btn-primary btn-sm mt-2">Canjear ahora</a>
+      </div>
+      {% endif %}
+      <a href="{{ url_for('notes.download_note', note_id=note.id) }}" class="btn btn-outline-primary w-100 mb-2">Descargar</a>
+      <button type="button" class="btn btn-outline-secondary w-100 mb-2" id="saveBtn">Guardar</button>
+      <button type="button" class="btn btn-outline-secondary w-100 share-btn" data-share-url="{{ url_for('notes.view_note', id=note.id, _external=True) }}">Compartir</button>
       {% if current_user.is_authenticated and note.user_id == current_user.id %}
-      <a href="{{ url_for('notes.edit_note', note_id=note.id) }}" class="btn btn-outline-secondary btn-sm">Editar</a>
-      <form action="{{ url_for('notes.delete_note', note_id=note.id) }}" method="post" class="d-inline" onsubmit="return confirm('¿Eliminar este apunte?');">
+      <a href="{{ url_for('notes.edit_note', note_id=note.id) }}" class="btn btn-outline-secondary w-100 mt-2">Editar</a>
+      <form action="{{ url_for('notes.delete_note', note_id=note.id) }}" method="post" onsubmit="return confirm('¿Eliminar este apunte?');" class="mt-2">
         {{ csrf.csrf_field() }}
-        <button type="submit" class="btn btn-danger btn-sm">Eliminar</button>
+        <button type="submit" class="btn btn-danger w-100">Eliminar</button>
       </form>
       {% endif %}
       {% if current_user.is_authenticated and current_user.id != note.author.id %}
-      <button type="button" class="btn btn-outline-warning btn-sm" data-bs-toggle="modal" data-bs-target="#reportNoteModal">Reportar</button>
-      <form id="likeForm" method="post" action="{{ url_for('notes.like_note', note_id=note.id) }}" style="display:inline;">
+      <button type="button" class="btn btn-outline-warning w-100 mt-2" data-bs-toggle="modal" data-bs-target="#reportNoteModal">Reportar</button>
+      <form id="likeForm" method="post" action="{{ url_for('notes.like_note', note_id=note.id) }}" class="mt-2">
         {{ csrf.csrf_field() }}
-        <button class="btn btn-outline-success btn-sm" type="submit">👍 Me gusta</button>
+        <button class="btn btn-outline-success w-100" type="submit">👍 Me gusta</button>
       </form>
+      <p class="mt-1 mb-0"><strong>Likes:</strong> <span id="likeCount">{{ note.likes }}</span></p>
       {% endif %}
-      <p><strong>Likes:</strong> <span id="likeCount">{{ note.likes }}</span></p>
-    <canvas id="pdfViewer" class="w-100 border rounded shadow-sm mb-3" style="max-height: 600px;"></canvas>
-    <p class="text-muted small">¿No puedes visualizar el PDF? <a href="{{ note.filename }}" target="_blank">Haz clic aquí para descargarlo</a>.</p>
-    <h5 class="mb-3">Comentarios</h5>
-    <div id="comments">
-      {% for c in note.comments|sort(attribute='created_at', reverse=True) %}
-      <div class="d-flex mb-3 comment">
-        <img loading="lazy" src="{{ c.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
-        <div>
-          <div class="small text-muted">
-            <a href="{{ url_for('auth.profile_by_username', username=c.author.username) }}" class="text-decoration-none">{{ c.author.username }}</a> • {{ c.created_at.strftime('%Y-%m-%d %H:%M') }}
-          </div>
-          <div>{{ c.body }}</div>
-        </div>
-      </div>
-      {% endfor %}
     </div>
-    {% if current_user.is_authenticated %}
-    <form id="commentForm" class="mt-3">
-      {{ csrf.csrf_field() }}
-      <div class="input-group">
-        <input type="text" name="body" class="form-control" placeholder="Añadir comentario" required>
-        <button class="btn btn-primary" type="submit">Enviar</button>
+  </div>
+  <hr>
+  <h5 class="mb-3">Comentarios</h5>
+  <div id="comments">
+    {% for c in note.comments|sort(attribute='created_at', reverse=True) %}
+    <div class="d-flex mb-3 comment">
+      <img loading="lazy" src="{{ c.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
+      <div>
+        <div class="small text-muted">
+          <a href="{{ url_for('auth.profile_by_username', username=c.author.username) }}" class="text-decoration-none">{{ c.author.username }}</a> • {{ c.created_at.strftime('%Y-%m-%d %H:%M') }}
+        </div>
+        <div>{{ c.body }}</div>
       </div>
-    </form>
-    {% endif %}
-  </article>
+    </div>
+    {% endfor %}
+  </div>
+  {% if current_user.is_authenticated %}
+  <form id="commentForm" class="mt-3">
+    {{ csrf.csrf_field() }}
+    <div class="input-group">
+      <input type="text" name="body" class="form-control" placeholder="Añadir comentario" required>
+      <button class="btn btn-primary" type="submit">Enviar</button>
+    </div>
+  </form>
+  {% endif %}
 </div>
 {% if current_user.is_authenticated and current_user.id != note.author.id %}
 <div class="modal fade" id="reportNoteModal" tabindex="-1" aria-hidden="true">
@@ -95,8 +96,6 @@
 </div>
 {% endif %}
 <script>
-
-
   document.getElementById('commentForm')?.addEventListener('submit', function(e){
     e.preventDefault();
     const btn = this.querySelector('button');
@@ -108,13 +107,12 @@
     }).then(r => r.json()).then(c => {
       const div = document.createElement('div');
       div.className = 'd-flex mb-3 comment';
-      div.innerHTML = `<img loading="lazy" src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar"><div><div class=\"small text-muted\">${c.author} • ${c.timestamp}</div><div>${c.body}</div></div>`;
+      div.innerHTML = `<img loading=\"lazy\" src=\"{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}\" class=\"rounded-circle me-2\" width=\"32\" height=\"32\" alt=\"avatar\"><div><div class=\"small text-muted\">${c.author} • ${c.timestamp}</div><div>${c.body}</div></div>`;
       document.getElementById('comments').prepend(div);
       e.target.reset();
       showToast('Comentario agregado');
     }).finally(() => { btn.disabled = false; });
   });
-
   document.getElementById('likeForm')?.addEventListener('submit', function(e){
     e.preventDefault();
     const btn = this.querySelector('button');
@@ -128,48 +126,14 @@
       }
     }).finally(() => { btn.disabled = false; });
   });
-
-  document.getElementById('shareForm')?.addEventListener('submit', function(e){
-    e.preventDefault();
-    const btn = this.querySelector('button');
-    btn.disabled = true;
-    csrfFetch(this.action, {method:'POST'}).then(() => {
-      showToast('Gracias por compartir');
-    }).finally(() => { btn.disabled = false; });
+  document.getElementById('saveBtn')?.addEventListener('click', () => {
+    showToast('Función de guardar próximamente');
   });
 </script>
 {% endblock %}
 
 {% block body_end %}
 <script src="{{ url_for('static', filename='pdfjs/pdf.min.js') }}"></script>
-<script>
-  pdfjsLib.GlobalWorkerOptions.workerSrc = "{{ url_for('static', filename='pdfjs/pdf.worker.min.js') }}";
-
-  const url = "{{ note.filename }}";
-  const loadingTask = pdfjsLib.getDocument(url);
-
-  loadingTask.promise.then(pdf => {
-    pdf.getPage(1).then(page => {
-      const scale = 1.5;
-      const viewport = page.getViewport({ scale });
-
-      const canvas = document.getElementById('pdfViewer');
-      const context = canvas.getContext('2d');
-      canvas.height = viewport.height;
-      canvas.width = viewport.width;
-
-      const renderContext = {
-        canvasContext: context,
-        viewport: viewport
-      };
-      page.render(renderContext);
-    });
-  }).catch(error => {
-    console.error("Error al cargar el PDF:", error);
-    const fallback = document.createElement("p");
-    fallback.className = "text-danger";
-    fallback.textContent = "No se pudo cargar el PDF. Puedes descargarlo abajo.";
-    document.getElementById("pdfViewer").replaceWith(fallback);
-  });
-</script>
+<script src="{{ url_for('static', filename='js/viewer.js') }}"></script>
+<script>pdfjsLib.GlobalWorkerOptions.workerSrc = "{{ url_for('static', filename='pdfjs/pdf.worker.min.js') }}";</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- redesign notes detail page with 2-column layout
- add PDF and image viewer logic
- detect file type in route
- init note viewer from `main.js`
- document changes in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685c9418cc748325b092f9c993c15e41