### PR TITLE
Fix notes link BuildError

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -365,3 +365,4 @@
 - Registered Crunebot and saved blueprints for public instance and removed unreachable code; added merge migration to unify heads (hotfix crunebot-blueprint).
 - Renamed the assistant blueprint to Crunebot across routes, templates and attachments (PR crunebot-rename).
 - Fixed sidebar credits display and search link endpoint to prevent template errors (PR feed-sidebar-credits-fix).
+- Updated notes links to use 'notes.list_notes' in bottom nav, sidebar and saved list to avoid BuildError (PR notes-list-alias-fix).

--- a/crunevo/templates/components/mobile_bottom_nav.html
+++ b/crunevo/templates/components/mobile_bottom_nav.html
@@ -22,10 +22,10 @@
         </a>
 
         <!-- Notes -->
-        <a href="{{ url_for('notes.list') }}" 
-           class="nav-item {{ 'active' if request.endpoint == 'notes.list' }}">
+        <a href="{{ url_for('notes.list_notes') }}"
+           class="nav-item {{ 'active' if request.endpoint == 'notes.list_notes' }}">
           <div class="nav-icon">
-            <i class="bi bi-journal{{ '-text-fill' if request.endpoint == 'notes.list' }}"></i>
+            <i class="bi bi-journal{{ '-text-fill' if request.endpoint == 'notes.list_notes' }}"></i>
           </div>
           <span class="nav-label">Apuntes</span>
         </a>

--- a/crunevo/templates/components/sidebar_left_feed.html
+++ b/crunevo/templates/components/sidebar_left_feed.html
@@ -56,7 +56,7 @@
         </li>
         
         <li>
-          <a href="{{ url_for('notes.list') }}" class="nav-link {{ 'active' if request.endpoint == 'notes.list' }}">
+          <a href="{{ url_for('notes.list_notes') }}" class="nav-link {{ 'active' if request.endpoint == 'notes.list_notes' }}">
             <i class="bi bi-journal-text"></i>
             <span class="fw-semibold">Apuntes</span>
             <span class="badge bg-primary rounded-pill ms-auto">{{ current_user.notes.count() if current_user.notes else 0 }}</span>

--- a/crunevo/templates/saved/list.html
+++ b/crunevo/templates/saved/list.html
@@ -85,7 +85,7 @@
                         <i class="bi bi-bookmark text-muted" style="font-size: 4rem;"></i>
                         <h4 class="text-muted mt-3">No tienes apuntes guardados</h4>
                         <p class="text-muted">Explora los apuntes y guarda los que más te interesen</p>
-                        <a href="{{ url_for('notes.list') }}" class="btn btn-primary">
+                        <a href="{{ url_for('notes.list_notes') }}" class="btn btn-primary">
                             <i class="bi bi-search me-1"></i>
                             Explorar Apuntes
                         </a>


### PR DESCRIPTION
## Summary
- update notes links in nav/sidebar/saved templates to use `notes.list_notes`
- document update in AGENTS.md

## Testing
- `make fmt` *(fails: ruff found 24 errors)*
- `make test` *(fails: ruff found 24 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685f9456b2908325a233221611018a48