### PR TITLE
Implement reaction dropdown and cleanup post buttons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,3 +286,4 @@
 - Redesigned note detail with two-column layout, PDF/image viewer via viewer.js and file type detection in notes_routes (PR note-detail-redesign).
 - Expanded notes model with language, reading_time, content_type, summary, course and career; upload form modernized with collapse "Más ajustes" (PR notes-upload-form-v2).
 - Formulario de publicación ahora usa un modal emergente activado por un botón estilo Facebook en el feed (PR fb-style-modal).
+- Refactorizada la sección inferior de los posts con dropdown y reacciones múltiples (PR reactions-ui).

--- a/crunevo/models/__init__.py
+++ b/crunevo/models/__init__.py
@@ -24,3 +24,4 @@ from .answer import Answer  # noqa: F401
 from .saved_post import SavedPost  # noqa: F401
 from .notification import Notification  # noqa: F401
 from .mission import Mission, UserMission  # noqa: F401
+from .post_reaction import PostReaction  # noqa: F401

--- a/crunevo/models/post_reaction.py
+++ b/crunevo/models/post_reaction.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+from crunevo.extensions import db
+
+
+class PostReaction(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    post_id = db.Column(db.Integer, db.ForeignKey("post.id"), nullable=False)
+    reaction_type = db.Column(db.String(10), nullable=False)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+
+    __table_args__ = (
+        db.UniqueConstraint("user_id", "post_id", name="uniq_post_reaction"),
+    )

--- a/crunevo/routes/feed_routes.py
+++ b/crunevo/routes/feed_routes.py
@@ -20,6 +20,7 @@ from crunevo.extensions import db, csrf
 from crunevo.models import (
     Post,
     PostComment,
+    PostReaction,
     FeedItem,
     Note,
     User,
@@ -330,18 +331,49 @@ feed_bp.add_url_rule(
 @feed_bp.route("/like/<int:post_id>", methods=["POST"])
 @activated_required
 def like_post(post_id):
+    """Handle reactions to a post allowing one per user."""
     post = Post.query.get_or_404(post_id)
-    if post.likes is None:
-        post.likes = 0
-    post.likes += 1
-    if post.author_id != current_user.id:
-        send_notification(
-            post.author_id,
-            f"{current_user.username} le dio like a tu publicación",
-            url_for("feed.view_post", post_id=post.id),
+    reaction = request.form.get("reaction", "🔥")
+    existing = PostReaction.query.filter_by(
+        user_id=current_user.id, post_id=post.id
+    ).first()
+
+    if existing:
+        if existing.reaction_type == reaction:
+            # remove reaction
+            db.session.delete(existing)
+            post.likes = max((post.likes or 0) - 1, 0)
+            action = "removed"
+        else:
+            # change reaction type
+            existing.reaction_type = reaction
+            action = "changed"
+    else:
+        db.session.add(
+            PostReaction(
+                user_id=current_user.id,
+                post_id=post.id,
+                reaction_type=reaction,
+            )
         )
+        post.likes = (post.likes or 0) + 1
+        action = "added"
+        if post.author_id != current_user.id:
+            send_notification(
+                post.author_id,
+                f"{current_user.username} reaccionó a tu publicación",
+                url_for("feed.view_post", post_id=post.id),
+            )
+
     db.session.commit()
-    return jsonify({"likes": post.likes})
+
+    counts = dict(
+        db.session.query(PostReaction.reaction_type, db.func.count())
+        .filter_by(post_id=post.id)
+        .group_by(PostReaction.reaction_type)
+        .all()
+    )
+    return jsonify({"likes": post.likes, "counts": counts, "status": action})
 
 
 @feed_bp.route("/comment/<int:post_id>", methods=["POST"])

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -35,3 +35,28 @@
   max-width: 100%;
   object-fit: contain;
 }
+.reaction-options {
+  background: white;
+  border-radius: 12px;
+  padding: 6px;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+  z-index: 100;
+  top: -60px;
+  left: 0;
+  display: flex;
+  gap: 6px;
+}
+
+.reaction-btn {
+  border: none;
+  background: transparent;
+  font-size: 24px;
+  cursor: pointer;
+}
+
+.btn-reaction {
+  background-color: #f9f9f9;
+  border-radius: 20px;
+  padding: 6px 10px;
+  border: 1px solid #ccc;
+}

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -28,6 +28,37 @@ function showToast(message, options = {}) {
   new bootstrap.Toast(div).show();
 }
 
+function showReactions(btn) {
+  const container = btn.closest('.reaction-container');
+  const options = container.querySelector('.reaction-options');
+  if (!options) return;
+  options.classList.remove('d-none');
+  setTimeout(() => {
+    options.classList.add('d-none');
+  }, 4000);
+}
+
+function initReactions() {
+  document.querySelectorAll('.reaction-btn').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const reaction = btn.dataset.reaction;
+      const container = btn.closest('.reaction-container');
+      const postId = container.dataset.postId;
+      const span = container.querySelector('.count');
+      const options = container.querySelector('.reaction-options');
+      const data = new URLSearchParams();
+      data.set('reaction', reaction);
+      csrfFetch(`/like/${postId}`, { method: 'POST', body: data })
+        .then((r) => r.json())
+        .then((d) => {
+          if (span) span.textContent = d.likes;
+          if (options) options.classList.add('d-none');
+          showToast('¡Gracias por tu reacción!');
+        });
+    });
+  });
+}
+
 function initPdfPreviews() {
   if (typeof pdfjsLib === 'undefined') return;
   document.querySelectorAll('canvas.pdf-thumb').forEach((canvas) => {
@@ -109,6 +140,9 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   if (typeof initFeedInteractions === 'function') {
     initFeedInteractions();
+  }
+  if (typeof initReactions === 'function') {
+    initReactions();
   }
   if (typeof initQuickFilters === 'function') {
     initQuickFilters();

--- a/crunevo/templates/components/reactions.html
+++ b/crunevo/templates/components/reactions.html
@@ -1,0 +1,17 @@
+{% macro reaction_container(post) %}
+<div class="reaction-container position-relative d-inline-block" data-post-id="{{ post.id }}">
+  <button class="btn btn-reaction" onmouseenter="showReactions(this)">
+    🔥 <span class="count">{{ post.likes or 0 }}</span>
+  </button>
+  <div class="reaction-options d-none position-absolute">
+    <button class="reaction-btn" data-reaction="🔥">🔥</button>
+    <button class="reaction-btn" data-reaction="🧠">🧠</button>
+    <button class="reaction-btn" data-reaction="💔">💔</button>
+    <button class="reaction-btn" data-reaction="😠">😠</button>
+    <button class="reaction-btn" data-reaction="🥶">🥶</button>
+    <button class="reaction-btn" data-reaction="😂">😂</button>
+    <button class="reaction-btn" data-reaction="🤡">🤡</button>
+    <button class="reaction-btn" data-reaction="😎">😎</button>
+  </div>
+</div>
+{% endmacro %}

--- a/crunevo/templates/feed/post_card.html
+++ b/crunevo/templates/feed/post_card.html
@@ -1,4 +1,5 @@
 {% import 'components/csrf.html' as csrf %}
+{% import 'components/reactions.html' as react %}
 <article class="card shadow-sm mb-3">
   <div class="card-header bg-transparent d-flex align-items-center gap-2">
     {% set author = post.author %}
@@ -15,6 +16,17 @@
       <button class="btn btn-sm btn-light" data-bs-toggle="dropdown" aria-expanded="false"><i class="bi bi-three-dots"></i></button>
       <ul class="dropdown-menu dropdown-menu-end">
         <li><a class="dropdown-item" href="{{ url_for('feed.view_post', post_id=post.id) }}">Ver publicación</a></li>
+        {% if post.author_id == current_user.id %}
+        <li><a class="dropdown-item" data-bs-toggle="modal" href="#editModal{{ post.id }}">Editar</a></li>
+        <li>
+          <form action="{{ url_for('feed.eliminar_post', post_id=post.id) }}" method="POST" onsubmit="return confirm('¿Eliminar esta publicación?');">
+            {{ csrf.csrf_field() }}
+            <button type="submit" class="dropdown-item text-danger">Eliminar</button>
+          </form>
+        </li>
+        {% else %}
+        <li><a class="dropdown-item text-warning" data-bs-toggle="modal" href="#reportPost{{ post.id }}">Reportar</a></li>
+        {% endif %}
       </ul>
     </div>
   </div>
@@ -28,22 +40,8 @@
       {% endif %}
     {% endif %}
     <div class="d-flex align-items-center gap-2 mb-2">
-      <form class="like-form" method="post" action="{{ url_for('feed.like_post', post_id=post.id) }}" data-target="likeCount{{ post.id }}">
-        {{ csrf.csrf_field() }}
-        <button class="btn btn-outline-danger btn-sm" type="submit">🔥</button>
-      </form>
-      <span id="likeCount{{ post.id }}">{{ post.likes or 0 }}</span>
-      <button class="btn btn-outline-secondary btn-sm share-btn" data-share-url="{{ url_for('feed.view_post', post_id=post.id, _external=True) }}"><i class="bi bi-share"></i></button>
-      <a href="{{ url_for('feed.view_post', post_id=post.id) }}" class="btn btn-outline-primary btn-sm">Ver publicación</a>
-      {% if post.author_id == current_user.id %}
-      <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#editModal{{ post.id }}">Editar</button>
-      <form action="{{ url_for('feed.eliminar_post', post_id=post.id) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar esta publicación?');">
-        {{ csrf.csrf_field() }}
-        <button type="submit" class="btn btn-outline-danger btn-sm">🗑️ Eliminar</button>
-      </form>
-      {% else %}
-      <button type="button" class="btn btn-outline-warning btn-sm" data-bs-toggle="modal" data-bs-target="#reportPost{{ post.id }}">Reportar</button>
-      {% endif %}
+      {{ react.reaction_container(post) }}
+      <a href="#comments{{ post.id }}" class="btn btn-outline-secondary btn-sm"><i class="bi bi-chat-dots"></i></a>
     </div>
     <div id="comments{{ post.id }}">
       {% if post.comments %}

--- a/migrations/versions/f0b41d2f9c3a_add_post_reaction.py
+++ b/migrations/versions/f0b41d2f9c3a_add_post_reaction.py
@@ -1,0 +1,31 @@
+"""add post reaction table
+
+Revision ID: f0b41d2f9c3a
+Revises: 056ac5a1f108
+Create Date: 2025-07-01 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "f0b41d2f9c3a"
+down_revision = "056ac5a1f108"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "post_reaction",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("user.id"), nullable=False),
+        sa.Column("post_id", sa.Integer(), sa.ForeignKey("post.id"), nullable=False),
+        sa.Column("reaction_type", sa.String(length=10), nullable=False),
+        sa.Column("timestamp", sa.DateTime(), nullable=True),
+        sa.UniqueConstraint("user_id", "post_id", name="uniq_post_reaction"),
+    )
+
+
+def downgrade():
+    op.drop_table("post_reaction")

--- a/tests/test_post_likes.py
+++ b/tests/test_post_likes.py
@@ -1,4 +1,4 @@
-from crunevo.models import Post
+from crunevo.models import Post, PostReaction
 
 
 def login(client, username, password):
@@ -11,9 +11,41 @@ def test_like_post_handles_null_likes(client, db_session, test_user, another_use
     db_session.commit()
 
     login(client, test_user.username, "secret")
-    resp = client.post(f"/like/{post.id}")
+    resp = client.post(f"/like/{post.id}", data={"reaction": "🔥"})
     assert resp.status_code == 200
     assert resp.get_json()["likes"] == 1
 
     db_session.refresh(post)
     assert post.likes == 1
+    assert PostReaction.query.count() == 1
+
+
+def test_change_reaction(client, db_session, test_user, another_user):
+    post = Post(content="hi", author=another_user)
+    db_session.add(post)
+    db_session.commit()
+
+    login(client, test_user.username, "secret")
+    client.post(f"/like/{post.id}", data={"reaction": "🔥"})
+    client.post(f"/like/{post.id}", data={"reaction": "😂"})
+
+    db_session.refresh(post)
+    reaction = PostReaction.query.filter_by(
+        user_id=test_user.id, post_id=post.id
+    ).first()
+    assert reaction.reaction_type == "😂"
+    assert post.likes == 1
+
+
+def test_remove_reaction(client, db_session, test_user, another_user):
+    post = Post(content="bye", author=another_user)
+    db_session.add(post)
+    db_session.commit()
+
+    login(client, test_user.username, "secret")
+    client.post(f"/like/{post.id}", data={"reaction": "🔥"})
+    resp = client.post(f"/like/{post.id}", data={"reaction": "🔥"})
+    assert resp.get_json()["likes"] == 0
+    db_session.refresh(post)
+    assert PostReaction.query.count() == 0
+    assert post.likes == 0


### PR DESCRIPTION
## Summary
- add `PostReaction` model and migration
- support multi-type post reactions in `/like/<id>`
- reorganize post card actions into dropdown and add reaction component
- expose reaction UI styles and JS handlers
- extend post like tests for reactions
- document work in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685ca12a170c8325a7b75fa450041bb4