### PR TITLE
Improve reactions UI with counts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,3 +286,5 @@
 - Redesigned note detail with two-column layout, PDF/image viewer via viewer.js and file type detection in notes_routes (PR note-detail-redesign).
 - Expanded notes model with language, reading_time, content_type, summary, course and career; upload form modernized with collapse "Más ajustes" (PR notes-upload-form-v2).
 - Formulario de publicación ahora usa un modal emergente activado por un botón estilo Facebook en el feed (PR fb-style-modal).
+- Refactorizada la sección inferior de los posts con dropdown y reacciones múltiples (PR reactions-ui).
+- Sistema de reacciones actualizado con conteo por emoji y compatibilidad móvil (PR reactions-ui-counts).

--- a/crunevo/models/__init__.py
+++ b/crunevo/models/__init__.py
@@ -24,3 +24,4 @@ from .answer import Answer  # noqa: F401
 from .saved_post import SavedPost  # noqa: F401
 from .notification import Notification  # noqa: F401
 from .mission import Mission, UserMission  # noqa: F401
+from .post_reaction import PostReaction  # noqa: F401

--- a/crunevo/models/post_reaction.py
+++ b/crunevo/models/post_reaction.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+from crunevo.extensions import db
+
+
+class PostReaction(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    post_id = db.Column(db.Integer, db.ForeignKey("post.id"), nullable=False)
+    reaction_type = db.Column(db.String(20), nullable=False)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+
+    __table_args__ = (
+        db.UniqueConstraint("user_id", "post_id", name="uniq_post_reaction"),
+    )
+
+    @staticmethod
+    def counts_for_posts(post_ids):
+        if not post_ids:
+            return {}
+        rows = (
+            db.session.query(
+                PostReaction.post_id, PostReaction.reaction_type, db.func.count()
+            )
+            .filter(PostReaction.post_id.in_(post_ids))
+            .group_by(PostReaction.post_id, PostReaction.reaction_type)
+            .all()
+        )
+        counts = {}
+        for pid, rt, cnt in rows:
+            counts.setdefault(pid, {})[rt] = cnt
+        return counts
+
+    @staticmethod
+    def count_for_post(post_id):
+        return PostReaction.counts_for_posts([post_id]).get(post_id, {})

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -35,3 +35,34 @@
   max-width: 100%;
   object-fit: contain;
 }
+.reaction-options {
+  background: white;
+  border-radius: 12px;
+  padding: 6px;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+  z-index: 100;
+  top: -60px;
+  left: 0;
+  display: flex;
+  gap: 6px;
+}
+
+.reaction-btn {
+  border: none;
+  background: transparent;
+  font-size: 24px;
+  cursor: pointer;
+}
+
+.btn-reaction {
+  background-color: #f9f9f9;
+  border-radius: 20px;
+  padding: 6px 10px;
+  border: 1px solid #ccc;
+}
+
+.reaction-counts {
+  margin-top: 0.25rem;
+  font-size: 0.875rem;
+  color: #6c757d;
+}

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -28,6 +28,47 @@ function showToast(message, options = {}) {
   new bootstrap.Toast(div).show();
 }
 
