### PR TITLE
Fix forum links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -388,3 +388,4 @@
 - Fixed notifications dropdown link to 'noti.ver_notificaciones' to resolve BuildError (hotfix notifications-dropdown-link).
 - Fixed navbar missions link to use 'auth.perfil' with tab to avoid BuildError (hotfix navbar-missions-link).
 - Fixed saved link to use 'saved.list_saved' and corrected notes detail endpoints in templates (hotfix endpoint-fixes).
+- Fixed forum link in feed sidebar and profile quick actions to use 'forum.ask_question' (hotfix forum-ask-link).

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -381,7 +381,7 @@
               <a href="{{ url_for('notes.upload') }}" class="btn btn-primary btn-sm">
                 <i class="bi bi-plus-circle"></i> Subir Apunte
               </a>
-              <a href="{{ url_for('forum.ask') }}" class="btn btn-outline-primary btn-sm">
+              <a href="{{ url_for('forum.ask_question') }}" class="btn btn-outline-primary btn-sm">
                 <i class="bi bi-question-circle"></i> Hacer Pregunta
               </a>
               <a href="{{ url_for('club.list_clubs') }}" class="btn btn-outline-success btn-sm">

--- a/crunevo/templates/components/sidebar_left_feed.html
+++ b/crunevo/templates/components/sidebar_left_feed.html
@@ -130,7 +130,7 @@
         <a href="{{ url_for('notes.upload') }}" class="btn btn-primary btn-sm rounded-pill">
           <i class="bi bi-plus-circle"></i> Subir Apunte
         </a>
-        <a href="{{ url_for('forum.ask') }}" class="btn btn-outline-primary btn-sm rounded-pill">
+        <a href="{{ url_for('forum.ask_question') }}" class="btn btn-outline-primary btn-sm rounded-pill">
           <i class="bi bi-question-circle"></i> Hacer Pregunta
         </a>
       </div>


### PR DESCRIPTION
## Summary
- fix BuildError on feed sidebar and profile quick actions by using the correct `forum.ask_question` endpoint
- document change in AGENTS guidelines

## Testing
- `make fmt` *(fails: Found 57 errors (35 fixed, 22 remaining))*
- `make test` *(fails: Found 22 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68605de5e9fc83258481638e6b69282f