### PR TITLE
Fix achievement popup close

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -342,3 +342,4 @@
 
 - Fixed default boolean in achievement_popup migration using server_default="false" to prevent deployment failure (PR logs-migration-fix).
 - Restored comment input below reactions and kept reaction count line unchanged (PR post-comment-input-return).
+- Added close listener for achievement popup with fade animations and accessibility tweaks (PR achievement-popup-fix).

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -301,6 +301,14 @@ body[data-bs-theme='dark'] .notification-menu::before {
   animation: pop-in 0.3s ease forwards;
 }
 
+.animate-fade-in-down {
+  animation: fadeInDown 0.3s ease forwards;
+}
+
+.animate-fade-out-up {
+  animation: fadeOutUp 0.3s ease forwards;
+}
+
 @keyframes pop-in {
   from {
     transform: scale(0.8);
@@ -309,6 +317,28 @@ body[data-bs-theme='dark'] .notification-menu::before {
   to {
     transform: scale(1);
     opacity: 1;
+  }
+}
+
+@keyframes fadeInDown {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fadeOutUp {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-10px);
   }
 }
 

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -275,6 +275,10 @@ document.addEventListener('DOMContentLoaded', () => {
   if (window.NEW_ACHIEVEMENTS && window.NEW_ACHIEVEMENTS.length) {
     showAchievementPopup(window.NEW_ACHIEVEMENTS[0]);
   }
+  const closeBtn = document.getElementById('closeAchievementBtn');
+  if (closeBtn) {
+    closeBtn.addEventListener('click', closeAchievementPopup);
+  }
 
   initPdfPreviews();
   if (typeof initNoteViewer === 'function') {
@@ -607,10 +611,23 @@ function showAchievementPopup(data) {
   const popup = document.getElementById('achievementPopup');
   if (!popup) return;
   popup.querySelector('#achievementTitle').textContent = data.title || data.code;
-  popup.querySelector('.credit-gain').textContent = `+${data.credit_reward || 1} crolars`;
+  popup.querySelector('.credit-gain').textContent = `+${data.credit_reward || 1} Crolar`;
   popup.classList.remove('tw-hidden');
-  document.getElementById('closeAchievementBtn').addEventListener('click', () => {
+  const content = popup.querySelector('.popup-content');
+  content.classList.remove('animate-fade-out-up');
+  content.classList.add('animate-fade-in-down');
+}
+
+function closeAchievementPopup() {
+  const popup = document.getElementById('achievementPopup');
+  if (!popup) return;
+  const content = popup.querySelector('.popup-content');
+  content.classList.remove('animate-fade-in-down');
+  content.classList.add('animate-fade-out-up');
+  setTimeout(() => {
     popup.classList.add('tw-hidden');
+    popup.querySelector('#achievementTitle').textContent = '';
+    popup.querySelector('.credit-gain').textContent = '';
     csrfFetch('/api/achievement-popup/mark-shown', { method: 'POST' });
-  }, { once: true });
+  }, 300);
 }

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -49,12 +49,12 @@
       <a href="/privacidad" class="text-muted">Privacidad</a> ·
       <a href="/terminos" class="text-muted">Términos</a>
     </footer>
-    <div class="achievement-popup tw-hidden" id="achievementPopup">
-      <div class="popup-content bg-dark text-white p-4 rounded-3 text-center">
-        <h3>🎖 ¡Logro desbloqueado!</h3>
+    <div class="achievement-popup tw-hidden" id="achievementPopup" role="dialog" aria-modal="true">
+      <div class="popup-content bg-dark bg-opacity-75 text-white p-4 rounded-3 text-center shadow-lg">
+        <h3>🏆 ¡Logro desbloqueado!</h3>
         <p id="achievementTitle" class="mb-1"></p>
-        <p class="credit-gain mb-3">+1 crolar</p>
-        <button class="btn btn-primary" id="closeAchievementBtn">OK</button>
+        <p class="credit-gain mb-3">+1 Crolar</p>
+        <button class="btn btn-primary" id="closeAchievementBtn" aria-label="Cerrar logro desbloqueado">OK</button>
       </div>
     </div>
     <div class="toast-container position-fixed bottom-0 end-0 p-3"></div>


### PR DESCRIPTION
## Summary
- tweak achievement popup HTML for better accessibility and style
- add fade-in/out animations for achievement popup
- wire close button handler in main.js
- add new animations to CSS
- document changes in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685e4f4119dc8325850d2954a7ffdead