### PR TITLE
Fix post card comment input

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -338,3 +338,7 @@
 - Added static /cookies page with footer links to cookies, privacidad and terminos (PR cookies-page).
 - Botón para eliminar apuntes por admin solo visible si ADMIN_INSTANCE está habilitado para evitar BuildError (PR note-delete-admin-fix).
 - Logros ahora otorgan crolars y muestran popup al desbloquear (PR achievements-credits-popup).
+- Post cards redesigned with hover effect, reaction panel animation and comment counts (PR post-ui-polish).
+
+- Fixed default boolean in achievement_popup migration using server_default="false" to prevent deployment failure (PR logs-migration-fix).
+- Restored comment input below reactions and kept reaction count line unchanged (PR post-comment-input-return).

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -86,3 +86,31 @@
     display: none !important;
   }
 }
+
+.hover-scale {
+  transition: transform 0.15s ease;
+}
+.hover-scale:hover {
+  transform: scale(1.02);
+}
+
+.reaction-options {
+  animation: fadeInDown 0.2s ease;
+}
+
+@keyframes fadeInDown {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.reaction-btn.active {
+  background-color: #f3f3ff;
+  border: 1px solid #8a2be2;
+  border-radius: 50%;
+}

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -281,6 +281,11 @@ body[data-bs-theme='dark'] .notification-menu::before {
   background-color: #6f42c1;
   color: #fff;
 }
+.btn-outline-purple.active {
+  background-color: #f3f3ff;
+  border-color: #8a2be2;
+  color: #6f42c1;
+}
 
 .achievement-popup {
   position: fixed;

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -66,6 +66,12 @@ function showReactions(btn) {
   const container = btn.closest('.reaction-container');
   const options = container.querySelector('.reaction-options');
   if (!options) return;
+  const current = container.dataset.myReaction;
+  if (current) {
+    options.querySelectorAll('.reaction-btn').forEach((b) => {
+      b.classList.toggle('active', b.dataset.reaction === current);
+    });
+  }
   options.classList.remove('d-none');
   clearTimeout(options._timeout);
   options._timeout = setTimeout(() => {

--- a/crunevo/templates/feed/post_card.html
+++ b/crunevo/templates/feed/post_card.html
@@ -1,6 +1,6 @@
 {% import 'components/csrf.html' as csrf %}
 {% import 'components/reactions.html' as react %}
-<article class="card shadow-sm mb-3">
+<article class="card shadow-sm mb-3 hover-scale">
   <div class="card-header bg-transparent d-flex align-items-center gap-2">
     {% set author = post.author %}
     <img loading="lazy" src="{{ (author and author.avatar_url) or url_for('static', filename='img/default.png') }}" class="rounded-circle" width="40" height="40" alt="avatar">
@@ -10,7 +10,7 @@
       {% else %}
       <span class="text-muted">Usuario eliminado</span><br>
       {% endif %}
-      <small class="text-muted">{{ post.created_at|timesince }}{% if post.edited %} • Editado{% endif %}</small>
+      <small class="text-muted small"><i class="bi bi-clock"></i> {{ post.created_at|timesince }}{% if post.edited %} • Editado{% endif %}</small>
     </div>
     <div class="dropdown">
       <button class="btn btn-sm btn-light" data-bs-toggle="dropdown" aria-expanded="false"><i class="bi bi-three-dots"></i></button>
@@ -50,6 +50,11 @@
     <div class="d-flex align-items-center gap-2 mb-2">
       {{ react.reaction_container(post, counts, my_reaction) }}
       <input type="text" class="form-control form-control-sm" placeholder="Escribe un comentario..." readonly data-bs-toggle="modal" data-bs-target="#postModal{{ post.id }}">
+    </div>
+    <hr class="my-2">
+    <div class="d-flex justify-content-between align-items-center">
+      <small class="text-muted">🔥 {{ post.likes or 0 }}&nbsp;&nbsp; 💬 {{ post.comments|length }}</small>
+      <button type="button" class="btn btn-outline-light btn-sm" data-bs-toggle="modal" data-bs-target="#postModal{{ post.id }}">Comentar</button>
     </div>
   </div>
 </article>

--- a/migrations/versions/abcd1234add_achievement_popup.py
+++ b/migrations/versions/abcd1234add_achievement_popup.py
@@ -29,7 +29,12 @@ def upgrade():
             sa.ForeignKey("achievement.id"),
             nullable=False,
         ),
-        sa.Column("shown", sa.Boolean(), nullable=False, server_default=sa.text("0")),
+        sa.Column(
+            "shown",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
     )
 
 


### PR DESCRIPTION
## Summary
- restore readonly comment input after the reactions
- document the fix in AGENTS notes

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685e45daf3b8832584bf9b1bde319597