### PR TITLE
Fix club sidebar link to resolve BuildError

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -369,3 +369,4 @@
 - Fixed bottom nav notifications link to 'noti.ver_notificaciones' and used `|length` for notes count in sidebar (hotfix notifications-link-count).
 - Updated profile links to use 'auth.perfil' instead of deprecated 'auth.profile' to avoid BuildError (hotfix profile-link-fix).
 - Replaced forum sidebar link with 'forum.list_questions' and wrapped referral ranking query in try/except; achievement session log now uses logger (PR logs-bugfixes).
+- Corrected sidebar club link to use 'club.list_clubs' and avoid BuildError (hotfix club-link-fix).

--- a/crunevo/templates/components/sidebar_left_feed.html
+++ b/crunevo/templates/components/sidebar_left_feed.html
@@ -71,7 +71,7 @@
         </li>
         
         <li>
-          <a href="{{ url_for('club.list') }}" class="nav-link {{ 'active' if request.endpoint == 'club.list' }}">
+          <a href="{{ url_for('club.list_clubs') }}" class="nav-link {{ 'active' if request.endpoint == 'club.list_clubs' }}">
             <i class="bi bi-people"></i>
             <span class="fw-semibold">Clubes</span>
           </a>


### PR DESCRIPTION
## Summary
- fix sidebar to reference `club.list_clubs`
- document change in AGENTS.md

## Testing
- `make fmt` *(fails: ruff found 24 errors)*
- `make test` *(fails: ruff found 64 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685fa180d42083258d8ca3edffbe6ac4