### PR TITLE
Fix achievement popup session cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,3 +350,4 @@
 - Popup overlay fully hidden with `d-none` when closed and restored on show to prevent blocking clicks (PR achievement-popup-display-fix).
 - Achievement popup clears `session['new_achievements']` on mark-shown and `base.html` only defines `NEW_ACHIEVEMENTS` for logged-in users (PR achievement-popup-session-clear).
 - Popup shown only once: JS waits for successful mark-shown response before clearing `window.NEW_ACHIEVEMENTS` and base template omits the variable when empty (PR achievement-popup-once).
+- Session cleanup reinforced: before_app_request clears `session['new_achievements']` when no pending records and mark-shown logs username (PR achievement-popup-session-cleanup).

--- a/crunevo/routes/achievement_routes.py
+++ b/crunevo/routes/achievement_routes.py
@@ -6,9 +6,20 @@ from crunevo.models import AchievementPopup
 ach_bp = Blueprint("achievement_popup", __name__)
 
 
+@ach_bp.before_app_request
+def clear_session_new_achievements():
+    if current_user.is_authenticated:
+        has_pending = AchievementPopup.query.filter_by(
+            user_id=current_user.id, shown=False
+        ).count()
+        if not has_pending:
+            session.pop("new_achievements", None)
+
+
 @ach_bp.route("/api/achievement-popup/mark-shown", methods=["POST"])
 @login_required
 def mark_achievement_popup_seen():
+    print("\U0001F9E0 Marcar logros como vistos para:", current_user.username)
     AchievementPopup.query.filter_by(user_id=current_user.id, shown=False).update(
         {"shown": True}
     )


### PR DESCRIPTION
## Summary
- clear `session['new_achievements']` if no pending popups via `before_app_request`
- log user when marking achievement popup as shown
- document change in AGENTS guidelines

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685f112192248325879ae35e1002c1b7