### PR TITLE
Fix profile link endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -367,3 +367,4 @@
 - Fixed sidebar credits display and search link endpoint to prevent template errors (PR feed-sidebar-credits-fix).
 - Updated notes links to use 'notes.list_notes' in bottom nav, sidebar and saved list to avoid BuildError (PR notes-list-alias-fix).
 - Fixed bottom nav notifications link to 'noti.ver_notificaciones' and used `|length` for notes count in sidebar (hotfix notifications-link-count).
+- Updated profile links to use 'auth.perfil' instead of deprecated 'auth.profile' to avoid BuildError (hotfix profile-link-fix).

--- a/crunevo/templates/components/mobile_bottom_nav.html
+++ b/crunevo/templates/components/mobile_bottom_nav.html
@@ -46,8 +46,8 @@
         </a>
 
         <!-- Profile -->
-        <a href="{{ url_for('auth.profile') }}" 
-           class="nav-item {{ 'active' if request.endpoint == 'auth.profile' }}">
+        <a href="{{ url_for('auth.perfil') }}"
+           class="nav-item {{ 'active' if request.endpoint == 'auth.perfil' }}">
           <div class="nav-icon">
             {% if current_user.is_authenticated %}
             <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" 

--- a/crunevo/templates/components/sidebar_left_feed.html
+++ b/crunevo/templates/components/sidebar_left_feed.html
@@ -49,7 +49,7 @@
         </li>
         
         <li>
-          <a href="{{ url_for('auth.profile') }}" class="nav-link {{ 'active' if request.endpoint == 'auth.profile' }}">
+          <a href="{{ url_for('auth.perfil') }}" class="nav-link {{ 'active' if request.endpoint == 'auth.perfil' }}">
             <i class="bi bi-person-circle"></i>
             <span class="fw-semibold">Mi Perfil</span>
           </a>


### PR DESCRIPTION
## Summary
- use `auth.perfil` endpoint for sidebar and mobile navigation links
- document profile-link fix in AGENTS log

## Testing
- `make fmt` *(fails: E712 errors)*
- `make test` *(fails: E712 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685f98c3920c83259d2ddb1b9bf043fd