### PR TITLE
Fix achievement popup persistence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,3 +349,4 @@
 - Delegated close handler for achievement popup ensuring button works even if regenerated, and removing inline style on close (PR achievement-popup-delegate-close).
 - Popup overlay fully hidden with `d-none` when closed and restored on show to prevent blocking clicks (PR achievement-popup-display-fix).
 - Achievement popup clears `session['new_achievements']` on mark-shown and `base.html` only defines `NEW_ACHIEVEMENTS` for logged-in users (PR achievement-popup-session-clear).
+- Popup shown only once: JS waits for successful mark-shown response before clearing `window.NEW_ACHIEVEMENTS` and base template omits the variable when empty (PR achievement-popup-once).

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -654,8 +654,10 @@ function closeAchievementPopup() {
     popup.removeAttribute('style');
     popup.querySelector('#achievementTitle').textContent = '';
     popup.querySelector('.credit-gain').textContent = '';
-    csrfFetch('/api/achievement-popup/mark-shown', { method: 'POST' }).then(() =>
-      (window.NEW_ACHIEVEMENTS = [])
-    );
+    csrfFetch('/api/achievement-popup/mark-shown', { method: 'POST' }).then((r) => {
+      if (r.ok) {
+        window.NEW_ACHIEVEMENTS = [];
+      }
+    });
   }, 300);
 }

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -77,9 +77,11 @@
     <script>window.HAS_STORE = {{ 'true' if 'store.cart_count_api' in current_app.view_functions else 'false' }};</script>
     {% if current_user.is_authenticated %}
     <script>
-      window.NEW_ACHIEVEMENTS = {{ NEW_ACHIEVEMENTS|tojson }};
       const CURRENT_USER_ID = {{ current_user.id }};
       window.CURRENT_USER_ID = CURRENT_USER_ID;
+      {% if NEW_ACHIEVEMENTS %}
+      window.NEW_ACHIEVEMENTS = {{ NEW_ACHIEVEMENTS|tojson }};
+      {% endif %}
     </script>
     {% else %}
     <script>


### PR DESCRIPTION
## Summary
- hide NEW_ACHIEVEMENTS script when empty and preserve CURRENT_USER_ID
- clear new achievements only when mark-shown call succeeds
- document change in AGENTS guidelines

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685ee57879bc8325a018eeaf044009e7