### PR TITLE
Implement referral model and profile tab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -316,3 +316,4 @@
 - compute_mission_states detecta dinámicamente el progreso según code y category (PR mission progress dynamic).
 - Perfil muestra misiones con progreso, estado y botón para reclamar créditos manualmente (PR missions-claim-ui).
 - Ruta /misiones/reclamar_mision permite reclamar créditos por misión (PR mission-reclaim-route).
+- Añadido modelo Referral y pestaña de referidos en el perfil con registro básico en onboarding (PR referral-system).

--- a/crunevo/models/__init__.py
+++ b/crunevo/models/__init__.py
@@ -26,3 +26,4 @@ from .saved_post import SavedPost  # noqa: F401
 from .notification import Notification  # noqa: F401
 from .mission import Mission, UserMission  # noqa: F401
 from .post_reaction import PostReaction  # noqa: F401
+from .referido import Referral  # noqa: F401

--- a/crunevo/models/referido.py
+++ b/crunevo/models/referido.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+from crunevo.extensions import db
+
+
+class Referral(db.Model):
+    __tablename__ = "referrals"
+
+    id = db.Column(db.Integer, primary_key=True)
+    code = db.Column(db.String(20), unique=True, nullable=False)
+    invitador_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    invitado_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
+    completado = db.Column(db.Boolean, default=False)
+    fecha_creacion = db.Column(db.DateTime, default=datetime.utcnow)
+
+    invitador = db.relationship("User", foreign_keys=[invitador_id])
+    invitado = db.relationship("User", foreign_keys=[invitado_id])

--- a/crunevo/routes/auth_routes.py
+++ b/crunevo/routes/auth_routes.py
@@ -115,12 +115,25 @@ def perfil():
 
     misiones = None
     progresos = None
+    referidos = None
+    total_referidos = 0
+    referidos_completados = 0
+    enlace_referido = None
     if tab == "misiones":
         from crunevo.routes.missions_routes import compute_mission_states
         from crunevo.models import Mission
 
         misiones = Mission.query.all()
         progresos = compute_mission_states(current_user)
+    elif tab == "referidos":
+        from crunevo.models import Referral
+
+        referidos = Referral.query.filter_by(invitador_id=current_user.id).all()
+        total_referidos = len(referidos)
+        referidos_completados = sum(1 for r in referidos if r.completado)
+        enlace_referido = url_for(
+            "onboarding.register", ref=current_user.username, _external=True
+        )
 
     return render_template(
         "auth/perfil.html",
@@ -130,6 +143,10 @@ def perfil():
         tab=tab,
         misiones=misiones,
         progresos=progresos,
+        referidos=referidos,
+        total_referidos=total_referidos,
+        referidos_completados=referidos_completados,
+        enlace_referido=enlace_referido,
     )
 
 

--- a/crunevo/routes/missions_routes.py
+++ b/crunevo/routes/missions_routes.py
@@ -84,19 +84,3 @@ def compute_mission_states(user):
 def list_missions():
     """Legacy route; redirect to profile missions tab."""
     return redirect(url_for("auth.perfil", tab="misiones"))
-
-    progress = compute_mission_states(current_user).get(mission_id)
-    if not progress or not progress["completada"]:
-        flash("Aún no has completado esta misión", "warning")
-        return redirect(url_for("auth.perfil", tab="misiones"))
-
-    db.session.add(UserMission(user_id=current_user.id, mission_id=mission_id))
-    add_credit(current_user, mission.credit_reward, CreditReasons.DONACION)
-    db.session.commit()
-    flash("¡Créditos reclamados!", "success")
-    return redirect(url_for("auth.perfil", tab="misiones"))
-
-@missions_bp.route("/")
-def list_missions():
-    """Legacy route; redirect to profile missions tab."""
-    return redirect(url_for("auth.perfil", tab="misiones"))

--- a/crunevo/routes/onboarding_routes.py
+++ b/crunevo/routes/onboarding_routes.py
@@ -62,6 +62,24 @@ def register():
             current_app.logger.warning("IntegrityError: %s", e)
             flash("Usuario o correo ya registrado", "danger")
             return render_template("onboarding/register.html"), 400
+
+        # vincular referido si viene el código en la URL
+        ref = request.args.get("ref")
+        if ref:
+            from crunevo.models import Referral
+
+            referidor = User.query.filter_by(username=ref).first()
+            if referidor:
+                codigo = f"{referidor.username}-{user.username}"
+                if not Referral.query.filter_by(code=codigo).first():
+                    db.session.add(
+                        Referral(
+                            code=codigo,
+                            invitador_id=referidor.id,
+                            invitado_id=user.id,
+                        )
+                    )
+                    db.session.commit()
         if not send_confirmation_email(user):
             flash(
                 "No se pudo enviar el correo de confirmación. Inténtalo más tarde.",

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -20,6 +20,9 @@
         <a class="nav-link {% if tab == 'misiones' %}active{% endif %}" href="{{ url_for('auth.perfil', tab='misiones') }}">🧠 Misiones</a>
       </li>
       <li class="nav-item">
+        <a class="nav-link {% if tab == 'referidos' %}active{% endif %}" href="{{ url_for('auth.perfil', tab='referidos') }}">👥 Referidos</a>
+      </li>
+      <li class="nav-item">
         <a class="nav-link {% if tab == 'verificacion' %}active{% endif %}" href="{{ url_for('auth.perfil', tab='verificacion') }}">Verificación</a>
       </li>
     </ul>
@@ -134,6 +137,8 @@
 
     {% if tab == 'misiones' %}
       {% include 'auth/missions_tab.html' %}
+    {% elif tab == 'referidos' %}
+      {% include 'auth/referrals_tab.html' %}
     {% elif tab == 'verificacion' %}
       <div class="card">
         <div class="card-body text-center">

--- a/crunevo/templates/auth/referrals_tab.html
+++ b/crunevo/templates/auth/referrals_tab.html
@@ -1,0 +1,29 @@
+<h3 class="mb-3">🎉 Invita amigos y gana Créditos</h3>
+<p>Comparte tu enlace:
+  <code>{{ enlace_referido }}</code>
+  <button class="btn btn-sm btn-outline-primary" onclick="copiarEnlace()">📋 Copiar</button>
+</p>
+<p><strong>{{ referidos_completados }}</strong> de {{ total_referidos }} completaron requisitos</p>
+<ul class="list-group mb-3">
+{% for ref in referidos %}
+  <li class="list-group-item">
+    {{ ref.invitado.username if ref.invitado else 'Pendiente' }} —
+    {% if ref.completado %}
+      <span class="text-success">✅ Completado</span>
+    {% else %}
+      <span class="text-muted">⏳ En progreso</span>
+    {% endif %}
+  </li>
+{% endfor %}
+</ul>
+<script>
+function copiarEnlace() {
+  navigator.clipboard.writeText("{{ enlace_referido }}").then(() => {
+    if (typeof showToast === 'function') {
+      showToast('Enlace copiado');
+    } else {
+      alert('Enlace copiado');
+    }
+  });
+}
+</script>


### PR DESCRIPTION
## Summary
- create `Referral` model
- link referrals during onboarding registration
- add referral tab in profile with share link and progress list
- document update in `AGENTS.md`
- fix stray code in `missions_routes`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685e0eb1dfa883259dd88986e4d5c055