### PR TITLE
Fix clubot blueprint and migrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -362,3 +362,4 @@
 - Updated enhanced_chat_system migration to set booleans using `false` instead of `0` to fix upgrade error (hotfix boolean-migration).
 - Sidebar feed links now use tailwind text color classes for better readability (PR feed-sidebar-color).
 - Fixed ambiguous join in chat global view to avoid AmbiguousForeignKeysError (hotfix chat-active-users-join).
+- Registered clubot and saved blueprints for public instance and removed unreachable code; added merge migration to unify heads (hotfix clubot-blueprint).

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -155,6 +155,8 @@ def create_app():
     from .routes.forum_routes import forum_bp
     from .routes.event_routes import event_bp
     from .routes.about_routes import about_bp
+    from .routes.clubot_routes import clubot_bp
+    from .routes.saved_routes import saved_bp
 
     @app.route("/")
     def home_redirect():
@@ -230,6 +232,8 @@ def create_app():
         app.register_blueprint(forum_bp)
         app.register_blueprint(event_bp)
         app.register_blueprint(about_bp)
+        app.register_blueprint(clubot_bp)
+        app.register_blueprint(saved_bp)
         app.register_blueprint(errors_bp)
         app.register_blueprint(admin_blocker_bp)
         if testing_env:
@@ -268,20 +272,3 @@ def create_app():
         app.logger.info("DB=%s", app.config.get("SQLALCHEMY_DATABASE_URI"))
 
     return app
-
-# Register blueprints
-    from .routes.club_routes import club_bp
-    from .routes.forum_routes import forum_bp
-    from .routes.event_routes import event_bp
-    from .routes.about_routes import about_bp
-    from .routes.certificate_routes import cert_bp
-    from .routes.clubot_routes import clubot_bp
-    from .routes.saved_routes import saved_bp
-
-    app.register_blueprint(club_bp)
-    app.register_blueprint(forum_bp)
-    app.register_blueprint(event_bp)
-    app.register_blueprint(about_bp)
-    app.register_blueprint(cert_bp)
-    app.register_blueprint(clubot_bp)
-    app.register_blueprint(saved_bp)

--- a/migrations/versions/3539c14f3a41_merge_third_phase_heads.py
+++ b/migrations/versions/3539c14f3a41_merge_third_phase_heads.py
@@ -1,0 +1,18 @@
+"""Merge third_phase_2024 into 2654d90049d2
+
+Revision ID: 3539c14f3a41
+Revises: 2654d90049d2, third_phase_2024
+Create Date: 2025-06-28 00:00:00.000000
+"""
+
+# revision identifiers, used by Alembic.
+revision = '3539c14f3a41'
+down_revision = ('2654d90049d2', 'third_phase_2024')
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    pass
+
+def downgrade():
+    pass


### PR DESCRIPTION
## Summary
- register `clubot` and `saved` blueprints in the public instance
- remove unreachable blueprint registrations
- add merge migration to unify alembic heads

## Testing
- `make fmt` *(fails: E712 etc.)*
- `make test` *(fails: ruff style errors)*

------
https://chatgpt.com/codex/tasks/task_e_685f83de31d483258a6dac5016626af7