### PR TITLE
Hide feed filters on mobile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,3 +292,4 @@
 - Comentarios ahora se abren en un modal con la publicación centrada y las reacciones ordenadas; se eliminó el ícono de corazón (PR reactions-modal-update).
 - Manejo de IntegrityError en like_post para evitar fallas de logs por duplicados.
 - Corregido template de reacciones convirtiendo sorted_counts a lista para evitar UndefinedError (PR reaction-container-fix).
+- Filtros rápidos ocultos en móviles (<=768px) y disponibles solo en el menú flotante azul (PR feed-mobile-filters-hide).

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -66,3 +66,9 @@
   font-size: 0.875rem;
   color: #6c757d;
 }
+
+@media (max-width: 768px) {
+  #feed-filtros-principales {
+    display: none !important;
+  }
+}

--- a/crunevo/templates/feed/index.html
+++ b/crunevo/templates/feed/index.html
@@ -19,7 +19,7 @@
         <span class="text-muted">¿Qué deseas compartir?</span>
       </div>
     </div>
-    <div class="d-lg-none mb-3">
+    <div id="feed-filtros-principales" class="d-lg-none mb-3">
       {% include 'components/feed_sidebar.html' %}
     </div>
     <div id="feed" class="tw-space-y-4" data-categoria="{{ categoria or '' }}">


### PR DESCRIPTION
## Summary
- hide filters from the main feed on screens up to 768px
- log change in AGENTS history

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685cc410dc0483259f2773b8f91d2609