### PR TITLE
Implement mission claim route

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -312,3 +312,5 @@
 - Sistema de rachas de inicio de sesión que otorga créditos crecientes cada día (PR login-streak-rewards).
 - Recompensa de racha ahora se reclama manualmente con /api/reclamar-racha y widget flotante en el feed (PR login-streak-claim).
 - Página /crolars con explicación de la moneda y enlaces desde navbar y footer (PR crolars-info-page).
+- Perfil muestra misiones con progreso, estado y botón para reclamar créditos manualmente (PR missions-claim-ui).
+- Ruta /misiones/reclamar_mision permite reclamar créditos por misión (PR mission-reclaim-route).

--- a/crunevo/routes/auth_routes.py
+++ b/crunevo/routes/auth_routes.py
@@ -113,11 +113,14 @@ def perfil():
             if ACHIEVEMENT_CATEGORIES.get(a.badge_code) == ach_type
         ]
 
-    missions = None
+    misiones = None
+    progresos = None
     if tab == "misiones":
         from crunevo.routes.missions_routes import compute_mission_states
+        from crunevo.models import Mission
 
-        missions = compute_mission_states(current_user)
+        misiones = Mission.query.all()
+        progresos = compute_mission_states(current_user)
 
     return render_template(
         "auth/perfil.html",
@@ -125,7 +128,8 @@ def perfil():
         achievements=achievements,
         ach_type=ach_type,
         tab=tab,
-        missions=missions,
+        misiones=misiones,
+        progresos=progresos,
     )
 
 

--- a/crunevo/templates/auth/missions_tab.html
+++ b/crunevo/templates/auth/missions_tab.html
@@ -1,20 +1,31 @@
-<h4 class="mb-3">Misiones semanales</h4>
-<div class="row row-cols-1 row-cols-md-2 g-3">
-{% for m in missions %}
-  <div class="col">
-    <div class="card h-100">
-      <div class="card-body d-flex flex-column">
-        <h5 class="card-title">{{ m.mission.description }}</h5>
-        <p class="card-text">Progreso: {{ m.progress }}/{{ m.mission.goal }}</p>
-        {% if m.completed %}
-        <span class="badge bg-success mt-auto">✔ Completada</span>
+{% import 'components/csrf.html' as csrf %}
+<h3 class="mb-3">🎯 Tus misiones activas</h3>
+
+{% for mision in misiones %}
+  {% set progreso = progresos.get(mision.id) %}
+  <div class="card mb-3">
+    <div class="card-body">
+      <h5 class="card-title">{{ mision.description }}</h5>
+      <small class="text-muted">Meta: {{ mision.goal }} • Recompensa: +{{ mision.credit_reward }} créditos</small><br>
+      {% if progreso %}
+        <progress value="{{ progreso.progreso }}" max="{{ mision.goal }}"></progress>
+        <p>Progreso: {{ progreso.progreso }}/{{ mision.goal }}</p>
+        {% if progreso.completada and not progreso.reclamada %}
+          <form method="post" action="{{ url_for('missions.reclamar_mision', mission_id=mision.id) }}">
+            {{ csrf.csrf_field() }}
+            <button class="btn btn-success btn-sm mt-2">🎁 Reclamar créditos</button>
+          </form>
+        {% elif progreso.reclamada %}
+          <span class="badge bg-primary mt-2">Ya reclamada</span>
         {% else %}
-        <span class="badge bg-secondary mt-auto">❌ Pendiente</span>
+          <span class="badge bg-secondary mt-2">❌ Pendiente</span>
         {% endif %}
-      </div>
+      {% else %}
+        <progress value="0" max="{{ mision.goal }}"></progress>
+        <p>Progreso: 0/{{ mision.goal }}</p>
+      {% endif %}
     </div>
   </div>
 {% else %}
-  <p class="text-muted">No hay misiones.</p>
+  <p>No hay misiones disponibles aún.</p>
 {% endfor %}
-</div>


### PR DESCRIPTION
## Summary
- tweak missions blueprint to use `login_required`
- add `/misiones/reclamar_mision/<id>` route
- hook mission claim form to the new endpoint
- log the change in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685e0423f7b48325afd5f569bbfc37aa