### PR TITLE
Fix search notes function and event link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -370,3 +370,4 @@
 - Updated profile links to use 'auth.perfil' instead of deprecated 'auth.profile' to avoid BuildError (hotfix profile-link-fix).
 - Replaced forum sidebar link with 'forum.list_questions' and wrapped referral ranking query in try/except; achievement session log now uses logger (PR logs-bugfixes).
 - Corrected sidebar club link to use 'club.list_clubs' and avoid BuildError (hotfix club-link-fix).
+- Fixed sidebar event link and refactored search notes to use existing fields (hotfix search-notes-fields).

--- a/crunevo/templates/components/sidebar_left_feed.html
+++ b/crunevo/templates/components/sidebar_left_feed.html
@@ -78,7 +78,7 @@
         </li>
         
         <li>
-          <a href="{{ url_for('event.list') }}" class="nav-link {{ 'active' if request.endpoint == 'event.list' }}">
+          <a href="{{ url_for('event.list_events') }}" class="nav-link {{ 'active' if request.endpoint == 'event.list_events' }}">
             <i class="bi bi-calendar-event"></i>
             <span class="fw-semibold">Eventos</span>
           </a>


### PR DESCRIPTION
## Summary
- adjust `search_notes` to query existing fields
- link sidebar Events to `event.list_events`
- update AGENTS log

## Testing
- `make fmt` *(fails: E712 errors)*
- `make test` *(fails: E712 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685fa3e6ebc08325a8b75fb08f810970