### PR TITLE
Fix reaction toggle and mobile layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,3 +295,6 @@
 - Filtros rápidos ocultos en móviles (<=768px) y disponibles solo en el menú flotante azul (PR feed-mobile-filters-hide).
 - Reacciones muestran el emoji seleccionado de inmediato y panel accesible con pulsación prolongada; campo "Escribe un comentario..." abre el modal y evita el ícono previo (PR feed-reactions-final-touch).
 - Feedback instantáneo al reaccionar: la interfaz actualiza al instante y revierte si falla la petición (PR feed-reactions-ux-instant-feedback).
+- Sistema de reacciones final ajustado: un clic agrega o quita, conteo correcto y botón sin estilo visible (PR reaction-toggle-final).
+- Reacciones mejoradas: panel 4x2 en móvil, estado del usuario en data-my-reaction y actualización instantánea con reversión (PR reactions-toggle-ux).
+- Se evitó que el scroll dispare reacciones; el panel siempre muestra las 8 opciones y se puede volver a abrir sin bloqueos (PR reactions-touch-fix).

--- a/crunevo/models/post_reaction.py
+++ b/crunevo/models/post_reaction.py
@@ -33,3 +33,15 @@ class PostReaction(db.Model):
     @staticmethod
     def count_for_post(post_id):
         return PostReaction.counts_for_posts([post_id]).get(post_id, {})
+
+    @staticmethod
+    def reactions_for_user_posts(user_id, post_ids):
+        if not post_ids:
+            return {}
+        rows = (
+            db.session.query(PostReaction.post_id, PostReaction.reaction_type)
+            .filter(PostReaction.user_id == user_id)
+            .filter(PostReaction.post_id.in_(post_ids))
+            .all()
+        )
+        return {pid: rt for pid, rt in rows}

--- a/crunevo/routes/feed_routes.py
+++ b/crunevo/routes/feed_routes.py
@@ -184,11 +184,13 @@ def edu_feed():
             post_ids.append(post.id)
 
     reaction_map = PostReaction.counts_for_posts(post_ids)
+    user_reactions = PostReaction.reactions_for_user_posts(current_user.id, post_ids)
 
     return render_template(
         "feed/list.html",
         feed_items=feed_items,
         reaction_counts=reaction_map,
+        user_reactions=user_reactions,
         note_form=note_form,
         image_form=image_form,
     )
@@ -257,12 +259,14 @@ def view_feed():
                 feed_items.append({"type": "note", "data": note})
 
     reaction_map = PostReaction.counts_for_posts(post_ids)
+    user_reactions = PostReaction.reactions_for_user_posts(current_user.id, post_ids)
 
     return render_template(
         "feed/index.html",
         feed_items=feed_items,
         categoria=categoria,
         reaction_counts=reaction_map,
+        user_reactions=user_reactions,
     )
 
 
@@ -283,6 +287,9 @@ def trending():
     top_notes, top_posts, top_users = get_featured_posts()
 
     reaction_map = PostReaction.counts_for_posts([p.id for p in weekly_posts])
+    user_reactions = PostReaction.reactions_for_user_posts(
+        current_user.id, [p.id for p in weekly_posts]
+    )
 
     return render_template(
         "feed/trending.html",
@@ -293,6 +300,7 @@ def trending():
         top_posts=top_posts,
         top_users=top_users,
         reaction_counts=reaction_map,
+        user_reactions=user_reactions,
     )
 
 
@@ -302,7 +310,17 @@ def view_post(post_id: int):
     """Display a single post."""
     post = Post.query.get_or_404(post_id)
     counts = PostReaction.count_for_post(post.id)
-    return render_template("feed/post_detail.html", post=post, reaction_counts=counts)
+    my_reaction = (
+        PostReaction.query.with_entities(PostReaction.reaction_type)
+        .filter_by(user_id=current_user.id, post_id=post.id)
+        .scalar()
+    )
+    return render_template(
+        "feed/post_detail.html",
+        post=post,
+        reaction_counts=counts,
+        user_reaction=my_reaction,
+    )
 
 
 @feed_bp.route("/user/<int:user_id>/posts")
@@ -318,12 +336,16 @@ def user_posts(user_id: int):
     )
     posts = pagination.items
     reaction_map = PostReaction.counts_for_posts([p.id for p in posts])
