### PR TITLE
Log device token

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,3 +330,4 @@
 - Ocultado el menú inferior móvil en la instancia de administración para evitar BuildError al resolver 'feed.feed_home' (PR admin-bottom-nav-fix).
 - Botón de carrito y fetch de recuento condicionados a la existencia de rutas de tienda para evitar BuildError en la instancia admin (PR admin-store-route-check).
 - Agregadas vistas /admin/misiones y alias /admin/creditos; manage_credits admite filtros por usuario y razón y los usuarios muestran enlace a su historial (PR admin-missions-page).
+- Added device token header from localStorage via main.js and stored in auth events (PR device-token-logging).

--- a/crunevo/utils/audit.py
+++ b/crunevo/utils/audit.py
@@ -1,10 +1,21 @@
 from flask import request
 from datetime import datetime
+import json
+
 from crunevo.extensions import db
 from crunevo.models import AuthEvent
 
 
 def record_auth_event(user, event_type, extra=None):
+    token = request.headers.get("X-Device-Token")
+    if token:
+        try:
+            data = json.loads(extra) if extra else {}
+        except Exception:
+            data = {"info": extra}
+        data["device_token"] = token
+        extra = json.dumps(data)
+
     ev = AuthEvent(
         user_id=user.id if user else None,
         event_type=event_type,


### PR DESCRIPTION
## Summary
- store client device token in localStorage and send via `X-Device-Token` header
- include device token in auth event logs
- document latest change

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685e33fb2acc8325a1ae763b9d992828