### PR TITLE
Fix navbar courses link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -384,3 +384,4 @@
 - Fixed missing `render_template` import in `__init__.py` causing 500 errors (hotfix render-template-import).
 - Added `if_not_exists=True` and `if_exists=True` to `add_courses_system` migration to avoid duplicate table errors (hotfix courses-migration-fix).
 - Fixed navbar store link to use 'store.store_index' and avoid BuildError (hotfix navbar-store-link)
+- Fixed navbar courses link to use 'courses.list_courses' and avoid BuildError (hotfix navbar-courses-link)

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -68,7 +68,7 @@
           </li>
 
           <li class="nav-item">
-            <a class="nav-link" href="{{ url_for('course.list_courses') }}">
+            <a class="nav-link" href="{{ url_for('courses.list_courses') }}">
               <i class="bi bi-play-circle-fill me-1"></i>Cursos
             </a>
           </li>


### PR DESCRIPTION
## Summary
- fix courses link to use `courses.list_courses`
- document fix in AGENTS

## Testing
- `make fmt` *(fails: F841 and E712 issues)*
- `make test` *(fails: 22 errors from ruff)*

------
https://chatgpt.com/codex/tasks/task_e_686054da26ac8325b1987b1a38e41ff6