+    user_reactions = PostReaction.reactions_for_user_posts(
+        current_user.id, [p.id for p in posts]
+    )
     return render_template(
         "feed/user_posts.html",
         user=user,
         posts=posts,
         pagination=pagination,
         reaction_counts=reaction_map,
+        user_reactions=user_reactions,
     )
 
 

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -39,14 +39,13 @@
   background: white;
   border-radius: 12px;
   padding: 6px;
-  box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
   z-index: 100;
   top: -60px;
   left: 0;
-  display: flex;
-  gap: 6px;
-  flex-wrap: nowrap;
-  overflow-x: auto;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 4px;
   max-width: 100%;
 }
 
@@ -57,11 +56,18 @@
   cursor: pointer;
 }
 
+@media (max-width: 576px) {
+  .reaction-btn {
+    font-size: 20px;
+  }
+}
+
 .btn-reaction {
-  background-color: #f9f9f9;
-  border-radius: 20px;
-  padding: 6px 10px;
-  border: 1px solid #ccc;
+  background: none;
+  border: none;
+  font-size: 24px;
+  box-shadow: none;
+  padding: 0;
 }
 .reaction-active {
   transform: scale(1.2);

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -46,13 +46,31 @@ function initReactions() {
     const span = container.querySelector('.count');
     const countsDiv = container.querySelector('.reaction-counts');
     const postId = container.dataset.postId;
+    let currentReaction = container.dataset.myReaction || null;
+
+    let isSending = false;
 
     function sendReaction(reaction) {
+      if (isSending) return;
+      isSending = true;
       const mainEmoji = container.querySelector('.main-emoji');
       const prevEmoji = mainEmoji ? mainEmoji.textContent : '🔥';
       const prevLikes = span ? parseInt(span.textContent) || 0 : 0;
+
+      const prevReaction = currentReaction;
+      let predictedLikes = prevLikes;
+      if (currentReaction === reaction) {
+        predictedLikes = Math.max(prevLikes - 1, 0);
+        currentReaction = null;
+      } else if (currentReaction === null) {
+        predictedLikes = prevLikes + 1;
+        currentReaction = reaction;
+      } else {
+        currentReaction = reaction;
+      }
+
+      if (span) span.textContent = predictedLikes;
       if (mainEmoji) mainEmoji.textContent = reaction;
-      if (span) span.textContent = prevLikes + 1;
       mainBtn.classList.add('reaction-active');
       setTimeout(() => mainBtn.classList.remove('reaction-active'), 200);
 
@@ -69,18 +87,30 @@ function initReactions() {
           if (mainEmoji) {
             mainEmoji.textContent = entries.length ? entries[0][0] : '🔥';
           }
+          if (d.status === 'removed') {
+            currentReaction = null;
+          } else {
+            currentReaction = reaction;
+          }
+          container.dataset.myReaction = currentReaction || '';
         })
         .catch(() => {
           if (mainEmoji) mainEmoji.textContent = prevEmoji;
           if (span) span.textContent = prevLikes;
           showToast('No se pudo registrar tu reacción. Intenta nuevamente.');
+          currentReaction = prevReaction;
+        })
+        .finally(() => {
+          isSending = false;
         });
     }
 
     let pressTimer;
     let longPress = false;
+    let moved = false;
 
     function startPress() {
+      moved = false;
       longPress = false;
       pressTimer = setTimeout(() => {
         longPress = true;
@@ -88,16 +118,22 @@ function initReactions() {
       }, 600);
     }
 
+    function movePress() {
+      moved = true;
+      clearTimeout(pressTimer);
+    }
+
     function endPress() {
       clearTimeout(pressTimer);
-      if (!longPress) {
+      if (!longPress && !moved) {
         const emoji = container.querySelector('.main-emoji');
         sendReaction(emoji ? emoji.textContent.trim() : '🔥');
       }
     }
 
     mainBtn.addEventListener('mousedown', startPress);
-    mainBtn.addEventListener('touchstart', startPress);
+    mainBtn.addEventListener('touchstart', startPress, { passive: true });
+    mainBtn.addEventListener('touchmove', movePress);
     ['mouseup', 'mouseleave', 'touchend', 'touchcancel'].forEach((ev) => {
       mainBtn.addEventListener(ev, endPress);
     });

--- a/crunevo/templates/components/reactions.html
+++ b/crunevo/templates/components/reactions.html
@@ -1,7 +1,7 @@
-{% macro reaction_container(post, counts=None) %}
+{% macro reaction_container(post, counts=None, my=None) %}
 {% set sorted_counts = counts|dictsort(false, 'value')|reverse|list if counts else [] %}
 {% set main = sorted_counts[0][0] if sorted_counts else '🔥' %}
-<div class="reaction-container position-relative d-inline-block" data-post-id="{{ post.id }}">
+<div class="reaction-container position-relative d-inline-block" data-post-id="{{ post.id }}" data-my-reaction="{{ my or '' }}">
   <button class="btn btn-reaction">
     <span class="main-emoji">{{ main }}</span> <span class="count">{{ post.likes or 0 }}</span>
   </button>

--- a/crunevo/templates/feed/index.html
+++ b/crunevo/templates/feed/index.html
@@ -30,6 +30,7 @@
         {% elif item.type == 'post' %}
           {% set post = item.data %}
           {% set counts = reaction_counts.get(post.id, {}) %}
+          {% set my_reaction = user_reactions.get(post.id) %}
           {% include 'feed/post_card.html' %}
         {% endif %}
       {% endfor %}

--- a/crunevo/templates/feed/list.html
+++ b/crunevo/templates/feed/list.html
@@ -30,6 +30,7 @@
         {% elif item.type == 'post' %}
           {% set post = item.data %}
           {% set counts = reaction_counts.get(post.id, {}) %}
+          {% set my_reaction = user_reactions.get(post.id) %}
           {% include 'feed/post_card.html' %}
         {% endif %}
       {% endfor %}

--- a/crunevo/templates/feed/post_card.html
+++ b/crunevo/templates/feed/post_card.html
@@ -40,7 +40,7 @@
       {% endif %}
     {% endif %}
     <div class="d-flex align-items-center gap-2 mb-2">
-      {{ react.reaction_container(post, counts) }}
+      {{ react.reaction_container(post, counts, my_reaction) }}
       <input type="text" class="form-control form-control-sm" placeholder="Escribe un comentario..." readonly data-bs-toggle="modal" data-bs-target="#postModal{{ post.id }}">
     </div>
   </div>
@@ -111,7 +111,7 @@
           <img loading="lazy" src="{{ post.file_url }}" class="img-fluid rounded mb-2" alt="imagen">
           {% endif %}
         {% endif %}
-        {{ react.reaction_container(post, counts) }}
+        {{ react.reaction_container(post, counts, my_reaction) }}
         <h6 class="mt-3 mb-2">Comentarios</h6>
         <div id="modalComments{{ post.id }}" class="mb-2" style="max-height:300px; overflow-y:auto;">
           {% if post.comments %}

--- a/crunevo/templates/feed/post_detail.html
+++ b/crunevo/templates/feed/post_detail.html
@@ -26,7 +26,7 @@
         {% endif %}
       {% endif %}
       {% set counts = reaction_counts %}
-      {{ react.reaction_container(post, counts) }}
+      {{ react.reaction_container(post, counts, user_reaction) }}
 
       <div class="d-flex gap-2 my-3">
         <button type="button" class="btn btn-outline-secondary btn-sm share-btn" data-share-url="{{ url_for('feed.view_post', post_id=post.id, _external=True) }}">

--- a/crunevo/templates/feed/trending.html
+++ b/crunevo/templates/feed/trending.html
@@ -42,11 +42,12 @@
           {% endif %}
         {% endif %}
         {% set counts = reaction_counts.get(post.id, {}) %}
+        {% set my_reaction = user_reactions.get(post.id) %}
         {% if author %}
         <a href="{{ url_for('auth.profile_by_username', username=author.username) }}" class="btn btn-sm btn-outline-info mb-2">Ver perfil</a>
         <a href="{{ url_for('feed.view_post', post_id=post.id) }}" class="btn btn-sm btn-outline-primary mb-2">Ver publicación</a>
         {% endif %}
-        {{ react.reaction_container(post, counts) }}
+        {{ react.reaction_container(post, counts, my_reaction) }}
       </div>
     </div>
     {% endfor %}

--- a/crunevo/templates/feed/user_posts.html
+++ b/crunevo/templates/feed/user_posts.html
@@ -10,6 +10,7 @@
   {% for post in posts %}
   <div class="col">
     {% set counts = reaction_counts.get(post.id, {}) %}
+    {% set my_reaction = user_reactions.get(post.id) %}
     {% include 'feed/post_card.html' %}
   </div>
   {% else %}


### PR DESCRIPTION
## Summary
- show all reaction emojis on mobile in a grid without scrolling
- prevent scroll from triggering accidental reactions
- keep reaction button active so users can change reactions
- document fixes in AGENTS notes

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685ccd740b8c83259bb212c17252bd42