### PR TITLE
Implement login streak rewards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,3 +309,4 @@
 - Añadida animación pop a los botones de reacciones y en cada emoji del panel (PR reactions-anim-pop).
 - Vista previa de imagen muestra spinner de subida en el modal de publicación (PR feed-upload-spinner).
 - Filtros rápidos rediseñados como badges con scroll horizontal en móviles (PR feed-quickfilters-redesign).
+- Sistema de rachas de inicio de sesión que otorga créditos crecientes cada día (PR login-streak-rewards).

--- a/crunevo/constants/credit_reasons.py
+++ b/crunevo/constants/credit_reasons.py
@@ -5,3 +5,4 @@ class CreditReasons:
     AGRADECIMIENTO = "agradecimiento"
     VOTO_POSITIVO = "voto_positivo"
     DONACION_FEED = "donación_feed"
+    RACHA_LOGIN = "racha_login"

--- a/crunevo/models/__init__.py
+++ b/crunevo/models/__init__.py
@@ -10,6 +10,7 @@ from .credit import Credit  # noqa: F401
 from .ranking import RankingCache  # noqa: F401
 from .achievement import Achievement, UserAchievement  # noqa: F401
 from .login_history import LoginHistory  # noqa: F401
+from .login_streak import LoginStreak  # noqa: F401
 from .note_vote import NoteVote  # noqa: F401
 from .feed_item import FeedItem  # noqa: F401
 from .email_token import EmailToken  # noqa: F401

--- a/crunevo/models/login_streak.py
+++ b/crunevo/models/login_streak.py
@@ -1,0 +1,10 @@
+from crunevo.extensions import db
+
+
+class LoginStreak(db.Model):
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), primary_key=True)
+    current_day = db.Column(db.Integer, nullable=False, default=0)
+    last_login = db.Column(db.Date)
+    streak_start = db.Column(db.Date)
+
+    user = db.relationship("User", backref=db.backref("login_streak", uselist=False))

--- a/crunevo/routes/auth_routes.py
+++ b/crunevo/routes/auth_routes.py
@@ -53,7 +53,11 @@ def login():
                 login_user(user)
                 return redirect(url_for("onboarding.pending"))
             login_user(user)
-            record_login(user)
+            day, credits = record_login(user)
+            if credits:
+                flash(
+                    f"\ud83c\udf89 D\u00eda {day} de tu racha activa: has ganado {credits} cr\u00e9ditos."
+                )
             if admin_mode:
                 return redirect(url_for("admin.dashboard"))
             next_page = request.args.get("next")

--- a/crunevo/utils/__init__.py
+++ b/crunevo/utils/__init__.py
@@ -2,5 +2,6 @@ from .helpers import admin_required  # noqa: F401
 from .credits import add_credit, spend_credit  # noqa: F401
 from .achievements import unlock_achievement  # noqa: F401
 from .login_history import record_login  # noqa: F401
+from .login_streak import handle_login_streak  # noqa: F401
 from .feed import create_feed_item_for_all  # noqa: F401
 from .notify import send_notification  # noqa: F401

--- a/crunevo/utils/login_history.py
+++ b/crunevo/utils/login_history.py
@@ -3,10 +3,14 @@ from crunevo.models import LoginHistory
 from crunevo.extensions import db
 from crunevo.utils.achievements import unlock_achievement
 from crunevo.constants import AchievementCodes
+from .login_streak import handle_login_streak
 
 
 def record_login(user, login_date=None):
-    """Store a login date and unlock the 7-day streak achievement."""
+    """Store a login date, update streak and unlock achievement.
+
+    Returns the current streak day and credits awarded.
+    """
     if login_date is None:
         login_date = date.today()
 
@@ -17,6 +21,9 @@ def record_login(user, login_date=None):
         entry = LoginHistory(user_id=user.id, login_date=login_date)
         db.session.add(entry)
         db.session.commit()
+        day, credits = handle_login_streak(user, login_date)
+    else:
+        day, credits = handle_login_streak(user, login_date)
 
     last_entries = (
         LoginHistory.query.filter_by(user_id=user.id)
@@ -24,13 +31,14 @@ def record_login(user, login_date=None):
         .limit(7)
         .all()
     )
