### PR TITLE
Feed reactions UI polish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,3 +293,5 @@
 - Manejo de IntegrityError en like_post para evitar fallas de logs por duplicados.
 - Corregido template de reacciones convirtiendo sorted_counts a lista para evitar UndefinedError (PR reaction-container-fix).
 - Filtros rápidos ocultos en móviles (<=768px) y disponibles solo en el menú flotante azul (PR feed-mobile-filters-hide).
+- Reacciones muestran el emoji seleccionado de inmediato y panel accesible con pulsación prolongada; campo "Escribe un comentario..." abre el modal y evita el ícono previo (PR feed-reactions-final-touch).
+- Feedback instantáneo al reaccionar: la interfaz actualiza al instante y revierte si falla la petición (PR feed-reactions-ux-instant-feedback).

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -45,6 +45,9 @@
   left: 0;
   display: flex;
   gap: 6px;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  max-width: 100%;
 }
 
 .reaction-btn {
@@ -59,6 +62,10 @@
   border-radius: 20px;
   padding: 6px 10px;
   border: 1px solid #ccc;
+}
+.reaction-active {
+  transform: scale(1.2);
+  transition: transform 0.2s;
 }
 
 .reaction-counts {

--- a/crunevo/templates/components/reactions.html
+++ b/crunevo/templates/components/reactions.html
@@ -2,7 +2,7 @@
 {% set sorted_counts = counts|dictsort(false, 'value')|reverse|list if counts else [] %}
 {% set main = sorted_counts[0][0] if sorted_counts else '🔥' %}
 <div class="reaction-container position-relative d-inline-block" data-post-id="{{ post.id }}">
-  <button class="btn btn-reaction" onclick="showReactions(this)">
+  <button class="btn btn-reaction">
     <span class="main-emoji">{{ main }}</span> <span class="count">{{ post.likes or 0 }}</span>
   </button>
   <div class="reaction-options d-none position-absolute">

--- a/crunevo/templates/feed/post_card.html
+++ b/crunevo/templates/feed/post_card.html
@@ -39,11 +39,9 @@
         <img loading="lazy" src="{{ post.file_url }}" class="feed-image img-fluid rounded mt-2" style="max-height: 400px; width: auto;" alt="imagen">
       {% endif %}
     {% endif %}
-    <div class="d-flex justify-content-between align-items-center gap-2 mb-2">
+    <div class="d-flex align-items-center gap-2 mb-2">
       {{ react.reaction_container(post, counts) }}
-      <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#postModal{{ post.id }}">
-        <i class="bi bi-chat-dots"></i>
-      </button>
+      <input type="text" class="form-control form-control-sm" placeholder="Escribe un comentario..." readonly data-bs-toggle="modal" data-bs-target="#postModal{{ post.id }}">
     </div>
   </div>
 </article>


### PR DESCRIPTION
## Summary
- enable horizontal scroll for reaction options and add quick animation
- update reaction JS for long press options and instant feedback
- replace comment icon with read-only input that opens modal
- track latest modifications in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685cc8a2c7f083259be53eba7d735ce9