### PR TITLE
Fix store template links to existing endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -371,3 +371,4 @@
 - Replaced forum sidebar link with 'forum.list_questions' and wrapped referral ranking query in try/except; achievement session log now uses logger (PR logs-bugfixes).
 - Corrected sidebar club link to use 'club.list_clubs' and avoid BuildError (hotfix club-link-fix).
 - Fixed sidebar event link and refactored search notes to use existing fields (hotfix search-notes-fields).
+- Fixed store links pointing to deprecated endpoints in navbar, feed sidebar and store.html (hotfix store-endpoint-fix).

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -28,9 +28,9 @@
             <i class="bi bi-fire me-1"></i>Trending
           </a>
         </li>
-        {% if 'store.store' in current_app.view_functions %}
+        {% if 'store.store_index' in current_app.view_functions %}
         <li class="nav-item">
-          <a class="nav-link" href="{{ url_for('store.store') }}">
+          <a class="nav-link" href="{{ url_for('store.store_index') }}">
             <i class="bi bi-shop me-1"></i>Tienda
           </a>
         </li>

--- a/crunevo/templates/components/sidebar_left_feed.html
+++ b/crunevo/templates/components/sidebar_left_feed.html
@@ -85,7 +85,7 @@
         </li>
         
         <li>
-          <a href="{{ url_for('store.store') }}" class="nav-link {{ 'active' if request.endpoint == 'store.store' }}">
+          <a href="{{ url_for('store.store_index') }}" class="nav-link {{ 'active' if request.endpoint == 'store.store_index' }}">
             <i class="bi bi-shop"></i>
             <span class="fw-semibold">Tienda</span>
             {% if session.get('cart_count', 0) > 0 %}

--- a/crunevo/templates/store/store.html
+++ b/crunevo/templates/store/store.html
@@ -61,7 +61,7 @@
       <div class="d-flex gap-3 overflow-auto pb-3" style="scroll-snap-type: x mandatory;">
         {% for product in featured_products %}
         <div class="featured-card flex-shrink-0" style="scroll-snap-align: start;">
-          <a href="{{ url_for('store.product_detail', id=product.id) }}" class="text-decoration-none">
+          <a href="{{ url_for('store.view_product', product_id=product.id) }}" class="text-decoration-none">
             <img src="{{ product.image_url or url_for('static', filename='img/default_product.png') }}" 
                  class="card-img-top" alt="{{ product.name }}" loading="lazy">
             <div class="p-2">
@@ -84,15 +84,15 @@
       {% for product in products %}
       <div class="col-lg-3 col-md-4 col-sm-6 col-12 mb-4 product-item" data-category="{{ product.category or 'general' }}">
         <div class="card product-card h-100">
-          <a href="{{ url_for('store.product_detail', id=product.id) }}" class="text-decoration-none">
+          <a href="{{ url_for('store.view_product', product_id=product.id) }}" class="text-decoration-none">
             <img src="{{ product.image_url or url_for('static', filename='img/default_product.png') }}" 
                  class="card-img-top" alt="{{ product.name }}" loading="lazy"
                  style="height: 200px; object-fit: cover;">
           </a>
           <div class="card-body d-flex flex-column">
             <h5 class="product-name mb-2">
-              <a href="{{ url_for('store.product_detail', id=product.id) }}" 
-                 class="text-decoration-none">{{ product.name }}</a>
+              <a href="{{ url_for('store.view_product', product_id=product.id) }}"
+                class="text-decoration-none">{{ product.name }}</a>
             </h5>
             <p class="product-desc text-muted flex-grow-1">{{ product.description or 'Sin descripción disponible' }}</p>
             


### PR DESCRIPTION
## Summary
- fix store link in navbar to use `store.store_index`
- update feed sidebar store link
- correct product links in store grid
- document changes in AGENTS log

## Testing
- `make fmt` (fails: E712 issues in unrelated files)
- `make test` (fails: ruff found 19 errors)

------
https://chatgpt.com/codex/tasks/task_e_685fa6c3661c83258143c78f100aaf4b