### PR TITLE
Fix feed routes and CSRF

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -375,3 +375,4 @@
 - Fixed missions sidebar link to use 'auth.perfil' with tab instead of nonexistent 'misiones.index' (hotfix missions-link).
 - Fixed AI chat sidebar link to use 'ia.ia_chat' endpoint and avoid BuildError (hotfix ia-chat-link).
 - Added aliases for achievements, notifications, onboarding and certificate blueprints to fix ImportError (PR blueprint-alias-fix).
+- Corregido feed: eliminado return duplicado, actualizado CSRF en index y enlaces en trending a feed.view_post (PR feed-fix-routes).

--- a/crunevo/routes/feed_routes.py
+++ b/crunevo/routes/feed_routes.py
@@ -233,7 +233,6 @@ def view_feed():
         create_feed_item_for_all("post", post.id)
         flash("Publicación creada")
         return redirect(url_for("feed.view_feed"))
-        return redirect(url_for("feed.view_feed"))
 
     categoria = request.args.get("categoria")
     query = FeedItem.query.filter_by(owner_id=current_user.id)
@@ -682,9 +681,10 @@ def api_quickfeed():
 def api_trending():
     """Return trending content filtered by type."""
     filter_opt = request.args.get("filter", "semana")
-    
+
     if filter_opt == "semana":
         from datetime import datetime, timedelta
+
         last_week = datetime.utcnow() - timedelta(days=7)
         posts = (
             Post.query.filter(Post.created_at > last_week)
@@ -694,6 +694,7 @@ def api_trending():
         )
     elif filter_opt == "mes":
         from datetime import datetime, timedelta
+
         last_month = datetime.utcnow() - timedelta(days=30)
         posts = (
             Post.query.filter(Post.created_at > last_month)
@@ -713,7 +714,7 @@ def api_trending():
         )
     else:
         posts = Post.query.order_by(Post.created_at.desc()).limit(10).all()
-    
+
     html = render_template("feed/_trending_posts.html", posts=posts)
     return jsonify({"html": html, "count": len(posts)})
 

--- a/crunevo/templates/feed/_trending_posts.html
+++ b/crunevo/templates/feed/_trending_posts.html
@@ -27,7 +27,7 @@
       <span class="text-danger"><i class="bi bi-heart-fill me-1"></i>{{ post.likes or 0 }}</span>
       <span class="text-primary"><i class="bi bi-chat me-1"></i>{{ post.comment_count or 0 }}</span>
     </div>
-    <a href="{{ url_for('feed.view_post_bp', post_id=post.id) }}" class="btn btn-sm btn-outline-primary rounded-pill">
+    <a href="{{ url_for('feed.view_post', post_id=post.id) }}" class="btn btn-sm btn-outline-primary rounded-pill">
       Ver publicación
     </a>
   </div>

--- a/crunevo/templates/feed/index.html
+++ b/crunevo/templates/feed/index.html
@@ -1,5 +1,6 @@
 
 {% extends "base.html" %}
+{% import "components/csrf.html" as csrf %}
 
 {% block title %}Feed - Crunevo{% endblock %}
 
@@ -19,7 +20,7 @@
         <div class="card mb-4 shadow-sm border-0 rounded-4 feed-create-card">
           <div class="card-body p-4">
             <form method="post" enctype="multipart/form-data" id="feedForm">
-              {{ csrf_token() }}
+              {{ csrf.csrf_field() }}
               <div class="d-flex gap-3 align-items-start">
                 <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" 
                      alt="Tu avatar" class="feed-avatar rounded-circle" width="48" height="48">
@@ -168,7 +169,7 @@
           <!-- Comments will be loaded here -->
         </div>
         <form id="commentForm" class="d-flex gap-2">
-          {{ csrf_token() }}
+          {{ csrf.csrf_field() }}
           <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" 
                class="rounded-circle" width="32" height="32">
           <input type="text" name="body" class="form-control rounded-pill" placeholder="Escribe un comentario..." required>

--- a/crunevo/templates/feed/trending.html
+++ b/crunevo/templates/feed/trending.html
@@ -229,7 +229,7 @@
                     <span class="text-danger"><i class="bi bi-heart-fill me-1"></i>{{ post.likes or 0 }}</span>
                     <span class="text-primary"><i class="bi bi-chat me-1"></i>{{ post.comment_count or 0 }}</span>
                   </div>
-                  <a href="{{ url_for('feed.view_post_bp', post_id=post.id) }}" class="btn btn-sm btn-outline-primary rounded-pill">
+                  <a href="{{ url_for('feed.view_post', post_id=post.id) }}" class="btn btn-sm btn-outline-primary rounded-pill">
                     Ver publicación
                   </a>
                 </div>


### PR DESCRIPTION
## Summary
- fix duplicate redirect in `view_feed`
- use CSRF macro in feed index page
- update trending templates to use `feed.view_post`
- document changes in `AGENTS.md`

## Testing
- `make fmt` (fails: 84 errors)
- `make test` (fails: 47 errors)

------
https://chatgpt.com/codex/tasks/task_e_68601d8158308325bd9a1414159a5b9f