### PR TITLE
Fix notification dropdown color

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,3 +305,4 @@
 
 - Se documenta la hoja de ruta "Mejoras Fase 2": comentarios avanzados, transferencias de créditos, notificaciones ampliadas, logros y ranking, pulido móvil y pruebas de usabilidad.
 - Corregido icono de campana en lista de notificaciones usando emoji real para evitar UnicodeEncodeError (hotfix notifications-emoji).
+- Ajustado fondo del dropdown de notificaciones a colores neutros con modo oscuro y botón 'Marcar todo como leído' con estilo btn-outline-secondary. Se añadió flecha decorativa (PR notifications-bg-fix).

--- a/crunevo/static/css/navbar.css
+++ b/crunevo/static/css/navbar.css
@@ -24,17 +24,17 @@
 }
 
 
-.navbar-crunevo .dropdown-menu {
+.navbar-crunevo .dropdown-menu:not(.notification-menu) {
   background-color: var(--primary);
   color: #fff;
 }
-.navbar-crunevo .dropdown-menu .dropdown-item {
+.navbar-crunevo .dropdown-menu:not(.notification-menu) .dropdown-item {
   color: #fff;
 }
-.navbar-crunevo .dropdown-menu .dropdown-divider {
+.navbar-crunevo .dropdown-menu:not(.notification-menu) .dropdown-divider {
   border-color: rgba(255, 255, 255, 0.2);
 }
-.navbar-crunevo .dropdown-menu .dropdown-item:hover {
+.navbar-crunevo .dropdown-menu:not(.notification-menu) .dropdown-item:hover {
   background-color: rgba(255, 255, 255, 0.1);
 }
 

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -179,8 +179,30 @@ html {
 
 /* Notification dropdown */
 .notification-menu {
+  position: relative;
   border-radius: 0.5rem;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  background-color: #f9f9f9;
+  color: #000;
+}
+
+body[data-bs-theme='dark'] .notification-menu {
+  background-color: #1e1e1e;
+  color: #fff;
+}
+
+.notification-menu::before {
+  content: "";
+  position: absolute;
+  top: -6px;
+  right: 1.5rem;
+  border-width: 0 6px 6px 6px;
+  border-style: solid;
+  border-color: transparent transparent #f9f9f9 transparent;
+}
+
+body[data-bs-theme='dark'] .notification-menu::before {
+  border-color: transparent transparent #1e1e1e transparent;
 }
 .notification-menu .noti-item.unread {
   background-color: #f0f4ff;

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -31,7 +31,7 @@
           <ul class="dropdown-menu dropdown-menu-end notification-menu" aria-labelledby="notifDropdown" style="min-width:20rem;">
             <li class="px-3 py-2 border-bottom d-flex justify-content-between align-items-center">
               <span class="fw-semibold">Notificaciones</span>
-              <a id="markAllRead" class="small" href="#">Marcar todo como leído</a>
+              <a id="markAllRead" class="btn btn-sm btn-outline-secondary" href="#">Marcar todo como leído</a>
             </li>
             <div id="notifList" class="list-unstyled mb-0" style="max-height:300px;overflow-y:auto;">
               {% for n in current_user.notifications.order_by(Notification.timestamp.desc()).limit(5) %}


### PR DESCRIPTION
## Summary
- restyle notification dropdown with neutral background in light/dark mode
- keep other dropdowns purple
- make "Marcar todo como leído" a clear outline button
- document change in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685cea99008c8325bb8fa0d460a463c0