### PR TITLE
Fix indentation in create_app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -358,3 +358,4 @@
 - Popup now shown on DOMContentLoaded only when NEW_ACHIEVEMENTS has items and mark-shown updates immediately via API (PR achievement-popup-auto-mark)
 - Verified new design commit d3b38ae; reviewed templates and CSS, no conflicts detected. make test shows failing BuildError in routes.
 - Fixed missing endpoints for navbar links: added legacy aliases for feed and ranking blueprints and updated notifications link (PR feed-route-aliases).
+- Fixed indentation in create_app to resolve deployment error (hotfix indentation).

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -216,7 +216,7 @@ def create_app():
         )
         app.register_blueprint(store_bp)
         app.register_blueprint(chat_bp)
-    app.register_blueprint(search_bp)
+        app.register_blueprint(search_bp)
         app.register_blueprint(ia_bp)
         app.register_blueprint(noti_bp)
         app.register_blueprint(ach_bp)


### PR DESCRIPTION
## Summary
- fix indentation error in `create_app` that caused deployment failure
- document the update in `AGENTS.md`

## Testing
- `make fmt` *(fails: E712 Avoid equality comparisons)*
- `make test` *(fails: E712 Avoid equality comparisons)*

------
https://chatgpt.com/codex/tasks/task_e_685f41d41ff4832583d678ed44cbc1b6