### PR TITLE
mobile-longpress-reactions-fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,3 +299,4 @@
 - Reacciones mejoradas: panel 4x2 en móvil, estado del usuario en data-my-reaction y actualización instantánea con reversión (PR reactions-toggle-ux).
 - Se evitó que el scroll dispare reacciones; el panel siempre muestra las 8 opciones y se puede volver a abrir sin bloqueos (PR reactions-touch-fix).
 - Se ignora el movimiento del cursor o la rueda para evitar reacciones accidentales (PR reaction-scroll-fix).
+- Long press fix for mobile reactions: preventDefault en touchstart y umbral de movimiento para mostrar panel correctamente (PR mobile-longpress-reactions-fix).

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -109,21 +109,32 @@ function initReactions() {
     let longPress = false;
     let moved = false;
     let pressing = false;
+    let startX = 0;
+    let startY = 0;
 
-    function startPress() {
+    function startPress(e) {
+      e.preventDefault();
       moved = false;
       longPress = false;
       pressing = true;
+      const t = e.touches ? e.touches[0] : e;
+      startX = t.clientX;
+      startY = t.clientY;
       pressTimer = setTimeout(() => {
         longPress = true;
         showReactions(mainBtn);
       }, 600);
     }
 
-    function movePress() {
+    function movePress(e) {
       if (!pressing) return;
-      moved = true;
-      clearTimeout(pressTimer);
+      const t = e.touches ? e.touches[0] : e;
+      const dx = Math.abs(t.clientX - startX);
+      const dy = Math.abs(t.clientY - startY);
+      if (dx > 10 || dy > 10) {
+        moved = true;
+        clearTimeout(pressTimer);
+      }
     }
 
     function endPress() {
@@ -137,13 +148,15 @@ function initReactions() {
     }
 
     mainBtn.addEventListener('mousedown', startPress);
-    mainBtn.addEventListener('touchstart', startPress, { passive: true });
+    mainBtn.addEventListener('touchstart', startPress, { passive: false });
     mainBtn.addEventListener('touchmove', movePress);
     mainBtn.addEventListener('mousemove', movePress);
     mainBtn.addEventListener('wheel', movePress);
-    ['mouseup', 'mouseleave', 'touchend', 'touchcancel'].forEach((ev) => {
+    ['mouseup', 'mouseleave'].forEach((ev) => {
       mainBtn.addEventListener(ev, endPress);
     });
+    mainBtn.addEventListener('touchend', endPress);
+    mainBtn.addEventListener('touchcancel', endPress);
 
     container.querySelectorAll('.reaction-btn').forEach((btn) => {
       btn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- tweak long press handling for reaction buttons on mobile
- document change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685ce01e3e3c8325905faed9e1d0b81a