### PR TITLE
Fix admin note delete button

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,3 +334,4 @@
 - Added AdminLog model, comentarios y estadísticas en admin con alerta de reportes urgentes (PR admin-logs-stats).
 
 - Added static /cookies page with footer links to cookies, privacidad and terminos (PR cookies-page).
+- Botón para eliminar apuntes por admin solo visible si ADMIN_INSTANCE está habilitado para evitar BuildError (PR note-delete-admin-fix).

--- a/crunevo/templates/components/note_card.html
+++ b/crunevo/templates/components/note_card.html
@@ -20,7 +20,7 @@
             </form>
           {% else %}
             <button type="button" class="btn btn-outline-warning btn-sm" data-bs-toggle="modal" data-bs-target="#reportNote{{ note.id }}">Reportar</button>
-            {% if current_user.role == 'admin' %}
+            {% if current_user.role == 'admin' and config.ADMIN_INSTANCE %}
             <form action="{{ url_for('admin.delete_note_admin', note_id=note.id) }}" method="post" class="d-inline" onsubmit="return confirm('¿Eliminar este apunte?');">
               {{ csrf.csrf_field() }}
               <button type="submit" class="btn btn-outline-danger btn-sm">🗑️</button>


### PR DESCRIPTION
## Summary
- avoid BuildError on the public instance by only showing the admin note delete link when `ADMIN_INSTANCE` is active
- document the change in AGENTS.md

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685e39f7d0c88325a29e210f199c58a8