### PR TITLE
Fix BuildError on admin by hiding crolars link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -322,3 +322,4 @@
 - Se otorgan créditos por referido al confirmar el correo y la pestaña muestra tarjetas con total de créditos (PR referral-rewards).
 - Misiones de referidos detectan los completados, nuevos niveles y maratón añadidos. Se premia al invitado con créditos y se desbloquean insignias de "Embajador" y "Aliado". Ranking mensual opcional (PR referral-missions).
 - Se agregaron rutas de administrador para eliminar publicaciones y apuntes con notificación al autor y limpieza de feed. La página de reportes permite marcar como resuelto y eliminar posts reportados (PR admin-delete-post).
+- Ocultado enlace a /crolars en admin para evitar BuildError (PR admin-crolars-link-fix).

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -45,7 +45,9 @@
         {% block content %}{% endblock %}
     </div>
     <footer class="text-center py-3 mt-auto">
+      {% if not current_app.config.get('ADMIN_INSTANCE') %}
       <a href="{{ url_for('main.crolars') }}" class="link-secondary text-decoration-none">¿Qué son los Crolars?</a>
+      {% endif %}
     </footer>
     <div class="toast-container position-fixed bottom-0 end-0 p-3"></div>
     {% if request.path.startswith('/store') %}


### PR DESCRIPTION
## Summary
- hide the footer link to `/crolars` when running the admin instance
- document the change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685e1e9e9f188325bd5557eafb6ecf5a