### PR TITLE
Fix navbar missions link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -386,3 +386,4 @@
 - Fixed navbar store link to use 'store.store_index' and avoid BuildError (hotfix navbar-store-link)
 - Fixed navbar courses link to use 'courses.list_courses' and avoid BuildError (hotfix navbar-courses-link)
 - Fixed notifications dropdown link to 'noti.ver_notificaciones' to resolve BuildError (hotfix notifications-dropdown-link).
+- Fixed navbar missions link to use 'auth.perfil' with tab to avoid BuildError (hotfix navbar-missions-link).

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -114,7 +114,7 @@
               <li><a class="dropdown-item" href="{{ url_for('auth.perfil') }}">
                 <i class="bi bi-person me-2"></i>Mi Perfil
               </a></li>
-              <li><a class="dropdown-item" href="{{ url_for('missions.index') }}">
+              <li><a class="dropdown-item" href="{{ url_for('auth.perfil', tab='misiones') }}">
                 <i class="bi bi-trophy me-2"></i>Misiones
               </a></li>
               <li><a class="dropdown-item" href="{{ url_for('saved.list') }}">


### PR DESCRIPTION
## Summary
- fix BuildError linking to nonexistent missions index
- document navbar fix in AGENTS log

## Testing
- `make fmt` *(fails: E712 and F841 errors)*
- `make test` *(fails: same ruff errors)*

------
https://chatgpt.com/codex/tasks/task_e_68605976ca808325b92e3b61543cb110