### PR TITLE
Fix missions sidebar link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -372,3 +372,4 @@
 - Corrected sidebar club link to use 'club.list_clubs' and avoid BuildError (hotfix club-link-fix).
 - Fixed sidebar event link and refactored search notes to use existing fields (hotfix search-notes-fields).
 - Fixed store links pointing to deprecated endpoints in navbar, feed sidebar and store.html (hotfix store-endpoint-fix).
+- Fixed missions sidebar link to use 'auth.perfil' with tab instead of nonexistent 'misiones.index' (hotfix missions-link).

--- a/crunevo/templates/components/sidebar_left_feed.html
+++ b/crunevo/templates/components/sidebar_left_feed.html
@@ -95,7 +95,7 @@
         </li>
         
         <li>
-          <a href="{{ url_for('misiones.index') }}" class="nav-link {{ 'active' if request.endpoint == 'misiones.index' }}">
+          <a href="{{ url_for('auth.perfil', tab='misiones') }}" class="nav-link {{ 'active' if request.endpoint == 'auth.perfil' and request.args.get('tab') == 'misiones' }}">
             <i class="bi bi-trophy"></i>
             <span class="fw-semibold">Misiones</span>
           </a>


### PR DESCRIPTION
## Summary
- fix `misiones.index` BuildError by linking to `auth.perfil` with `tab='misiones'`
- document change in `AGENTS.md`

## Testing
- `make fmt` *(fails: E712 and other lint errors)*
- `make test` *(fails: lint errors F401, E712, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685fa911d1b883259dfc43d9e222cc04