### PR TITLE
Fix blueprint aliases causing ImportErrors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -374,3 +374,4 @@
 - Fixed store links pointing to deprecated endpoints in navbar, feed sidebar and store.html (hotfix store-endpoint-fix).
 - Fixed missions sidebar link to use 'auth.perfil' with tab instead of nonexistent 'misiones.index' (hotfix missions-link).
 - Fixed AI chat sidebar link to use 'ia.ia_chat' endpoint and avoid BuildError (hotfix ia-chat-link).
+- Added aliases for achievements, notifications, onboarding and certificate blueprints to fix ImportError (PR blueprint-alias-fix).

--- a/crunevo/__init__.py
+++ b/crunevo/__init__.py
@@ -82,7 +82,7 @@ def create_app(config_class=Config):
     from crunevo.routes.ranking_routes import ranking_bp
     from crunevo.routes.achievement_routes import ach_bp as achievement_bp
     from crunevo.routes.missions_routes import missions_bp
-    from crunevo.routes.notifications_routes import notifications_bp
+    from crunevo.routes.notifications_routes import noti_bp as notifications_bp
     from crunevo.routes.onboarding_routes import onboarding_bp
     from crunevo.routes.about_routes import about_bp
     from crunevo.routes.ia_routes import ia_bp

--- a/crunevo/routes/achievement_routes.py
+++ b/crunevo/routes/achievement_routes.py
@@ -3,7 +3,10 @@ from flask_login import login_required, current_user
 from crunevo.extensions import db
 from crunevo.models import AchievementPopup
 
+
+# Define the blueprint and keep a short alias for backwards compatibility.
 achievement_bp = Blueprint("achievement_popup", __name__)
+ach_bp = achievement_bp
 
 @ach_bp.before_app_request
 def clear_session_new_achievements():

--- a/crunevo/routes/certificate_routes.py
+++ b/crunevo/routes/certificate_routes.py
@@ -7,6 +7,7 @@ from crunevo.utils.certificate_generator import generate_certificate_pdf, check_
 from datetime import datetime
 
 cert_bp = Blueprint('certificate', __name__)
+certificate_bp = cert_bp
 
 
 @cert_bp.route('/certificados')

--- a/crunevo/routes/onboarding_routes.py
+++ b/crunevo/routes/onboarding_routes.py
@@ -24,6 +24,7 @@ from crunevo.utils.audit import record_auth_event
 from sqlalchemy.exc import IntegrityError
 
 bp = Blueprint("onboarding", __name__, url_prefix="/onboarding")
+onboarding_bp = bp
 
 
 def generate_token():


### PR DESCRIPTION
## Summary
- alias the achievements blueprint for compatibility
- fix notifications blueprint import
- expose onboarding and certificate blueprint aliases
- document blueprint alias fix in AGENTS

## Testing
- `make fmt` *(fails: ruff found errors)*
- `make test` *(fails: ruff found errors)*


------
https://chatgpt.com/codex/tasks/task_e_685fc174775083258ea630202322d4f3