### PR TITLE
Fix boolean migration update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -359,3 +359,4 @@
 - Verified new design commit d3b38ae; reviewed templates and CSS, no conflicts detected. make test shows failing BuildError in routes.
 - Fixed missing endpoints for navbar links: added legacy aliases for feed and ranking blueprints and updated notifications link (PR feed-route-aliases).
 - Fixed indentation in create_app to resolve deployment error (hotfix indentation).
+- Updated enhanced_chat_system migration to set booleans using `false` instead of `0` to fix upgrade error (hotfix boolean-migration).

--- a/migrations/versions/add_enhanced_chat_system.py
+++ b/migrations/versions/add_enhanced_chat_system.py
@@ -27,7 +27,9 @@ def upgrade():
         batch_op.alter_column('content', nullable=False)
     
     # Update existing data
-    op.execute("UPDATE message SET is_global = 0, is_read = 0, is_deleted = 0 WHERE is_global IS NULL")
+    op.execute(
+        "UPDATE message SET is_global = false, is_read = false, is_deleted = false WHERE is_global IS NULL"
+    )
     
     # Create ChatRoom table
     op.create_table('chat_room',


### PR DESCRIPTION
## Summary
- ensure booleans are updated with `false` literals in enhanced chat migration
- document change in `AGENTS.md`

## Testing
- `make fmt` *(fails: 21 E712 errors remain)*
- `make test` *(fails: ruff E712 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685f481d770c8325a8b30df610cc52b2