### PR TITLE
Implement feed UI enhancements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -306,3 +306,6 @@
 - Se documenta la hoja de ruta "Mejoras Fase 2": comentarios avanzados, transferencias de créditos, notificaciones ampliadas, logros y ranking, pulido móvil y pruebas de usabilidad.
 - Corregido icono de campana en lista de notificaciones usando emoji real para evitar UnicodeEncodeError (hotfix notifications-emoji).
 - Ajustado fondo del dropdown de notificaciones a colores neutros con modo oscuro y botón 'Marcar todo como leído' con estilo btn-outline-secondary. Se añadió flecha decorativa (PR notifications-bg-fix).
+- Añadida animación pop a los botones de reacciones y en cada emoji del panel (PR reactions-anim-pop).
+- Vista previa de imagen muestra spinner de subida en el modal de publicación (PR feed-upload-spinner).
+- Filtros rápidos rediseñados como badges con scroll horizontal en móviles (PR feed-quickfilters-redesign).

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -54,6 +54,7 @@
   background: transparent;
   font-size: 24px;
   cursor: pointer;
+  transition: transform 0.2s;
 }
 
 @media (max-width: 576px) {

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -161,6 +161,8 @@ function initReactions() {
     container.querySelectorAll('.reaction-btn').forEach((btn) => {
       btn.addEventListener('click', () => {
         const reaction = btn.dataset.reaction;
+        btn.classList.add('reaction-active');
+        setTimeout(() => btn.classList.remove('reaction-active'), 200);
         sendReaction(reaction);
         if (options) options.classList.add('d-none');
       });
@@ -390,11 +392,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const postForm = document.getElementById('postForm');
   const postBtn = document.getElementById('postSubmitBtn');
+  const uploadSpinner = document.getElementById('uploadSpinner');
   if (postForm && postBtn) {
     postForm.addEventListener('submit', () => {
       postBtn.disabled = true;
       postBtn.innerHTML =
         '<span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>Publicando...';
+      if (uploadSpinner) {
+        uploadSpinner.classList.remove('tw-hidden');
+      }
     });
   }
 

--- a/crunevo/templates/components/feed_sidebar.html
+++ b/crunevo/templates/components/feed_sidebar.html
@@ -1,33 +1,33 @@
 <div class="card shadow-sm border-0 mb-4 sidebar">
   <div class="card-body">
     <h6 class="text-uppercase text-muted mb-3 d-none d-md-block">Filtros rápidos</h6>
-    <div id="quickFilters" class="btn-group btn-group-sm d-flex flex-wrap" role="group">
-      <button type="button" class="btn btn-primary active" data-filter="recientes">
+    <div id="quickFilters" class="d-flex gap-2 flex-nowrap overflow-x-auto py-1">
+      <button type="button" class="btn btn-outline-primary btn-sm active" data-filter="recientes">
         <i class="bi bi-clock"></i>
         <span class="d-none d-md-inline"> Recientes</span>
         <span class="badge bg-light text-dark ms-1 count tw-hidden"></span>
       </button>
-      <button type="button" class="btn btn-outline-primary" data-filter="populares">
+      <button type="button" class="btn btn-outline-primary btn-sm" data-filter="populares">
         <i class="bi bi-fire"></i>
         <span class="d-none d-md-inline"> Populares</span>
         <span class="badge bg-light text-dark ms-1 count tw-hidden"></span>
       </button>
-      <button type="button" class="btn btn-outline-primary" data-filter="relevantes">
+      <button type="button" class="btn btn-outline-primary btn-sm" data-filter="relevantes">
         <i class="bi bi-pin"></i>
         <span class="d-none d-md-inline"> Relevantes</span>
         <span class="badge bg-light text-dark ms-1 count tw-hidden"></span>
       </button>
-      <button type="button" class="btn btn-outline-primary" data-filter="apuntes">
+      <button type="button" class="btn btn-outline-primary btn-sm" data-filter="apuntes">
         <i class="bi bi-journal-text"></i>
         <span class="d-none d-md-inline"> Apuntes</span>
         <span class="badge bg-light text-dark ms-1 count tw-hidden"></span>
       </button>
-      <button type="button" class="btn btn-outline-primary" data-filter="publicaciones">
+      <button type="button" class="btn btn-outline-primary btn-sm" data-filter="publicaciones">
         <i class="bi bi-chat"></i>
         <span class="d-none d-md-inline"> Publicaciones</span>
         <span class="badge bg-light text-dark ms-1 count tw-hidden"></span>
       </button>
-</div>
+    </div>
 </div>
 <div class="card shadow-sm border-0 mb-4">
   <div class="card-body">

--- a/crunevo/templates/feed/index.html
+++ b/crunevo/templates/feed/index.html
@@ -87,6 +87,9 @@
               </button>
             </div>
             <div id="previewContainer" class="mt-2"></div>
+            <div id="uploadSpinner" class="text-center my-2 tw-hidden">
+              <div class="spinner-border" role="status"></div>
+            </div>
           </div>
           <div class="modal-footer">
             <button id="postSubmitBtn" class="btn btn-primary" type="submit">Publicar</button>

--- a/crunevo/templates/feed/list.html
+++ b/crunevo/templates/feed/list.html
@@ -73,6 +73,9 @@
               </button>
             </div>
             <div id="previewContainer" class="mt-2"></div>
+            <div id="uploadSpinner" class="text-center my-2 tw-hidden">
+              <div class="spinner-border" role="status"></div>
+            </div>
           </div>
           <div class="modal-footer">
             <button id="postSubmitBtn" class="btn btn-primary" type="submit">Publicar</button>

--- a/crunevo/templates/feed/trending.html
+++ b/crunevo/templates/feed/trending.html
@@ -142,6 +142,9 @@
               </button>
             </div>
             <div id="previewContainer" class="mt-2"></div>
+            <div id="uploadSpinner" class="text-center my-2 tw-hidden">
+              <div class="spinner-border" role="status"></div>
+            </div>
           </div>
           <div class="modal-footer">
             <button id="postSubmitBtn" class="btn btn-primary" type="submit">Publicar</button>


### PR DESCRIPTION
## Summary
- animate reaction options with a pop effect
- show spinner while uploading images in post modal
- redesign quick filters as scrollable badges
- document changes in AGENTS guide

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685cecd84e9c8325a02876fd72552df3