### PR TITLE
Add admin missions view and credit filters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -329,3 +329,4 @@
 - Renombrado el término 'cr\xc3\xa9ditos' a 'Crolars' en plantillas y mensajes visibles sin cambiar la base de datos (PR rename-credits-crolars).
 - Ocultado el menú inferior móvil en la instancia de administración para evitar BuildError al resolver 'feed.feed_home' (PR admin-bottom-nav-fix).
 - Botón de carrito y fetch de recuento condicionados a la existencia de rutas de tienda para evitar BuildError en la instancia admin (PR admin-store-route-check).
+- Agregadas vistas /admin/misiones y alias /admin/creditos; manage_credits admite filtros por usuario y razón y los usuarios muestran enlace a su historial (PR admin-missions-page).

--- a/crunevo/templates/admin/manage_missions.html
+++ b/crunevo/templates/admin/manage_missions.html
@@ -1,0 +1,35 @@
+{% extends 'admin/base_admin.html' %}
+{% block admin_content %}
+<h2 class="page-title mb-4">Misiones reclamadas</h2>
+<div class="card shadow-sm">
+  <div class="card-body p-0">
+    <div class="table-responsive">
+      <table id="tablaMisiones" class="table table-vcenter card-table">
+        <thead>
+          <tr>
+            <th>Usuario</th>
+            <th>Misión</th>
+            <th>Créditos</th>
+            <th>Fecha</th>
+          </tr>
+        </thead>
+        <tbody>
+        {% for record, user, mission in records %}
+          <tr>
+            <td>{{ user.username }}</td>
+            <td>{{ mission.description }}</td>
+            <td>{{ mission.credit_reward }}</td>
+            <td>{{ record.completed_at.strftime('%d/%m/%Y %H:%M') }}</td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  new simpleDatatables.DataTable('#tablaMisiones');
+});
+</script>
+{% endblock %}

--- a/crunevo/templates/admin/manage_users.html
+++ b/crunevo/templates/admin/manage_users.html
@@ -35,6 +35,7 @@
                 <li><button class="dropdown-item" data-bs-toggle="modal" data-bs-target="#editRoleModal{{ user.id }}">Cambiar rol</button></li>
                 <li><a class="dropdown-item text-warning" href="{{ url_for('admin.toggle_user_status', user_id=user.id) }}">Suspender / Reactivar</a></li>
                 {% endif %}
+                <li><a class="dropdown-item" href="{{ url_for('admin.manage_credits', user_id=user.id) }}">Historial Crolars</a></li>
                 <li><a class="dropdown-item text-muted" href="{{ url_for('admin.user_activity', user_id=user.id) }}">Ver actividad</a></li>
               </ul>
             </div>

--- a/crunevo/templates/admin/partials/sidebar.html
+++ b/crunevo/templates/admin/partials/sidebar.html
@@ -27,6 +27,9 @@
   <a class="nav-link {% if request.endpoint == 'admin.manage_achievements' %}active{% endif %}" href="{{ url_for('admin.manage_achievements') }}">
     <i class="ti ti-award me-2"></i> Logros
   </a>
+  <a class="nav-link {% if request.endpoint == 'admin.manage_missions' %}active{% endif %}" href="{{ url_for('admin.manage_missions') }}">
+    <i class="ti ti-target me-2"></i> Misiones
+  </a>
   <a class="nav-link disabled"><i class="ti ti-calendar-event me-2"></i> Eventos</a>
 
   <span class="text-muted fw-bold small mt-4 mb-2">⚙️ Sistema</span>


### PR DESCRIPTION
## Summary
- allow filtering credit history by user and reason
- create /admin/misiones page to review claimed missions
- add credit history link in user dropdown
- link new page from sidebar
- document new admin pages in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685e3182a24c8325a39c394d06e984e6