### PR TITLE
Add cookies policy page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,3 +331,4 @@
 - Botón de carrito y fetch de recuento condicionados a la existencia de rutas de tienda para evitar BuildError en la instancia admin (PR admin-store-route-check).
 - Agregadas vistas /admin/misiones y alias /admin/creditos; manage_credits admite filtros por usuario y razón y los usuarios muestran enlace a su historial (PR admin-missions-page).
 - Added device token header from localStorage via main.js and stored in auth events (PR device-token-logging).
+- Added static /cookies page with footer links to cookies, privacidad and terminos (PR cookies-page).

--- a/crunevo/__init__.py
+++ b/crunevo/__init__.py
@@ -1,7 +1,7 @@
 """Application package initializer."""
 
 from .app import create_app as _create_app
-from .routes import main_routes
+from .routes import main_routes, static_routes
 import os
 
 
@@ -10,5 +10,6 @@ def create_app():
 
     if os.environ.get("ADMIN_INSTANCE") != "1":
         app.register_blueprint(main_routes.main_bp)
+        app.register_blueprint(static_routes.static_bp)
 
     return app

--- a/crunevo/routes/static_routes.py
+++ b/crunevo/routes/static_routes.py
@@ -1,0 +1,8 @@
+from flask import Blueprint, render_template
+
+static_bp = Blueprint("static_pages", __name__)
+
+
+@static_bp.route("/cookies")
+def cookies():
+    return render_template("static/cookies.html")

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -44,10 +44,10 @@
         {% endwith %}
         {% block content %}{% endblock %}
     </div>
-    <footer class="text-center py-3 mt-auto">
-      {% if not current_app.config.get('ADMIN_INSTANCE') %}
-      <a href="{{ url_for('main.crolars') }}" class="link-secondary text-decoration-none">¿Qué son los Crolars?</a>
-      {% endif %}
+    <footer class="text-center small mt-5 mb-3">
+      <a href="/cookies" class="text-muted">Política de Cookies</a> ·
+      <a href="/privacidad" class="text-muted">Privacidad</a> ·
+      <a href="/terminos" class="text-muted">Términos</a>
     </footer>
     <div class="toast-container position-fixed bottom-0 end-0 p-3"></div>
     {% if request.path.startswith('/store') and 'store.view_cart' in current_app.view_functions %}

--- a/crunevo/templates/static/cookies.html
+++ b/crunevo/templates/static/cookies.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="container mt-5 mb-5">
+  <h2 class="text-center mb-4">🍪 Política de Cookies</h2>
+
+  <div class="card shadow-sm p-4">
+    <p>En <strong>Crunevo</strong>, usamos cookies para mejorar tu experiencia, personalizar el contenido y analizar el tráfico del sitio. Al usar nuestra plataforma, aceptas el uso de cookies según esta política.</p>
+
+    <h5 class="mt-4">¿Qué son las cookies?</h5>
+    <p>Las cookies son pequeños archivos de texto que se almacenan en tu dispositivo cuando visitas una página web.</p>
+
+    <h5 class="mt-4">¿Qué tipos de cookies usamos?</h5>
+    <ul>
+      <li><strong>Cookies esenciales:</strong> Necesarias para el funcionamiento básico del sitio (inicio de sesión, navegación segura, etc.).</li>
+      <li><strong>Cookies de rendimiento:</strong> Nos ayudan a entender cómo interactúas con el sitio para mejorarlo.</li>
+      <li><strong>Cookies de funcionalidad:</strong> Guardan tus preferencias como idioma, tema oscuro, etc.</li>
+      <li><strong>Cookies opcionales:</strong> Solo si das consentimiento explícito (como recordar tu sesión por más tiempo o recomendaciones personalizadas).</li>
+    </ul>
+
+    <h5 class="mt-4">¿Cómo puedes gestionar las cookies?</h5>
+    <p>Puedes cambiar la configuración de cookies desde tu navegador o desde la configuración de tu cuenta Crunevo (próximamente).</p>
+
+    <h5 class="mt-4">¿Se comparten las cookies con terceros?</h5>
+    <p>No compartimos tus datos con terceros sin tu consentimiento. En el futuro, podríamos usar servicios externos como analítica educativa de forma anónima.</p>
+
+    <p class="mt-4">Si tienes dudas, contáctanos en <a href="mailto:soporte@crunevo.com">soporte@crunevo.com</a>.</p>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- serve `/cookies` under new static_pages blueprint
- add cookie policy template
- link policy pages in footer
- register new blueprint
- document update in AGENTS guidelines

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685e3665d11883258c4ada130cc799d6