+function showReactions(btn) {
+  const container = btn.closest('.reaction-container');
+  const options = container.querySelector('.reaction-options');
+  if (!options) return;
+  if (options.classList.contains('d-none')) {
+    options.classList.remove('d-none');
+    setTimeout(() => {
+      options.classList.add('d-none');
+    }, 4000);
+  } else {
+    options.classList.add('d-none');
+  }
+}
+
+function initReactions() {
+  document.querySelectorAll('.reaction-btn').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const reaction = btn.dataset.reaction;
+      const container = btn.closest('.reaction-container');
+      const postId = container.dataset.postId;
+      const span = container.querySelector('.count');
+      const countsDiv = container.querySelector('.reaction-counts');
+      const options = container.querySelector('.reaction-options');
+      const data = new URLSearchParams();
+      data.set('reaction', reaction);
+      csrfFetch(`/like/${postId}`, { method: 'POST', body: data })
+        .then((r) => r.json())
+        .then((d) => {
+          if (span) span.textContent = d.likes;
+          if (countsDiv) {
+            countsDiv.innerHTML = Object.entries(d.counts)
+              .map(([e, c]) => `${e} ${c}`)
+              .join(' ');
+          }
+          if (options) options.classList.add('d-none');
+          showToast('¡Gracias por tu reacción!');
+        });
+    });
+  });
+}
+
 function initPdfPreviews() {
   if (typeof pdfjsLib === 'undefined') return;
   document.querySelectorAll('canvas.pdf-thumb').forEach((canvas) => {
@@ -109,6 +150,9 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   if (typeof initFeedInteractions === 'function') {
     initFeedInteractions();
+  }
+  if (typeof initReactions === 'function') {
+    initReactions();
   }
   if (typeof initQuickFilters === 'function') {
     initQuickFilters();

--- a/crunevo/templates/components/reactions.html
+++ b/crunevo/templates/components/reactions.html
@@ -1,0 +1,24 @@
+{% macro reaction_container(post, counts=None) %}
+<div class="reaction-container position-relative d-inline-block" data-post-id="{{ post.id }}">
+  <button class="btn btn-reaction" onclick="showReactions(this)">
+    <i class="bi bi-heart"></i> <span class="count">{{ post.likes or 0 }}</span>
+  </button>
+  <div class="reaction-options d-none position-absolute">
+    <button class="reaction-btn" data-reaction="🔥" title="Crunazo">🔥</button>
+    <button class="reaction-btn" data-reaction="🧠" title="Neuro">🧠</button>
+    <button class="reaction-btn" data-reaction="💔" title="Roto">💔</button>
+    <button class="reaction-btn" data-reaction="😠" title="Molesto">😠</button>
+    <button class="reaction-btn" data-reaction="🥶" title="Congelao">🥶</button>
+    <button class="reaction-btn" data-reaction="😂" title="Vacilón">😂</button>
+    <button class="reaction-btn" data-reaction="🤡" title="Cringe">🤡</button>
+    <button class="reaction-btn" data-reaction="😎" title="Bacán">😎</button>
+  </div>
+  {% if counts %}
+  <div class="reaction-counts mt-1 small text-muted">
+    {% for emoji, count in counts.items() %}
+      {{ emoji }} {{ count }}
+    {% endfor %}
+  </div>
+  {% endif %}
+</div>
+{% endmacro %}

--- a/crunevo/templates/feed/index.html
+++ b/crunevo/templates/feed/index.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% import 'components/csrf.html' as csrf %}
+{% import 'components/reactions.html' as react %}
 
 {% block head_extra %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/feed.css') }}">
@@ -28,6 +29,7 @@
           {% include 'components/feed_card.html' %}
         {% elif item.type == 'post' %}
           {% set post = item.data %}
+          {% set counts = reaction_counts.get(post.id, {}) %}
           {% include 'feed/post_card.html' %}
         {% endif %}
       {% endfor %}

--- a/crunevo/templates/feed/list.html
+++ b/crunevo/templates/feed/list.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% import 'components/csrf.html' as csrf %}
+{% import 'components/reactions.html' as react %}
 
 {% block head_extra %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/feed.css') }}">
@@ -28,6 +29,7 @@
           {% include 'components/feed_card.html' %}
         {% elif item.type == 'post' %}
           {% set post = item.data %}
+          {% set counts = reaction_counts.get(post.id, {}) %}
           {% include 'feed/post_card.html' %}
         {% endif %}
       {% endfor %}

--- a/crunevo/templates/feed/post_card.html
+++ b/crunevo/templates/feed/post_card.html
@@ -1,4 +1,5 @@
 {% import 'components/csrf.html' as csrf %}
+{% import 'components/reactions.html' as react %}
 <article class="card shadow-sm mb-3">
   <div class="card-header bg-transparent d-flex align-items-center gap-2">
     {% set author = post.author %}
@@ -15,6 +16,17 @@
       <button class="btn btn-sm btn-light" data-bs-toggle="dropdown" aria-expanded="false"><i class="bi bi-three-dots"></i></button>
       <ul class="dropdown-menu dropdown-menu-end">
         <li><a class="dropdown-item" href="{{ url_for('feed.view_post', post_id=post.id) }}">Ver publicación</a></li>
+        {% if post.author_id == current_user.id %}
+        <li><a class="dropdown-item" data-bs-toggle="modal" href="#editModal{{ post.id }}">Editar</a></li>
+        <li>
+          <form action="{{ url_for('feed.eliminar_post', post_id=post.id) }}" method="POST" onsubmit="return confirm('¿Eliminar esta publicación?');">
+            {{ csrf.csrf_field() }}
+            <button type="submit" class="dropdown-item text-danger">Eliminar</button>
+          </form>
+        </li>
+        {% else %}
+        <li><a class="dropdown-item text-warning" data-bs-toggle="modal" href="#reportPost{{ post.id }}">Reportar</a></li>
+        {% endif %}
       </ul>
     </div>
   </div>
@@ -27,23 +39,9 @@
         <img loading="lazy" src="{{ post.file_url }}" class="feed-image img-fluid rounded mt-2" style="max-height: 400px; width: auto;" alt="imagen">
       {% endif %}
     {% endif %}
-    <div class="d-flex align-items-center gap-2 mb-2">
-      <form class="like-form" method="post" action="{{ url_for('feed.like_post', post_id=post.id) }}" data-target="likeCount{{ post.id }}">
-        {{ csrf.csrf_field() }}
-        <button class="btn btn-outline-danger btn-sm" type="submit">🔥</button>
-      </form>
-      <span id="likeCount{{ post.id }}">{{ post.likes or 0 }}</span>
-      <button class="btn btn-outline-secondary btn-sm share-btn" data-share-url="{{ url_for('feed.view_post', post_id=post.id, _external=True) }}"><i class="bi bi-share"></i></button>
-      <a href="{{ url_for('feed.view_post', post_id=post.id) }}" class="btn btn-outline-primary btn-sm">Ver publicación</a>
-      {% if post.author_id == current_user.id %}
-      <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#editModal{{ post.id }}">Editar</button>
-      <form action="{{ url_for('feed.eliminar_post', post_id=post.id) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar esta publicación?');">
-        {{ csrf.csrf_field() }}
-        <button type="submit" class="btn btn-outline-danger btn-sm">🗑️ Eliminar</button>
-      </form>
-      {% else %}
-      <button type="button" class="btn btn-outline-warning btn-sm" data-bs-toggle="modal" data-bs-target="#reportPost{{ post.id }}">Reportar</button>
-      {% endif %}
+    <div class="d-flex justify-content-between align-items-center gap-2 mb-2">
+      {{ react.reaction_container(post, counts) }}
+      <a href="#comments{{ post.id }}" class="btn btn-outline-secondary btn-sm"><i class="bi bi-chat-dots"></i></a>
     </div>
     <div id="comments{{ post.id }}">
       {% if post.comments %}

--- a/crunevo/templates/feed/post_detail.html
+++ b/crunevo/templates/feed/post_detail.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% import 'components/csrf.html' as csrf %}
+{% import 'components/reactions.html' as react %}
 {% block content %}
 <div class="card">
   <div class="card-body">
@@ -24,19 +25,8 @@
         <img loading="lazy" src="{{ post.file_url }}" class="feed-image img-fluid rounded mb-2">
         {% endif %}
       {% endif %}
-      <p class="text-muted small mb-2">
-        <strong>Likes:</strong>
-        <span id="likeCount{{ post.id }}">{{ post.likes or 0 }}</span>
-      </p>
-      <form
-        id="likeForm"
-        method="post"
-        action="{{ url_for('feed.like_post', post_id=post.id) }}"
-        data-target="likeCount{{ post.id }}"
-      >
-        {{ csrf.csrf_field() }}
-        <button class="btn btn-outline-success btn-sm" type="submit">👍 Me gusta</button>
-      </form>
+      {% set counts = reaction_counts %}
+      {{ react.reaction_container(post, counts) }}
 
       <div class="d-flex gap-2 my-3">
         <button type="button" class="btn btn-outline-secondary btn-sm share-btn" data-share-url="{{ url_for('feed.view_post', post_id=post.id, _external=True) }}">

--- a/crunevo/templates/feed/trending.html
+++ b/crunevo/templates/feed/trending.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% import 'components/csrf.html' as csrf %}
+{% import 'components/reactions.html' as react %}
 {% block title %}Publicaciones destacadas{% endblock %}
 {% block content %}
 <div class="row">
@@ -40,11 +41,12 @@
           <img loading="lazy" src="{{ post.file_url }}" class="feed-image img-fluid rounded mb-2">
           {% endif %}
         {% endif %}
+        {% set counts = reaction_counts.get(post.id, {}) %}
         {% if author %}
         <a href="{{ url_for('auth.profile_by_username', username=author.username) }}" class="btn btn-sm btn-outline-info mb-2">Ver perfil</a>
         <a href="{{ url_for('feed.view_post', post_id=post.id) }}" class="btn btn-sm btn-outline-primary mb-2">Ver publicación</a>
         {% endif %}
-        <p class="fs-5 fw-bold text-danger mb-0"><i class="bi bi-heart-fill me-1"></i>{{ post.likes or 0 }}</p>
+        {{ react.reaction_container(post, counts) }}
       </div>
     </div>
     {% endfor %}

--- a/crunevo/templates/feed/user_posts.html
+++ b/crunevo/templates/feed/user_posts.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% import 'components/reactions.html' as react %}
 {% block title %}Publicaciones de {{ user.username }}{% endblock %}
 {% block content %}
 <h2 class="mb-4">Publicaciones de {{ user.username }}</h2>
@@ -8,6 +9,7 @@
 <div class="row row-cols-1 g-3">
   {% for post in posts %}
   <div class="col">
+    {% set counts = reaction_counts.get(post.id, {}) %}
     {% include 'feed/post_card.html' %}
   </div>
   {% else %}

--- a/migrations/versions/81c3610645b1_extend_reaction_len.py
+++ b/migrations/versions/81c3610645b1_extend_reaction_len.py
@@ -1,0 +1,25 @@
+"""extend reaction_type length
+
+Revision ID: 81c3610645b1
+Revises: f0b41d2f9c3a
+Create Date: 2025-07-01 00:01:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "81c3610645b1"
+down_revision = "f0b41d2f9c3a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("post_reaction", recreate="always") as batch:
+        batch.alter_column("reaction_type", type_=sa.String(length=20))
+
+
+def downgrade():
+    with op.batch_alter_table("post_reaction", recreate="always") as batch:
+        batch.alter_column("reaction_type", type_=sa.String(length=10))

--- a/migrations/versions/f0b41d2f9c3a_add_post_reaction.py
+++ b/migrations/versions/f0b41d2f9c3a_add_post_reaction.py
@@ -1,0 +1,31 @@
+"""add post reaction table
+
+Revision ID: f0b41d2f9c3a
+Revises: 056ac5a1f108
+Create Date: 2025-07-01 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "f0b41d2f9c3a"
+down_revision = "056ac5a1f108"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "post_reaction",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("user.id"), nullable=False),
+        sa.Column("post_id", sa.Integer(), sa.ForeignKey("post.id"), nullable=False),
+        sa.Column("reaction_type", sa.String(length=10), nullable=False),
+        sa.Column("timestamp", sa.DateTime(), nullable=True),
+        sa.UniqueConstraint("user_id", "post_id", name="uniq_post_reaction"),
+    )
+
+
+def downgrade():
+    op.drop_table("post_reaction")

