### PR TITLE
Fix endpoints in templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -391,3 +391,4 @@
 - Fixed forum link in feed sidebar and profile quick actions to use 'forum.ask_question' (hotfix forum-ask-link).
 - Public instance blocks /admin again by using create_app from app and hiding the dropdown link; fixed perfil route user variable, float conversion in store template and saved feed link (hotfix admin-block-route).
 - Registered main blueprint and removed redundant home route to restore `main.index` endpoint (hotfix main-blueprint-register).
+- Added endpoint checks for footer and error pages to avoid BuildError when blueprints are missing (hotfix endpoint-checks).

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -92,7 +92,7 @@
             <span class="text-muted small">© 2024 Crunevo - Construyendo el futuro educativo</span>
           </div>
           <div class="col-md-6 text-md-end">
-            <a href="{{ url_for('about.about') }}" class="text-muted text-decoration-none me-3 small">Sobre Crunevo</a>
+            <a href="{{ url_for('about.about') if 'about.about' in url_for.__globals__.get('current_app', {}).view_functions else '/about' }}" class="text-muted text-decoration-none me-3 small">Sobre Crunevo</a>
             <a href="/cookies" class="text-muted text-decoration-none me-3 small">Cookies</a>
             <a href="/privacidad" class="text-muted text-decoration-none me-3 small">Privacidad</a>
             <a href="/terminos" class="text-muted text-decoration-none small">Términos</a>

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -68,7 +68,7 @@
           </li>
 
           <li class="nav-item">
-            <a class="nav-link" href="{{ url_for('courses.list_courses') }}">
+            <a class="nav-link" href="{{ url_for('courses.list_courses') if 'courses.list_courses' in url_for.__globals__.get('current_app', {}).view_functions else '/cursos' }}">
               <i class="bi bi-play-circle-fill me-1"></i>Cursos
             </a>
           </li>

--- a/crunevo/templates/errors/404.html
+++ b/crunevo/templates/errors/404.html
@@ -18,29 +18,29 @@
         </p>
         
         <div class="d-flex flex-column flex-sm-row gap-3 justify-content-center mb-5">
-          <a href="{{ url_for('feed.feed_home') }}" class="btn btn-primary btn-lg">
+          <a href="{{ url_for('feed.feed_home') if 'feed.feed_home' in url_for.__globals__.get('current_app', {}).view_functions else '/' }}" class="btn btn-primary btn-lg">
             <i class="bi bi-house-fill me-2"></i>Ir al Feed
           </a>
-          <a href="{{ url_for('notes.list_notes') }}" class="btn btn-outline-primary btn-lg">
+          <a href="{{ url_for('notes.list_notes') if 'notes.list_notes' in url_for.__globals__.get('current_app', {}).view_functions else '/notes' }}" class="btn btn-outline-primary btn-lg">
             <i class="bi bi-journal-text me-2"></i>Ver Apuntes
           </a>
         </div>
 
         <div class="row text-center">
           <div class="col-sm-4 mb-3">
-            <a href="{{ url_for('club.list_clubs') }}" class="text-decoration-none">
+            <a href="{{ url_for('club.list_clubs') if 'club.list_clubs' in url_for.__globals__.get('current_app', {}).view_functions else '/clubes' }}" class="text-decoration-none">
               <i class="bi bi-people-fill fs-2 text-info d-block mb-2"></i>
               <span class="text-muted">Explora Clubes</span>
             </a>
           </div>
           <div class="col-sm-4 mb-3">
-            <a href="{{ url_for('store.store_index') }}" class="text-decoration-none">
+            <a href="{{ url_for('store.store_index') if 'store.store_index' in url_for.__globals__.get('current_app', {}).view_functions else '/store' }}" class="text-decoration-none">
               <i class="bi bi-shop fs-2 text-success d-block mb-2"></i>
               <span class="text-muted">Visita la Tienda</span>
             </a>
           </div>
           <div class="col-sm-4 mb-3">
-            <a href="{{ url_for('ranking.show_ranking') }}" class="text-decoration-none">
+            <a href="{{ url_for('ranking.show_ranking') if 'ranking.show_ranking' in url_for.__globals__.get('current_app', {}).view_functions else '/ranking' }}" class="text-decoration-none">
               <i class="bi bi-trophy-fill fs-2 text-warning d-block mb-2"></i>
               <span class="text-muted">Ver Ranking</span>
             </a>

--- a/crunevo/templates/errors/500.html
+++ b/crunevo/templates/errors/500.html
@@ -21,7 +21,7 @@
           <button onclick="window.location.reload()" class="btn btn-primary btn-lg">
             <i class="bi bi-arrow-clockwise me-2"></i>Refrescar Página
           </button>
-          <a href="{{ url_for('feed.feed_home') }}" class="btn btn-outline-primary btn-lg">
+          <a href="{{ url_for('feed.feed_home') if 'feed.feed_home' in url_for.__globals__.get('current_app', {}).view_functions else '/' }}" class="btn btn-outline-primary btn-lg">
             <i class="bi bi-house-fill me-2"></i>Volver al Inicio
           </a>
         </div>


### PR DESCRIPTION
## Summary
- avoid BuildError for footer about link by checking blueprint
- make courses link robust in the navbar
- check endpoints for links on 404 and 500 pages
- document endpoint checks in AGENTS

## Testing
- `make fmt` *(fails: F841 and E712 issues)*
- `make test` *(fails: 22 errors from ruff)*

------
https://chatgpt.com/codex/tasks/task_e_6860676aff908325a3eb3055ae67ce13