### PR TITLE
Fix admin BuildError for store routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -328,3 +328,4 @@
 - Ocultado enlace a /crolars en admin para evitar BuildError (PR admin-crolars-link-fix).
 - Renombrado el término 'cr\xc3\xa9ditos' a 'Crolars' en plantillas y mensajes visibles sin cambiar la base de datos (PR rename-credits-crolars).
 - Ocultado el menú inferior móvil en la instancia de administración para evitar BuildError al resolver 'feed.feed_home' (PR admin-bottom-nav-fix).
+- Botón de carrito y fetch de recuento condicionados a la existencia de rutas de tienda para evitar BuildError en la instancia admin (PR admin-store-route-check).

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -428,7 +428,9 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  refreshCartCount();
+  if (window.HAS_STORE) {
+    refreshCartCount();
+  }
   document.querySelectorAll('.add-cart-btn').forEach((btn) => {
     btn.addEventListener('click', (e) => {
       e.preventDefault();

--- a/crunevo/templates/admin/manage_reports.html
+++ b/crunevo/templates/admin/manage_reports.html
@@ -1,4 +1,5 @@
 {% extends 'admin/base_admin.html' %}
+{% from 'components/csrf.html' import csrf_field %}
 {% block admin_content %}
 <h2 class="page-title mb-4">Reportes</h2>
 <div class="card shadow-sm">
@@ -17,13 +18,13 @@
           <td>{{ r.status }}</td>
           <td>
             <form action="{{ url_for('admin.resolve_report', report_id=r.id) }}" method="post" class="d-inline">
-              {{ csrf.csrf_field() }}
+              {{ csrf_field() }}
               <button class="btn btn-sm btn-success">Resolver</button>
             </form>
             {% if r.description.startswith('Post ') %}
               {% set pid = r.description.split()[1].split(':')[0] %}
               <form action="{{ url_for('admin.delete_post_admin', post_id=pid) }}" method="post" class="d-inline" onsubmit="return confirm('¿Eliminar publicación?');">
-                {{ csrf.csrf_field() }}
+                {{ csrf_field() }}
                 <button class="btn btn-sm btn-danger">Eliminar post</button>
               </form>
             {% endif %}

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -50,7 +50,7 @@
       {% endif %}
     </footer>
     <div class="toast-container position-fixed bottom-0 end-0 p-3"></div>
-    {% if request.path.startswith('/store') %}
+    {% if request.path.startswith('/store') and 'store.view_cart' in current_app.view_functions %}
     <a href="{{ url_for('store.view_cart') }}" class="btn btn-primary rounded-circle position-fixed bottom-0 end-0 m-3 d-lg-none">
       <i class="bi bi-cart"></i>
       <span id="mobileCartBadge" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger {% if CART_COUNT == 0 %}tw-hidden{% endif %}">{{ CART_COUNT }}</span>
@@ -64,6 +64,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="{{ url_for('static', filename='js/feed_toggle.js') }}" defer></script>
     <script src="{{ url_for('static', filename='js/feed.js') }}"></script>
+    <script>window.HAS_STORE = {{ 'true' if 'store.cart_count_api' in current_app.view_functions else 'false' }};</script>
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>
     {% block body_end %}{% endblock %}
 </body>

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -24,6 +24,10 @@ def test_post_forms_have_csrf_macro():
     missing = []
     for path in Path("crunevo/templates").rglob("*.html"):
         text = path.read_text()
-        if pattern.search(text) and "{{ csrf.csrf_field() }}" not in text:
+        if (
+            pattern.search(text)
+            and "{{ csrf.csrf_field() }}" not in text
+            and "{{ csrf_field() }}" not in text
+        ):
             missing.append(str(path))
     assert not missing, "Missing csrf_field in: " + ", ".join(missing)


### PR DESCRIPTION
## Summary
- avoid cart link BuildError when store blueprint is absent
- call `refreshCartCount()` only if store routes exist
- import csrf macro in `manage_reports.html`
- allow `csrf_field()` in csrf tests
- document change in AGENTS notes

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685e2f6f19f0832589f230801b407b20