### PR TITLE
Add modal post form in feed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,3 +285,4 @@
 - wsgi.py importa create_app desde el paquete crunevo nuevamente y se actualiz\xF3 wsgi_admin para mantener consistencia.
 - Redesigned note detail with two-column layout, PDF/image viewer via viewer.js and file type detection in notes_routes (PR note-detail-redesign).
 - Expanded notes model with language, reading_time, content_type, summary, course and career; upload form modernized with collapse "Más ajustes" (PR notes-upload-form-v2).
+- Formulario de publicación ahora usa un modal emergente activado por un botón estilo Facebook en el feed (PR fb-style-modal).

--- a/crunevo/templates/feed/index.html
+++ b/crunevo/templates/feed/index.html
@@ -12,27 +12,10 @@
     {% include 'components/feed_sidebar.html' %}
   </div>
   <div class="col-lg-7">
-    <div class="card shadow-sm mb-3">
-      <div class="card-body">
-        <div class="d-flex mb-3">
-          <img loading="lazy" loading="lazy" src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
-          <textarea name="content" form="postForm" class="form-control" rows="2" placeholder="¿Qué deseas compartir?" required></textarea>
-        </div>
-        <form id="postForm" method="post" enctype="multipart/form-data">
-          {{ csrf.csrf_field() }}
-          <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
-            <div class="btn-group">
-              <a href="{{ url_for('notes.upload') }}" class="btn btn-outline-secondary btn-sm"><i class="bi bi-file-earmark-plus"></i> Apunte</a>
-              <label class="btn btn-outline-secondary btn-sm mb-0">
-                <i class="bi bi-image"></i> Imagen
-                <input type="file" name="file" id="feedImageInput" accept="image/*" class="d-none">
-              </label>
-              <button type="button" class="btn btn-outline-secondary btn-sm" disabled><i class="bi bi-trophy"></i> Logro</button>
-            </div>
-            <button id="postSubmitBtn" class="btn btn-primary btn-sm" type="submit">Publicar</button>
-          </div>
-          <div id="previewContainer" class="mt-2"></div>
-        </form>
+    <div class="card mb-3 shadow-sm" data-bs-toggle="modal" data-bs-target="#createPostModal">
+      <div class="card-body d-flex align-items-center">
+        <img loading="lazy" src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
+        <span class="text-muted">¿Qué deseas compartir?</span>
       </div>
     </div>
     <div class="d-lg-none mb-3">
@@ -71,4 +54,42 @@
     {% include 'components/feed_sidebar.html' %}
   </div>
 </div>
+{% endblock %}
+
+{% block body_end %}
+  <div class="modal fade" id="createPostModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-lg">
+      <div class="modal-content">
+        <form id="postForm" method="post" action="{{ url_for('feed.view_feed') }}" enctype="multipart/form-data">
+          {{ csrf.csrf_field() }}
+          <div class="modal-header">
+            <h5 class="modal-title">Crear publicación</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          </div>
+          <div class="modal-body">
+            <div class="d-flex mb-3">
+              <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40">
+              <textarea class="form-control" name="content" rows="4" placeholder="¿Qué deseas compartir?" required></textarea>
+            </div>
+            <div class="d-flex gap-2 flex-wrap">
+              <label class="btn btn-outline-secondary btn-sm">
+                <i class="bi bi-image"></i> Imagen
+                <input type="file" name="file" id="feedImageInput" accept="image/*,.pdf" class="d-none">
+              </label>
+              <a href="{{ url_for('notes.upload') }}" class="btn btn-outline-secondary btn-sm">
+                <i class="bi bi-file-earmark-plus"></i> Apunte
+              </a>
+              <button type="button" class="btn btn-outline-secondary btn-sm" disabled>
+                <i class="bi bi-trophy"></i> Logro
+              </button>
+            </div>
+            <div id="previewContainer" class="mt-2"></div>
+          </div>
+          <div class="modal-footer">
+            <button id="postSubmitBtn" class="btn btn-primary" type="submit">Publicar</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
 {% endblock %}

--- a/crunevo/templates/feed/list.html
+++ b/crunevo/templates/feed/list.html
@@ -12,27 +12,10 @@
     {% include 'components/feed_sidebar.html' %}
   </div>
   <div class="col-lg-7">
-    <div class="card shadow-sm mb-3">
-      <div class="card-body">
-        <div class="d-flex mb-3">
-          <img loading="lazy" src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
-          <textarea name="content" form="postForm" class="form-control" rows="2" placeholder="¿Qué deseas compartir?" required></textarea>
-        </div>
-        <form id="postForm" method="post" enctype="multipart/form-data">
-          {{ csrf.csrf_field() }}
-          <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
-            <div class="btn-group">
-              <a href="{{ url_for('notes.upload') }}" class="btn btn-outline-secondary btn-sm"><i class="bi bi-file-earmark-plus"></i> Apunte</a>
-              <label class="btn btn-outline-secondary btn-sm mb-0">
-                <i class="bi bi-image"></i> Imagen
-                <input type="file" name="file" id="feedImageInput" accept="image/*" class="d-none">
-              </label>
-              <button type="button" class="btn btn-outline-secondary btn-sm" disabled><i class="bi bi-trophy"></i> Logro</button>
-            </div>
-            <button class="btn btn-primary btn-sm" type="submit">Publicar</button>
-          </div>
-        <div id="previewContainer" class="mt-2"></div>
-        </form>
+    <div class="card mb-3 shadow-sm" data-bs-toggle="modal" data-bs-target="#createPostModal">
+      <div class="card-body d-flex align-items-center">
+        <img loading="lazy" src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
+        <span class="text-muted">¿Qué deseas compartir?</span>
       </div>
     </div>
     <div class="d-lg-none mb-3">
