### PR TITLE
Fix achievement popup context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -352,3 +352,5 @@
 - Popup shown only once: JS waits for successful mark-shown response before clearing `window.NEW_ACHIEVEMENTS` and base template omits the variable when empty (PR achievement-popup-once).
 - Session cleanup reinforced: before_app_request clears `session['new_achievements']` when no pending records and mark-shown logs username (PR achievement-popup-session-cleanup).
 - Popup state reset on `beforeunload` and `showAchievementPopup` checks `NEW_ACHIEVEMENTS`; session log prints current value (PR achievement-popup-beforeunload).
+- Backend mark-shown endpoint loops through each record and handles errors to ensure achievements are updated (PR achievement-popup-mark-shown-fix).
+- Context processor serializes pending achievements and returns an empty list when none to avoid regenerating `window.NEW_ACHIEVEMENTS` (PR achievement-popup-context-fix).

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -25,7 +25,7 @@ def create_app():
     @app.context_processor
     def inject_globals():
         from .constants import ACHIEVEMENT_DETAILS
-        from .models import Note, Notification, AchievementPopup, Achievement
+        from .models import Note, Notification, AchievementPopup
         from flask import session
 
         latest_sidebar_notes = (
@@ -53,17 +53,22 @@ def create_app():
             urgent_count = sum(1 for c in counts.values() if c >= 3)
 
         if current_user.is_authenticated:
-            new_achievements = (
-                db.session.query(Achievement)
-                .join(
-                    AchievementPopup, Achievement.id == AchievementPopup.achievement_id
-                )
-                .filter(
-                    AchievementPopup.user_id == current_user.id,
-                    AchievementPopup.shown.is_(False),
-                )
-                .all()
-            )
+            popups = AchievementPopup.query.filter_by(
+                user_id=current_user.id, shown=False
+            ).all()
+            if popups:
+                new_achievements = [
+                    {
+                        "id": p.achievement.id,
+                        "code": p.achievement.code,
+                        "title": p.achievement.title,
+                        "credit_reward": p.achievement.credit_reward,
+                    }
+                    for p in popups
+                    if p.achievement
+                ]
+            else:
+                new_achievements = []
 
         return {
             "PUBLIC_BASE_URL": app.config.get("PUBLIC_BASE_URL"),

--- a/crunevo/routes/achievement_routes.py
+++ b/crunevo/routes/achievement_routes.py
@@ -23,10 +23,19 @@ def clear_session_new_achievements():
 @ach_bp.route("/api/achievement-popup/mark-shown", methods=["POST"])
 @login_required
 def mark_achievement_popup_seen():
-    print("\U0001F9E0 Marcar logros como vistos para:", current_user.username)
-    AchievementPopup.query.filter_by(user_id=current_user.id, shown=False).update(
-        {"shown": True}
-    )
-    db.session.commit()
-    session["new_achievements"] = []
-    return jsonify({"success": True})
+    """Mark all pending achievement popups as shown for the current user."""
+    try:
+        print("\U0001F9E0 Marcar logros como vistos para:", current_user.username)
+        popups = AchievementPopup.query.filter_by(
+            user_id=current_user.id, shown=False
+        ).all()
+        if not popups:
+            return jsonify({"success": True, "message": "No hay logros pendientes"})
+        for popup in popups:
+            popup.shown = True
+        db.session.commit()
+        session.pop("new_achievements", None)
+        return jsonify({"success": True})
+    except Exception as e:  # pragma: no cover - log unexpected errors
+        print("\u26a0\ufe0f Error al marcar logros como vistos:", e)
+        return jsonify({"success": False, "error": str(e)}), 500


### PR DESCRIPTION
## Summary
- serialize pending achievements in context processor and default to empty list
- document change in AGENTS log

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685f1a2e787083258114b550fde05f66