### PR TITLE
Fix saved and notes endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -387,3 +387,4 @@
 - Fixed navbar courses link to use 'courses.list_courses' and avoid BuildError (hotfix navbar-courses-link)
 - Fixed notifications dropdown link to 'noti.ver_notificaciones' to resolve BuildError (hotfix notifications-dropdown-link).
 - Fixed navbar missions link to use 'auth.perfil' with tab to avoid BuildError (hotfix navbar-missions-link).
+- Fixed saved link to use 'saved.list_saved' and corrected notes detail endpoints in templates (hotfix endpoint-fixes).

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -117,7 +117,7 @@
               <li><a class="dropdown-item" href="{{ url_for('auth.perfil', tab='misiones') }}">
                 <i class="bi bi-trophy me-2"></i>Misiones
               </a></li>
-              <li><a class="dropdown-item" href="{{ url_for('saved.list') }}">
+              <li><a class="dropdown-item" href="{{ url_for('saved.list_saved') }}">
                 <i class="bi bi-bookmark me-2"></i>Guardados
               </a></li>
               <li><hr class="dropdown-divider"></li>

--- a/crunevo/templates/feed/trending.html
+++ b/crunevo/templates/feed/trending.html
@@ -275,7 +275,7 @@
                 <div class="small text-muted">
                   <i class="bi bi-download me-1"></i>{{ note.downloads or 0 }} descargas
                 </div>
-                <a href="{{ url_for('notes.detalle_note', note_id=note.id) }}" 
+                <a href="{{ url_for('notes.view_note', id=note.id) }}"
                    class="btn btn-sm btn-primary rounded-pill">
                   Ver apunte
                 </a>

--- a/crunevo/templates/saved/list.html
+++ b/crunevo/templates/saved/list.html
@@ -43,7 +43,7 @@
                                 <div class="card-body">
                                     <div class="d-flex justify-content-between align-items-start mb-2">
                                         <h5 class="card-title mb-0">
-                                            <a href="{{ url_for('notes.detalle', id=note.id) }}" 
+                                            <a href="{{ url_for('notes.detail', note_id=note.id) }}"
                                                class="text-decoration-none">
                                                 {{ note.title }}
                                             </a>


### PR DESCRIPTION
## Summary
- fix navbar dropdown link to saved list
- correct note detail links in trending and saved templates
- document endpoint fixes in AGENTS.md

## Testing
- `make fmt` *(fails: unused variables, E712 comparisons)*
- `make test` *(fails: unused variables, E712 comparisons)*

------
https://chatgpt.com/codex/tasks/task_e_68605b23fd9883258bb4c76d6b7f6cbd