### PR TITLE
Fix AI chat sidebar link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -373,3 +373,4 @@
 - Fixed sidebar event link and refactored search notes to use existing fields (hotfix search-notes-fields).
 - Fixed store links pointing to deprecated endpoints in navbar, feed sidebar and store.html (hotfix store-endpoint-fix).
 - Fixed missions sidebar link to use 'auth.perfil' with tab instead of nonexistent 'misiones.index' (hotfix missions-link).
+- Fixed AI chat sidebar link to use 'ia.ia_chat' endpoint and avoid BuildError (hotfix ia-chat-link).

--- a/crunevo/templates/components/sidebar_left_feed.html
+++ b/crunevo/templates/components/sidebar_left_feed.html
@@ -109,7 +109,7 @@
         </li>
         
         <li>
-          <a href="{{ url_for('ia.chat') }}" class="nav-link {{ 'active' if request.endpoint == 'ia.chat' }}">
+          <a href="{{ url_for('ia.ia_chat') }}" class="nav-link {{ 'active' if request.endpoint == 'ia.ia_chat' }}">
             <i class="bi bi-robot"></i>
             <span class="fw-semibold">IA Chat</span>
             <span class="badge bg-success rounded-pill ms-auto">AI</span>

--- a/crunevo/templates/feed/sidebar_left_feed.html
+++ b/crunevo/templates/feed/sidebar_left_feed.html
@@ -20,7 +20,7 @@
   <a class="nav-link d-flex align-items-center gap-2" href="{{ url_for('auth.perfil', tab='misiones') }}" data-bs-toggle="tooltip" title="Misiones">
     <i class="bi bi-bullseye"></i><span>Misiones</span>
   </a>
-  <a class="nav-link d-flex align-items-center gap-2" href="{{ url_for('ia.chat') if 'ia.chat' in current_app.view_functions else '#' }}" data-bs-toggle="tooltip" title="Crubot">
+  <a class="nav-link d-flex align-items-center gap-2" href="{{ url_for('ia.ia_chat') if 'ia.ia_chat' in current_app.view_functions else '#' }}" data-bs-toggle="tooltip" title="Crubot">
     <i class="bi bi-robot"></i><span>Crubot</span>
   </a>
   <a class="nav-link d-flex align-items-center gap-2" href="#" data-bs-toggle="tooltip" title="Foro">


### PR DESCRIPTION
## Summary
- fix IA sidebar link BuildError by using correct `ia.ia_chat` endpoint
- record change in AGENTS log

## Testing
- `make fmt` *(fails: Found 47 errors (28 fixed, 19 remaining))*
- `make test` *(fails: Found 19 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685fab1d14748325b7b1ed48b70e9a7d