### PR TITLE
Fix achievement popup auto update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -355,3 +355,4 @@
 - Backend mark-shown endpoint loops through each record and handles errors to ensure achievements are updated (PR achievement-popup-mark-shown-fix).
 - Context processor serializes pending achievements and returns an empty list when none to avoid regenerating `window.NEW_ACHIEVEMENTS` (PR achievement-popup-context-fix).
 - Context processor syncs session['new_achievements'] and JS clears global variable after marking shown (PR achievement-popup-session-reset).
+- Popup now shown on DOMContentLoaded only when NEW_ACHIEVEMENTS has items and mark-shown updates immediately via API (PR achievement-popup-auto-mark)

--- a/crunevo/routes/achievement_routes.py
+++ b/crunevo/routes/achievement_routes.py
@@ -26,13 +26,10 @@ def mark_achievement_popup_seen():
     """Mark all pending achievement popups as shown for the current user."""
     try:
         print("\U0001F9E0 Marcar logros como vistos para:", current_user.username)
-        popups = AchievementPopup.query.filter_by(
-            user_id=current_user.id, shown=False
-        ).all()
-        if not popups:
+        q = AchievementPopup.query.filter_by(user_id=current_user.id, shown=False)
+        if q.count() == 0:
             return jsonify({"success": True, "message": "No hay logros pendientes"})
-        for popup in popups:
-            popup.shown = True
+        q.update({"shown": True}, synchronize_session=False)
         db.session.commit()
         session.pop("new_achievements", None)
         return jsonify({"success": True})

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -261,6 +261,9 @@ document.addEventListener('DOMContentLoaded', () => {
   if (navigator.hardwareConcurrency && navigator.hardwareConcurrency <= 4) {
     document.body.classList.add('no-anim');
   }
+  if (window.NEW_ACHIEVEMENTS && window.NEW_ACHIEVEMENTS.length > 0) {
+    showAchievementPopup(window.NEW_ACHIEVEMENTS[0]);
+  }
   if (sessionStorage.getItem('notifHighlight')) {
     sessionStorage.removeItem('notifHighlight');
     document.body.classList.add('notification-highlight');
@@ -639,6 +642,13 @@ function showAchievementPopup(data) {
   content.classList.remove('animate-fade-out-up');
   content.classList.add('animate-fade-in-down');
 
+  // Mark achievements as shown immediately after displaying
+  csrfFetch('/api/achievement-popup/mark-shown', { method: 'POST' }).then((r) => {
+    if (r.ok) {
+      window.NEW_ACHIEVEMENTS = undefined;
+    }
+  });
+
   const closeBtn = popup.querySelector('#closeAchievementBtn');
   if (closeBtn) {
     closeBtn.onclick = () => closeAchievementPopup();
@@ -655,11 +665,6 @@ function closeAchievementPopup() {
     popup.removeAttribute('style');
     popup.querySelector('#achievementTitle').textContent = '';
     popup.querySelector('.credit-gain').textContent = '';
-    csrfFetch('/api/achievement-popup/mark-shown', { method: 'POST' }).then((r) => {
-      if (r.ok) {
-        window.NEW_ACHIEVEMENTS = undefined;
-      }
-    });
   }, 300);
 }
 


### PR DESCRIPTION
## Summary
- ensure achievement popup shows only when NEW_ACHIEVEMENTS exist
- mark achievements as shown immediately when popup appears
- simplify mark-shown route with bulk update
- document latest changes in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685f2df5acf08325be95579779687a3c