### PR TITLE
Admin delete endpoints with report actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,3 +321,4 @@
 - Notificaciones ahora usan tarjetas con íconos por color y filtro rápido; se añadieron estilos y JS para filtrar (PR notifications-cards-filter).
 - Se otorgan créditos por referido al confirmar el correo y la pestaña muestra tarjetas con total de créditos (PR referral-rewards).
 - Misiones de referidos detectan los completados, nuevos niveles y maratón añadidos. Se premia al invitado con créditos y se desbloquean insignias de "Embajador" y "Aliado". Ranking mensual opcional (PR referral-missions).
+- Se agregaron rutas de administrador para eliminar publicaciones y apuntes con notificación al autor y limpieza de feed. La página de reportes permite marcar como resuelto y eliminar posts reportados (PR admin-delete-post).

--- a/crunevo/templates/admin/manage_reports.html
+++ b/crunevo/templates/admin/manage_reports.html
@@ -6,11 +6,29 @@
     <div class="table-responsive">
       <table id="tablaReportes" class="table table-vcenter card-table">
       <thead>
-        <tr><th>ID</th><th>Usuario</th><th>Descripción</th><th>Estado</th></tr>
+        <tr><th>ID</th><th>Usuario</th><th>Descripción</th><th>Estado</th><th>Acciones</th></tr>
       </thead>
       <tbody>
         {% for r in reports %}
-        <tr><td>{{ r.id }}</td><td>{{ r.user_id }}</td><td>{{ r.description }}</td><td>{{ r.status }}</td></tr>
+        <tr>
+          <td>{{ r.id }}</td>
+          <td>{{ r.user_id }}</td>
+          <td>{{ r.description }}</td>
+          <td>{{ r.status }}</td>
+          <td>
+            <form action="{{ url_for('admin.resolve_report', report_id=r.id) }}" method="post" class="d-inline">
+              {{ csrf.csrf_field() }}
+              <button class="btn btn-sm btn-success">Resolver</button>
+            </form>
+            {% if r.description.startswith('Post ') %}
+              {% set pid = r.description.split()[1].split(':')[0] %}
+              <form action="{{ url_for('admin.delete_post_admin', post_id=pid) }}" method="post" class="d-inline" onsubmit="return confirm('¿Eliminar publicación?');">
+                {{ csrf.csrf_field() }}
+                <button class="btn btn-sm btn-danger">Eliminar post</button>
+              </form>
+            {% endif %}
+          </td>
+        </tr>
         {% endfor %}
       </tbody>
       </table>

--- a/crunevo/templates/components/note_card.html
+++ b/crunevo/templates/components/note_card.html
@@ -13,13 +13,19 @@
         <a href="{{ url_for('notes.view_note', id=note.id) }}" class="btn btn-primary btn-sm">Ver detalle</a>
         {% if current_user.is_authenticated %}
           {% if note.user_id == current_user.id %}
-          <a href="{{ url_for('notes.edit_note', note_id=note.id) }}" class="btn btn-outline-secondary btn-sm">Editar</a>
-          <form action="{{ url_for('notes.delete_note', note_id=note.id) }}" method="post" class="d-inline" onsubmit="return confirm('¿Eliminar este apunte?');">
-            {{ csrf.csrf_field() }}
-            <button type="submit" class="btn btn-outline-danger btn-sm">🗑️</button>
-          </form>
+            <a href="{{ url_for('notes.edit_note', note_id=note.id) }}" class="btn btn-outline-secondary btn-sm">Editar</a>
+            <form action="{{ url_for('notes.delete_note', note_id=note.id) }}" method="post" class="d-inline" onsubmit="return confirm('¿Eliminar este apunte?');">
+              {{ csrf.csrf_field() }}
+              <button type="submit" class="btn btn-outline-danger btn-sm">🗑️</button>
+            </form>
           {% else %}
-          <button type="button" class="btn btn-outline-warning btn-sm" data-bs-toggle="modal" data-bs-target="#reportNote{{ note.id }}">Reportar</button>
+            <button type="button" class="btn btn-outline-warning btn-sm" data-bs-toggle="modal" data-bs-target="#reportNote{{ note.id }}">Reportar</button>
+            {% if current_user.role == 'admin' %}
+            <form action="{{ url_for('admin.delete_note_admin', note_id=note.id) }}" method="post" class="d-inline" onsubmit="return confirm('¿Eliminar este apunte?');">
+              {{ csrf.csrf_field() }}
+              <button type="submit" class="btn btn-outline-danger btn-sm">🗑️</button>
+            </form>
+            {% endif %}
           {% endif %}
         {% endif %}
       </div>

--- a/crunevo/templates/feed/post_card.html
+++ b/crunevo/templates/feed/post_card.html
@@ -26,6 +26,14 @@
         </li>
         {% else %}
         <li><a class="dropdown-item text-warning" data-bs-toggle="modal" href="#reportPost{{ post.id }}">Reportar</a></li>
+        {% if current_user.role == 'admin' %}
+        <li>
+          <form action="{{ url_for('admin.delete_post_admin', post_id=post.id) }}" method="POST" onsubmit="return confirm('¿Eliminar esta publicación?');">
+            {{ csrf.csrf_field() }}
+            <button type="submit" class="dropdown-item text-danger">Eliminar (admin)</button>
+          </form>
+        </li>
+        {% endif %}
         {% endif %}
       </ul>
     </div>

--- a/tests/test_admin_delete.py
+++ b/tests/test_admin_delete.py
@@ -1,0 +1,44 @@
+from crunevo.models import User, Post, Note
+from crunevo.utils.feed import create_feed_item_for_all
+
+
+def login(client, username, password):
+    return client.post("/login", data={"username": username, "password": password})
+
+
+def test_admin_delete_post(client, db_session, test_user):
+    admin = User(
+        username="adm",
+        email="adm@example.com",
+        role="admin",
+        activated=True,
+        avatar_url="a",
+    )
+    admin.set_password("pass")
+    post = Post(content="x", author=test_user)
+    db_session.add_all([admin, post])
+    db_session.commit()
+    create_feed_item_for_all("post", post.id)
+    login(client, "adm", "pass")
+    resp = client.post(f"/admin/delete-post/{post.id}")
+    assert resp.status_code == 302
+    assert Post.query.get(post.id) is None
+
+
+def test_admin_delete_note(client, db_session, test_user):
+    admin = User(
+        username="adm2",
+        email="adm2@example.com",
+        role="admin",
+        activated=True,
+        avatar_url="a",
+    )
+    admin.set_password("pass")
+    note = Note(title="t", filename="file.pdf", author=test_user)
+    db_session.add_all([admin, note])
+    db_session.commit()
+    create_feed_item_for_all("apunte", note.id)
+    login(client, "adm2", "pass")
+    resp = client.post(f"/admin/delete-note/{note.id}")
+    assert resp.status_code == 302
+    assert Note.query.get(note.id) is None


### PR DESCRIPTION
## Summary
- add admin endpoints to delete posts and notes
- notify authors and clean up feed cache
- allow resolving reports and deleting reported posts
- expose admin delete buttons in feed and notes
- test new admin deletion features

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685e1a9db5b883258d4e9bf2d35c0c3e