### PR TITLE
Fix achievement popup session clearing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -348,3 +348,4 @@
 - Achievement popup only triggered when backend response includes "new_achievement"; DOMContentLoaded check removed and csrfFetch now handles showing popup automatically (PR achievement-popup-runtime).
 - Delegated close handler for achievement popup ensuring button works even if regenerated, and removing inline style on close (PR achievement-popup-delegate-close).
 - Popup overlay fully hidden with `d-none` when closed and restored on show to prevent blocking clicks (PR achievement-popup-display-fix).
+- Achievement popup clears `session['new_achievements']` on mark-shown and `base.html` only defines `NEW_ACHIEVEMENTS` for logged-in users (PR achievement-popup-session-clear).

--- a/crunevo/routes/achievement_routes.py
+++ b/crunevo/routes/achievement_routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint
+from flask import Blueprint, session, jsonify
 from flask_login import login_required, current_user
 from crunevo.extensions import db
 from crunevo.models import AchievementPopup
@@ -13,4 +13,5 @@ def mark_achievement_popup_seen():
         {"shown": True}
     )
     db.session.commit()
-    return "", 204
+    session["new_achievements"] = []
+    return jsonify({"success": True})

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -83,8 +83,6 @@
     </script>
     {% else %}
     <script>
-      window.NEW_ACHIEVEMENTS = [];
-      const CURRENT_USER_ID = null;
       window.CURRENT_USER_ID = null;
     </script>
     {% endif %}


### PR DESCRIPTION
## Summary
- clear `session['new_achievements']` when marking popup as seen and return JSON
- only define `NEW_ACHIEVEMENTS` on `base.html` for logged-in users
- document change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685ee24f6a808325970e800887c8e85b