### PR TITLE
Fix mobile nav notifications link and notes count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -366,3 +366,4 @@
 - Renamed the assistant blueprint to Crunebot across routes, templates and attachments (PR crunebot-rename).
 - Fixed sidebar credits display and search link endpoint to prevent template errors (PR feed-sidebar-credits-fix).
 - Updated notes links to use 'notes.list_notes' in bottom nav, sidebar and saved list to avoid BuildError (PR notes-list-alias-fix).
+- Fixed bottom nav notifications link to 'noti.ver_notificaciones' and used `|length` for notes count in sidebar (hotfix notifications-link-count).

--- a/crunevo/templates/components/mobile_bottom_nav.html
+++ b/crunevo/templates/components/mobile_bottom_nav.html
@@ -31,10 +31,10 @@
         </a>
 
         <!-- Notifications -->
-        <a href="{{ url_for('notifications.lista') }}" 
-           class="nav-item position-relative {{ 'active' if request.endpoint == 'notifications.lista' }}">
+        <a href="{{ url_for('noti.ver_notificaciones') }}"
+           class="nav-item position-relative {{ 'active' if request.endpoint == 'noti.ver_notificaciones' }}">
           <div class="nav-icon">
-            <i class="bi bi-bell{{ '-fill' if request.endpoint == 'notifications.lista' }}"></i>
+            <i class="bi bi-bell{{ '-fill' if request.endpoint == 'noti.ver_notificaciones' }}"></i>
             {% if current_user.is_authenticated %}
             <span id="mobileNotificationBadge" 
                   class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger notification-badge">

--- a/crunevo/templates/components/sidebar_left_feed.html
+++ b/crunevo/templates/components/sidebar_left_feed.html
@@ -31,7 +31,7 @@
         </div>
         <div class="col-4">
           <div class="stat-item">
-            <div class="fw-bold text-info">{{ current_user.notes.count() if current_user.notes else 0 }}</div>
+            <div class="fw-bold text-info">{{ current_user.notes|length }}</div>
             <div class="small text-muted">Apuntes</div>
           </div>
         </div>
@@ -59,7 +59,7 @@
           <a href="{{ url_for('notes.list_notes') }}" class="nav-link {{ 'active' if request.endpoint == 'notes.list_notes' }}">
             <i class="bi bi-journal-text"></i>
             <span class="fw-semibold">Apuntes</span>
-            <span class="badge bg-primary rounded-pill ms-auto">{{ current_user.notes.count() if current_user.notes else 0 }}</span>
+            <span class="badge bg-primary rounded-pill ms-auto">{{ current_user.notes|length }}</span>
           </a>
         </li>
         


### PR DESCRIPTION
## Summary
- use `|length` instead of `.count()` for current user's notes
- fix notifications link in mobile bottom nav to match blueprint
- document changes in `AGENTS.md`

## Testing
- `make fmt` *(fails: Ruff found remaining issues)*
- `make test` *(fails: Ruff reported lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685f96deb96c8325bc8baec272ea15fc