--- a/tests/test_post_likes.py
+++ b/tests/test_post_likes.py
@@ -1,4 +1,4 @@
-from crunevo.models import Post
+from crunevo.models import Post, PostReaction
 
 
 def login(client, username, password):
@@ -11,9 +11,41 @@ def test_like_post_handles_null_likes(client, db_session, test_user, another_use
     db_session.commit()
 
     login(client, test_user.username, "secret")
-    resp = client.post(f"/like/{post.id}")
+    resp = client.post(f"/like/{post.id}", data={"reaction": "🔥"})
     assert resp.status_code == 200
     assert resp.get_json()["likes"] == 1
 
     db_session.refresh(post)
     assert post.likes == 1
+    assert PostReaction.query.count() == 1
+
+
+def test_change_reaction(client, db_session, test_user, another_user):
+    post = Post(content="hi", author=another_user)
+    db_session.add(post)
+    db_session.commit()
+
+    login(client, test_user.username, "secret")
+    client.post(f"/like/{post.id}", data={"reaction": "🔥"})
+    client.post(f"/like/{post.id}", data={"reaction": "😂"})
+
+    db_session.refresh(post)
+    reaction = PostReaction.query.filter_by(
+        user_id=test_user.id, post_id=post.id
+    ).first()
+    assert reaction.reaction_type == "😂"
+    assert post.likes == 1
+
+
+def test_remove_reaction(client, db_session, test_user, another_user):
+    post = Post(content="bye", author=another_user)
+    db_session.add(post)
+    db_session.commit()
+
+    login(client, test_user.username, "secret")
+    client.post(f"/like/{post.id}", data={"reaction": "🔥"})
+    resp = client.post(f"/like/{post.id}", data={"reaction": "🔥"})
+    assert resp.get_json()["likes"] == 0
+    db_session.refresh(post)
+    assert PostReaction.query.count() == 0
+    assert post.likes == 0


### PR DESCRIPTION
## Summary
- extend `reaction_type` column length and expose count helpers
- show counts per emoji and allow mobile-friendly reaction menu
- update post card, detail and trending views with new reaction container
- style reaction counts and button
- document work in AGENTS.md

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685ca12a170c8325a7b75fa450041bb4