@@ -57,4 +40,42 @@
     {% include 'components/sidebar_right.html' %}
   </div>
 </div>
+{% endblock %}
+
+{% block body_end %}
+  <div class="modal fade" id="createPostModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-lg">
+      <div class="modal-content">
+        <form id="postForm" method="post" action="{{ url_for('feed.edu_feed') }}" enctype="multipart/form-data">
+          {{ csrf.csrf_field() }}
+          <div class="modal-header">
+            <h5 class="modal-title">Crear publicación</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          </div>
+          <div class="modal-body">
+            <div class="d-flex mb-3">
+              <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40">
+              <textarea class="form-control" name="content" rows="4" placeholder="¿Qué deseas compartir?" required></textarea>
+            </div>
+            <div class="d-flex gap-2 flex-wrap">
+              <label class="btn btn-outline-secondary btn-sm">
+                <i class="bi bi-image"></i> Imagen
+                <input type="file" name="file" id="feedImageInput" accept="image/*,.pdf" class="d-none">
+              </label>
+              <a href="{{ url_for('notes.upload') }}" class="btn btn-outline-secondary btn-sm">
+                <i class="bi bi-file-earmark-plus"></i> Apunte
+              </a>
+              <button type="button" class="btn btn-outline-secondary btn-sm" disabled>
+                <i class="bi bi-trophy"></i> Logro
+              </button>
+            </div>
+            <div id="previewContainer" class="mt-2"></div>
+          </div>
+          <div class="modal-footer">
+            <button id="postSubmitBtn" class="btn btn-primary" type="submit">Publicar</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
 {% endblock %}

--- a/crunevo/templates/feed/trending.html
+++ b/crunevo/templates/feed/trending.html
@@ -7,27 +7,10 @@
     {% include 'components/feed_sidebar.html' %}
   </div>
   <div class="col-lg-7 col-md-12">
-    <div class="card shadow-sm mb-3">
-      <div class="card-body">
-        <div class="d-flex mb-3">
-          <img loading="lazy" src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
-          <textarea name="content" form="postForm" class="form-control" rows="2" placeholder="¿Qué deseas compartir?" required></textarea>
-        </div>
-        <form id="postForm" method="post" action="{{ url_for('feed.view_feed') }}" enctype="multipart/form-data">
-          {{ csrf.csrf_field() }}
-          <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
-            <div class="btn-group">
-              <a href="{{ url_for('notes.upload') }}" class="btn btn-outline-secondary btn-sm"><i class="bi bi-file-earmark-plus"></i> Apunte</a>
-              <label class="btn btn-outline-secondary btn-sm mb-0">
-                <i class="bi bi-image"></i> Imagen
-                <input type="file" name="file" id="feedImageInput" accept="image/*" class="d-none">
-              </label>
-              <button type="button" class="btn btn-outline-secondary btn-sm" disabled><i class="bi bi-trophy"></i> Logro</button>
-            </div>
-            <button id="postSubmitBtn" class="btn btn-primary btn-sm" type="submit">Publicar</button>
-          </div>
-          <div id="previewContainer" class="mt-2"></div>
-        </form>
+    <div class="card mb-3 shadow-sm" data-bs-toggle="modal" data-bs-target="#createPostModal">
+      <div class="card-body d-flex align-items-center">
+        <img loading="lazy" src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
+        <span class="text-muted">¿Qué deseas compartir?</span>
       </div>
     </div>
     <div class="d-lg-none mb-3">
@@ -129,6 +112,41 @@
 
 {% block body_end %}
 {{ super() }}
+  <div class="modal fade" id="createPostModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-lg">
+      <div class="modal-content">
+        <form id="postForm" method="post" action="{{ url_for('feed.view_feed') }}" enctype="multipart/form-data">
+          {{ csrf.csrf_field() }}
+          <div class="modal-header">
+            <h5 class="modal-title">Crear publicación</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          </div>
+          <div class="modal-body">
+            <div class="d-flex mb-3">
+              <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40">
+              <textarea class="form-control" name="content" rows="4" placeholder="¿Qué deseas compartir?" required></textarea>
+            </div>
+            <div class="d-flex gap-2 flex-wrap">
+              <label class="btn btn-outline-secondary btn-sm">
+                <i class="bi bi-image"></i> Imagen
+                <input type="file" name="file" id="feedImageInput" accept="image/*,.pdf" class="d-none">
+              </label>
+              <a href="{{ url_for('notes.upload') }}" class="btn btn-outline-secondary btn-sm">
+                <i class="bi bi-file-earmark-plus"></i> Apunte
+              </a>
+              <button type="button" class="btn btn-outline-secondary btn-sm" disabled>
+                <i class="bi bi-trophy"></i> Logro
+              </button>
+            </div>
+            <div id="previewContainer" class="mt-2"></div>
+          </div>
+          <div class="modal-footer">
+            <button id="postSubmitBtn" class="btn btn-primary" type="submit">Publicar</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
 <script src="{{ url_for('static', filename='pdfjs/pdf.min.js') }}"></script>
 <script>
   pdfjsLib.GlobalWorkerOptions.workerSrc = "{{ url_for('static', filename='pdfjs/pdf.worker.min.js') }}";


### PR DESCRIPTION
## Summary
- redesign feed post input as modal-trigger button
- open modal with image/file options
- document change in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685c9cc39f6883259591a953d8b29cb6