### PR TITLE
Fix forum link & referral ranking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -368,3 +368,4 @@
 - Updated notes links to use 'notes.list_notes' in bottom nav, sidebar and saved list to avoid BuildError (PR notes-list-alias-fix).
 - Fixed bottom nav notifications link to 'noti.ver_notificaciones' and used `|length` for notes count in sidebar (hotfix notifications-link-count).
 - Updated profile links to use 'auth.perfil' instead of deprecated 'auth.profile' to avoid BuildError (hotfix profile-link-fix).
+- Replaced forum sidebar link with 'forum.list_questions' and wrapped referral ranking query in try/except; achievement session log now uses logger (PR logs-bugfixes).

--- a/crunevo/templates/components/sidebar_left_feed.html
+++ b/crunevo/templates/components/sidebar_left_feed.html
@@ -64,7 +64,7 @@
         </li>
         
         <li>
-          <a href="{{ url_for('forum.list') }}" class="nav-link {{ 'active' if request.endpoint == 'forum.list' }}">
+          <a href="{{ url_for('forum.list_questions') }}" class="nav-link {{ 'active' if request.endpoint == 'forum.list_questions' }}">
             <i class="bi bi-chat-square-dots"></i>
             <span class="fw-semibold">Foro</span>
           </a>


### PR DESCRIPTION
## Summary
- fix `forum.list` BuildError in sidebar
- avoid crash if referrals table missing
- reduce achievement popup spam logging
- document fixes in `AGENTS.md`

## Testing
- `ruff check crunevo/routes/achievement_routes.py crunevo/routes/ranking_routes.py`
- `black crunevo/routes/achievement_routes.py crunevo/routes/ranking_routes.py`
- `make fmt` *(fails: 64 errors)*
- `make test` *(fails: 4 failed, 71 passed)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f9d8edcfc8325923f1e452a72e5a7