### PR TITLE
Fix achievement popup mark-shown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -352,3 +352,4 @@
 - Popup shown only once: JS waits for successful mark-shown response before clearing `window.NEW_ACHIEVEMENTS` and base template omits the variable when empty (PR achievement-popup-once).
 - Session cleanup reinforced: before_app_request clears `session['new_achievements']` when no pending records and mark-shown logs username (PR achievement-popup-session-cleanup).
 - Popup state reset on `beforeunload` and `showAchievementPopup` checks `NEW_ACHIEVEMENTS`; session log prints current value (PR achievement-popup-beforeunload).
+- Backend mark-shown endpoint loops through each record and handles errors to ensure achievements are updated (PR achievement-popup-mark-shown-fix).

--- a/crunevo/routes/achievement_routes.py
+++ b/crunevo/routes/achievement_routes.py
@@ -23,10 +23,19 @@ def clear_session_new_achievements():
 @ach_bp.route("/api/achievement-popup/mark-shown", methods=["POST"])
 @login_required
 def mark_achievement_popup_seen():
-    print("\U0001F9E0 Marcar logros como vistos para:", current_user.username)
-    AchievementPopup.query.filter_by(user_id=current_user.id, shown=False).update(
-        {"shown": True}
-    )
-    db.session.commit()
-    session["new_achievements"] = []
-    return jsonify({"success": True})
+    """Mark all pending achievement popups as shown for the current user."""
+    try:
+        print("\U0001F9E0 Marcar logros como vistos para:", current_user.username)
+        popups = AchievementPopup.query.filter_by(
+            user_id=current_user.id, shown=False
+        ).all()
+        if not popups:
+            return jsonify({"success": True, "message": "No hay logros pendientes"})
+        for popup in popups:
+            popup.shown = True
+        db.session.commit()
+        session.pop("new_achievements", None)
+        return jsonify({"success": True})
+    except Exception as e:  # pragma: no cover - log unexpected errors
+        print("\u26a0\ufe0f Error al marcar logros como vistos:", e)
+        return jsonify({"success": False, "error": str(e)}), 500


### PR DESCRIPTION
## Summary
- improve `/api/achievement-popup/mark-shown` so it updates each record and commits with error handling
- document change in AGENTS log

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685f1a2e787083258114b550fde05f66