### PR TITLE
Fix achievement popup session check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -343,3 +343,5 @@
 - Fixed default boolean in achievement_popup migration using server_default="false" to prevent deployment failure (PR logs-migration-fix).
 - Restored comment input below reactions and kept reaction count line unchanged (PR post-comment-input-return).
 - Added close listener for achievement popup with fade animations and accessibility tweaks (PR achievement-popup-fix).
+- Achievement popup hidden on admin instance, closes properly marking as shown and clearing state with button handler set dynamically (PR achievement-popup-bugfix).
+- Popup and window.NEW_ACHIEVEMENTS only load for authenticated users, injecting CURRENT_USER_ID and clearing achievements after successful mark-shown request (PR achievement-popup-login-check).

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -272,13 +272,10 @@ document.addEventListener('DOMContentLoaded', () => {
     new bootstrap.Toast(t).show();
   });
 
-  if (window.NEW_ACHIEVEMENTS && window.NEW_ACHIEVEMENTS.length) {
+  if (window.NEW_ACHIEVEMENTS && window.NEW_ACHIEVEMENTS.length && window.CURRENT_USER_ID) {
     showAchievementPopup(window.NEW_ACHIEVEMENTS[0]);
   }
-  const closeBtn = document.getElementById('closeAchievementBtn');
-  if (closeBtn) {
-    closeBtn.addEventListener('click', closeAchievementPopup);
-  }
+
 
   initPdfPreviews();
   if (typeof initNoteViewer === 'function') {
@@ -616,6 +613,11 @@ function showAchievementPopup(data) {
   const content = popup.querySelector('.popup-content');
   content.classList.remove('animate-fade-out-up');
   content.classList.add('animate-fade-in-down');
+
+  const closeBtn = popup.querySelector('#closeAchievementBtn');
+  if (closeBtn) {
+    closeBtn.onclick = () => closeAchievementPopup();
+  }
 }
 
 function closeAchievementPopup() {
@@ -628,6 +630,8 @@ function closeAchievementPopup() {
     popup.classList.add('tw-hidden');
     popup.querySelector('#achievementTitle').textContent = '';
     popup.querySelector('.credit-gain').textContent = '';
-    csrfFetch('/api/achievement-popup/mark-shown', { method: 'POST' });
+    csrfFetch('/api/achievement-popup/mark-shown', { method: 'POST' }).then(() => {
+      window.NEW_ACHIEVEMENTS = [];
+    });
   }, 300);
 }

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -49,6 +49,7 @@
       <a href="/privacidad" class="text-muted">Privacidad</a> ·
       <a href="/terminos" class="text-muted">Términos</a>
     </footer>
+    {% if current_user.is_authenticated and not config.ADMIN_INSTANCE %}
     <div class="achievement-popup tw-hidden" id="achievementPopup" role="dialog" aria-modal="true">
       <div class="popup-content bg-dark bg-opacity-75 text-white p-4 rounded-3 text-center shadow-lg">
         <h3>🏆 ¡Logro desbloqueado!</h3>
@@ -57,6 +58,7 @@
         <button class="btn btn-primary" id="closeAchievementBtn" aria-label="Cerrar logro desbloqueado">OK</button>
       </div>
     </div>
+    {% endif %}
     <div class="toast-container position-fixed bottom-0 end-0 p-3"></div>
     {% if request.path.startswith('/store') and 'store.view_cart' in current_app.view_functions %}
     <a href="{{ url_for('store.view_cart') }}" class="btn btn-primary rounded-circle position-fixed bottom-0 end-0 m-3 d-lg-none">
@@ -73,7 +75,19 @@
     <script src="{{ url_for('static', filename='js/feed_toggle.js') }}" defer></script>
     <script src="{{ url_for('static', filename='js/feed.js') }}"></script>
     <script>window.HAS_STORE = {{ 'true' if 'store.cart_count_api' in current_app.view_functions else 'false' }};</script>
-    <script>window.NEW_ACHIEVEMENTS = {{ NEW_ACHIEVEMENTS|tojson }};</script>
+    {% if current_user.is_authenticated %}
+    <script>
+      window.NEW_ACHIEVEMENTS = {{ NEW_ACHIEVEMENTS|tojson }};
+      const CURRENT_USER_ID = {{ current_user.id }};
+      window.CURRENT_USER_ID = CURRENT_USER_ID;
+    </script>
+    {% else %}
+    <script>
+      window.NEW_ACHIEVEMENTS = [];
+      const CURRENT_USER_ID = null;
+      window.CURRENT_USER_ID = null;
+    </script>
+    {% endif %}
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>
     {% block body_end %}{% endblock %}
 </body>


### PR DESCRIPTION
## Summary
- show achievement popup only for authenticated users
- expose CURRENT_USER_ID in base template
- check CURRENT_USER_ID before showing popup
- clear achievements only after mark-shown succeeds
- document changes

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685e534ea1008325af1e9b4f7939304a