### PR TITLE
Modern notification cards with filter UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,3 +318,4 @@
 - Ruta /misiones/reclamar_mision permite reclamar créditos por misión (PR mission-reclaim-route).
 - Añadido modelo Referral y pestaña de referidos en el perfil con registro básico en onboarding (PR referral-system).
 - Reimplementado endpoint /misiones/reclamar_mision y añadida prueba automática (PR mission-claim-route-test).
+- Notificaciones ahora usan tarjetas con íconos por color y filtro rápido; se añadieron estilos y JS para filtrar (PR notifications-cards-filter).

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -244,3 +244,41 @@ body[data-bs-theme='dark'] .notification-menu::before {
   }
 }
 
+/* Notification cards */
+.notification-card {
+  border-left: 0.25rem solid var(--bs-border-color);
+}
+.notification-card.unread {
+  border-left-width: 0.5rem;
+  background-color: var(--bs-light-bg-subtle);
+}
+.notification-card.reaction {
+  border-color: #ffc107;
+}
+.notification-card.comment {
+  border-color: #0dcaf0;
+}
+.notification-card.report {
+  border-color: #dc3545;
+}
+.notification-card.achievement {
+  border-color: #6f42c1;
+}
+.notification-card.follow {
+  border-color: #198754;
+}
+
+.text-purple {
+  color: #6f42c1 !important;
+}
+
+.btn-outline-purple {
+  color: #6f42c1;
+  border-color: #6f42c1;
+}
+.btn-outline-purple:hover,
+.btn-outline-purple:focus {
+  background-color: #6f42c1;
+  color: #fff;
+}
+

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -443,6 +443,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   initNotifications();
+  initNotificationFilters();
 
   // Auto hide navbar on scroll for all viewports
   let lastScrollTop = 0;
