### PR TITLE
Fix achievement popup and admin visibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -343,3 +343,4 @@
 - Fixed default boolean in achievement_popup migration using server_default="false" to prevent deployment failure (PR logs-migration-fix).
 - Restored comment input below reactions and kept reaction count line unchanged (PR post-comment-input-return).
 - Added close listener for achievement popup with fade animations and accessibility tweaks (PR achievement-popup-fix).
+- Achievement popup hidden on admin instance, closes properly marking as shown and clearing state with button handler set dynamically (PR achievement-popup-bugfix).

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -275,10 +275,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (window.NEW_ACHIEVEMENTS && window.NEW_ACHIEVEMENTS.length) {
     showAchievementPopup(window.NEW_ACHIEVEMENTS[0]);
   }
-  const closeBtn = document.getElementById('closeAchievementBtn');
-  if (closeBtn) {
-    closeBtn.addEventListener('click', closeAchievementPopup);
-  }
+
 
   initPdfPreviews();
   if (typeof initNoteViewer === 'function') {
@@ -616,6 +613,11 @@ function showAchievementPopup(data) {
   const content = popup.querySelector('.popup-content');
   content.classList.remove('animate-fade-out-up');
   content.classList.add('animate-fade-in-down');
+
+  const closeBtn = popup.querySelector('#closeAchievementBtn');
+  if (closeBtn) {
+    closeBtn.onclick = () => closeAchievementPopup();
+  }
 }
 
 function closeAchievementPopup() {
@@ -629,5 +631,6 @@ function closeAchievementPopup() {
     popup.querySelector('#achievementTitle').textContent = '';
     popup.querySelector('.credit-gain').textContent = '';
     csrfFetch('/api/achievement-popup/mark-shown', { method: 'POST' });
+    window.NEW_ACHIEVEMENTS = [];
   }, 300);
 }

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -49,6 +49,7 @@
       <a href="/privacidad" class="text-muted">Privacidad</a> ·
       <a href="/terminos" class="text-muted">Términos</a>
     </footer>
+    {% if not config.ADMIN_INSTANCE %}
     <div class="achievement-popup tw-hidden" id="achievementPopup" role="dialog" aria-modal="true">
       <div class="popup-content bg-dark bg-opacity-75 text-white p-4 rounded-3 text-center shadow-lg">
         <h3>🏆 ¡Logro desbloqueado!</h3>
@@ -57,6 +58,7 @@
         <button class="btn btn-primary" id="closeAchievementBtn" aria-label="Cerrar logro desbloqueado">OK</button>
       </div>
     </div>
+    {% endif %}
     <div class="toast-container position-fixed bottom-0 end-0 p-3"></div>
     {% if request.path.startswith('/store') and 'store.view_cart' in current_app.view_functions %}
     <a href="{{ url_for('store.view_cart') }}" class="btn btn-primary rounded-circle position-fixed bottom-0 end-0 m-3 d-lg-none">


### PR DESCRIPTION
## Summary
- hide achievement popup on admin instance
- connect OK button inside popup
- mark achievements as shown and clear state when closing
- update agent notes

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685e534ea1008325af1e9b4f7939304a