-    if len(last_entries) < 7:
-        return
 
-    expected = login_date
-    for item in last_entries:
-        if item.login_date != expected:
-            return
-        expected -= timedelta(days=1)
+    if len(last_entries) >= 7:
+        expected = login_date
+        for item in last_entries:
+            if item.login_date != expected:
+                break
+            expected -= timedelta(days=1)
+        else:
+            unlock_achievement(user, AchievementCodes.CONECTADO_7D)
 
-    unlock_achievement(user, AchievementCodes.CONECTADO_7D)
+    return day, credits

--- a/crunevo/utils/login_streak.py
+++ b/crunevo/utils/login_streak.py
@@ -1,0 +1,55 @@
+from datetime import date, timedelta
+from crunevo.extensions import db
+from crunevo.models import LoginStreak
+from crunevo.constants import CreditReasons
+from .credits import add_credit
+
+STREAK_REWARDS = {
+    1: 2,
+    2: 3,
+    3: 4,
+    4: 5,
+    5: 6,
+    6: 7,
+    7: 10,
+}
+
+
+def handle_login_streak(user, login_date=None):
+    """Update or create streak, award credits and return (day, credits)."""
+    if login_date is None:
+        login_date = date.today()
+
+    streak = LoginStreak.query.filter_by(user_id=user.id).first()
+    if not streak:
+        streak = LoginStreak(
+            user_id=user.id,
+            current_day=1,
+            last_login=login_date,
+            streak_start=login_date,
+        )
+        db.session.add(streak)
+        db.session.commit()
+        credits = STREAK_REWARDS[1]
+        add_credit(user, credits, CreditReasons.RACHA_LOGIN)
+        return 1, credits
+
+    if streak.last_login == login_date:
+        return streak.current_day, 0
+
+    yesterday = login_date - timedelta(days=1)
+    if streak.last_login == yesterday:
+        streak.current_day += 1
+    else:
+        streak.current_day = 1
+        streak.streak_start = login_date
+
+    if streak.current_day > 7:
+        streak.current_day = 1
+        streak.streak_start = login_date
+
+    streak.last_login = login_date
+    db.session.commit()
+    credits = STREAK_REWARDS[streak.current_day]
+    add_credit(user, credits, CreditReasons.RACHA_LOGIN)
+    return streak.current_day, credits

--- a/migrations/versions/018c30955e14_add_login_streaks.py
+++ b/migrations/versions/018c30955e14_add_login_streaks.py
@@ -1,0 +1,29 @@
+"""add login streaks table
+
+Revision ID: 018c30955e14
+Revises: 81c3610645b1
+Create Date: 2025-07-05 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "018c30955e14"
+down_revision = "81c3610645b1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "login_streak",
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("user.id"), primary_key=True),
+        sa.Column("current_day", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("last_login", sa.Date(), nullable=True),
+        sa.Column("streak_start", sa.Date(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_table("login_streak")

--- a/tests/test_login_streak.py
+++ b/tests/test_login_streak.py
@@ -1,0 +1,19 @@
+from datetime import date, timedelta
+from crunevo.utils.login_history import record_login
+from crunevo.constants import CreditReasons
+
+
+def test_streak_awards_credits(db_session, test_user):
+    day, credits = record_login(test_user, date.today())
+    assert day == 1
+    assert credits == 2
+    assert test_user.credits == 2
+    assert test_user.credit_history[-1].reason == CreditReasons.RACHA_LOGIN
+
+
+def test_streak_resets_after_break(db_session, test_user):
+    start = date.today() - timedelta(days=2)
+    record_login(test_user, start)
+    record_login(test_user, start + timedelta(days=1))
+    record_login(test_user, start + timedelta(days=3))
+    assert test_user.login_streak.current_day == 1


### PR DESCRIPTION
## Summary
- add `RACHA_LOGIN` to `CreditReasons`
- create `LoginStreak` model and migration
- reward users in `record_login` using `handle_login_streak`
- show login streak toast on successful login
- unit tests for streak logic
- document change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685cf61217708325950745e49f919c66