@@ -477,14 +478,20 @@ function initNotifications() {
   const markAll = document.getElementById('markAllRead');
   if (!list || !badge) return;
 
-  function getNotiIcon(msg) {
-    const m = msg.toLowerCase();
-    if (m.includes('reaccion')) return '🔥';
-    if (m.includes('coment')) return '💬';
-    if (m.includes('logro')) return '🧠';
-    if (m.includes('cr\u00e9dito')) return '👏';
-    return '🔔';
-  }
+function getNotiInfo(msg) {
+  const m = msg.toLowerCase();
+  if (m.includes('reaccion'))
+    return { icon: 'bi-hand-thumbs-up-fill text-warning', type: 'reaction' };
+  if (m.includes('coment'))
+    return { icon: 'bi-chat-left-dots-fill text-info', type: 'comment' };
+  if (m.includes('reporte'))
+    return { icon: 'bi-exclamation-circle-fill text-danger', type: 'report' };
+  if (m.includes('logro'))
+    return { icon: 'bi-trophy-fill text-purple', type: 'achievement' };
+  if (m.includes('seguidor'))
+    return { icon: 'bi-person-plus-fill text-success', type: 'follow' };
+  return { icon: 'bi-bell-fill text-secondary', type: 'other' };
+}
 
   function timeAgo(ts) {
     const d = new Date(ts);
@@ -514,9 +521,9 @@ function initNotifications() {
         list.innerHTML = '';
         items.forEach((n) => {
           const li = document.createElement('li');
-          const emoji = getNotiIcon(n.message);
+          const info = getNotiInfo(n.message);
           const time = timeAgo(n.timestamp);
-          li.innerHTML = `<a class="dropdown-item d-flex align-items-start gap-2 noti-item" href="${n.url || '#'}"><span class="noti-icon">${emoji}</span><span class="flex-grow-1">${n.message}</span><small class="noti-time text-muted ms-2">${time}</small></a>`;
+          li.innerHTML = `<a class="dropdown-item d-flex align-items-start gap-2 noti-item" href="${n.url || '#'}"><i class="${info.icon} me-2"></i><span class="flex-grow-1">${n.message}</span><small class="noti-time text-muted ms-2">${time}</small></a>`;
           const a = li.querySelector('a');
           a.addEventListener('click', () => {
             sessionStorage.setItem('notifHighlight', '1');
@@ -548,4 +555,21 @@ function refreshCartCount() {
   fetch('/store/api/cart_count')
     .then((r) => r.json())
     .then((data) => updateCartBadge(data.count));
+}
+
+function initNotificationFilters() {
+  const group = document.getElementById('notiFilterGroup');
+  if (!group) return;
+  const buttons = group.querySelectorAll('[data-noti-filter]');
+  const cards = document.querySelectorAll('.notification-card');
+  buttons.forEach((btn) => {
+    btn.addEventListener('click', (e) => {
+      e.preventDefault();
+      const filter = btn.dataset.notiFilter;
+      buttons.forEach((b) => b.classList.toggle('active', b === btn));
+      cards.forEach((c) => {
+        c.classList.toggle('tw-hidden', filter !== 'all' && c.dataset.type !== filter);
+      });
+    });
+  });
 }

--- a/crunevo/templates/notificaciones/lista.html
+++ b/crunevo/templates/notificaciones/lista.html
@@ -1,27 +1,51 @@
 {% extends 'base.html' %}
 {% block content %}
 <div class="container my-4">
-  <h3>🔔 Notificaciones</h3>
+  <h3 class="mb-3">🔔 Notificaciones</h3>
   <form method="post" action="{{ url_for('noti.marcar_leidas') }}" class="mb-3">
     {% import 'components/csrf.html' as csrf %}
     {{ csrf.csrf_field() }}
     <button class="btn btn-sm btn-outline-secondary">Marcar todo como leído</button>
   </form>
-  <ul class="list-group notification-page-list">
-    {% for n in notificaciones %}
-    <li class="list-group-item border-0 p-2 {% if not n.is_read %}unread{% endif %}">
-      <div class="d-flex align-items-start">
-        <span class="noti-icon me-2">🔔</span>
-        <div class="flex-grow-1">
-          <a class="stretched-link text-decoration-none" href="{{ n.url or '#' }}">{{ n.message }}</a>
-        </div>
-        <small class="text-muted ms-2 noti-time">{{ n.timestamp|timesince }}</small>
+  <div class="btn-group mb-3" id="notiFilterGroup" role="group">
+    <button class="btn btn-outline-primary active" data-noti-filter="all">Todos</button>
+    <button class="btn btn-outline-warning" data-noti-filter="reaction">❤️ Reacciones</button>
+    <button class="btn btn-outline-info" data-noti-filter="comment">📝 Comentarios</button>
+    <button class="btn btn-outline-danger" data-noti-filter="report">⚠️ Reportes</button>
+    <button class="btn btn-outline-purple" data-noti-filter="achievement">🏆 Logros</button>
+  </div>
+  {% for n in notificaciones %}
+  {% set msg = n.message.lower() %}
+  {% if 'reaccion' in msg %}
+    {% set icon = 'bi-hand-thumbs-up-fill text-warning' %}
+    {% set typ = 'reaction' %}
+  {% elif 'coment' in msg %}
+    {% set icon = 'bi-chat-left-dots-fill text-info' %}
+    {% set typ = 'comment' %}
+  {% elif 'reporte' in msg %}
+    {% set icon = 'bi-exclamation-circle-fill text-danger' %}
+    {% set typ = 'report' %}
+  {% elif 'logro' in msg %}
+    {% set icon = 'bi-trophy-fill text-purple' %}
+    {% set typ = 'achievement' %}
+  {% elif 'seguidor' in msg %}
+    {% set icon = 'bi-person-plus-fill text-success' %}
+    {% set typ = 'follow' %}
+  {% else %}
+    {% set icon = 'bi-bell-fill text-secondary' %}
+    {% set typ = 'other' %}
+  {% endif %}
+  <div class="card notification-card mb-2 fade-in {{ typ }} {% if not n.is_read %}unread{% endif %}" data-type="{{ typ }}">
+    <div class="card-body d-flex">
+      <i class="bi {{ icon }} me-2"></i>
+      <div>
+        <a class="stretched-link text-decoration-none" href="{{ n.url or '#' }}">{{ n.message }}</a>
+        <div><small class="text-muted">{{ n.timestamp|timesince }}</small></div>
       </div>
-    </li>
-    {% else %}
-    <li class="list-group-item">No tienes notificaciones.</li>
-    {% endfor %}
-  </ul>
+    </div>
+  </div>
+  {% else %}
+  <p>No tienes notificaciones.</p>
+  {% endfor %}
 </div>
 {% endblock %}
-


### PR DESCRIPTION
## Summary
- style notifications as cards and color-code them by type
- add quick filter buttons to the notification page
- support filtering in `main.js`
- tweak dropdown icons to Bootstrap icons
- document changes in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685e14902e0c8325828dca7de82508c7