### PR TITLE
Fix template errors and mobile nav checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -392,3 +392,4 @@
 - Public instance blocks /admin again by using create_app from app and hiding the dropdown link; fixed perfil route user variable, float conversion in store template and saved feed link (hotfix admin-block-route).
 - Registered main blueprint and removed redundant home route to restore `main.index` endpoint (hotfix main-blueprint-register).
 - Added endpoint checks for footer and error pages to avoid BuildError when blueprints are missing (hotfix endpoint-checks).
+- Fixed sidebar links to terms/privacy, trending post includes item context, optional missions list and mobile nav endpoint checks. Added user_level calculation in perfil view (hotfix template-errors).

--- a/crunevo/routes/auth_routes.py
+++ b/crunevo/routes/auth_routes.py
@@ -120,6 +120,7 @@ def perfil():
     referidos_completados = 0
     enlace_referido = None
     creditos_referidos = 0
+    user_level = current_user.verification_level * 2
     if tab == "misiones":
         from crunevo.routes.missions_routes import compute_mission_states
         from crunevo.models import Mission
@@ -163,6 +164,7 @@ def perfil():
         referidos_completados=referidos_completados,
         enlace_referido=enlace_referido,
         creditos_referidos=creditos_referidos,
+        user_level=user_level,
     )
 
 

--- a/crunevo/templates/auth/missions_tab.html
+++ b/crunevo/templates/auth/missions_tab.html
@@ -1,7 +1,7 @@
 {% import 'components/csrf.html' as csrf %}
 <h3 class="mb-3">🎯 Tus misiones activas</h3>
 
-{% for mision in misiones %}
+{% for mision in misiones or [] %}
   {% set progreso = progresos.get(mision.id) %}
   <div class="card mb-3">
     <div class="card-body">

--- a/crunevo/templates/components/mobile_bottom_nav.html
+++ b/crunevo/templates/components/mobile_bottom_nav.html
@@ -3,7 +3,7 @@
     <div class="container-fluid px-3">
       <div class="d-flex justify-content-around align-items-center w-100">
         <!-- Home -->
-        <a href="{{ url_for('feed.view_feed') }}" 
+        <a href="{{ url_for('feed.view_feed') if 'feed.view_feed' in url_for.__globals__.get('current_app', {}).view_functions else '/' }}"
            class="nav-item {{ 'active' if request.endpoint == 'feed.view_feed' }}">
           <div class="nav-icon">
             <i class="bi bi-house{{ '-fill' if request.endpoint == 'feed.view_feed' }}"></i>
@@ -12,7 +12,7 @@
         </a>
 
         <!-- Search -->
-        <a href="{{ url_for('search.search_page') }}"
+        <a href="{{ url_for('search.search_page') if 'search.search_page' in url_for.__globals__.get('current_app', {}).view_functions else '#' }}"
            class="nav-item {{ 'active' if request.endpoint == 'search.search_page' }}">
           <div class="nav-icon">
             <i class="bi bi-search"></i>
@@ -21,7 +21,7 @@
         </a>
 
         <!-- Notes -->
-        <a href="{{ url_for('notes.list_notes') }}"
+        <a href="{{ url_for('notes.list_notes') if 'notes.list_notes' in url_for.__globals__.get('current_app', {}).view_functions else '#' }}"
            class="nav-item {{ 'active' if request.endpoint == 'notes.list_notes' }}">
           <div class="nav-icon">
             <i class="bi bi-journal{{ '-text-fill' if request.endpoint == 'notes.list_notes' }}"></i>
@@ -30,7 +30,7 @@
         </a>
 
         <!-- Notifications -->
-        <a href="{{ url_for('noti.ver_notificaciones') }}"
+        <a href="{{ url_for('noti.ver_notificaciones') if 'noti.ver_notificaciones' in url_for.__globals__.get('current_app', {}).view_functions else '#' }}"
            class="nav-item position-relative {{ 'active' if request.endpoint == 'noti.ver_notificaciones' }}">
           <div class="nav-icon">
             <i class="bi bi-bell{{ '-fill' if request.endpoint == 'noti.ver_notificaciones' }}"></i>
@@ -45,7 +45,7 @@
         </a>
 
         <!-- Profile -->
-        <a href="{{ url_for('auth.perfil') }}"
+        <a href="{{ url_for('auth.perfil') if 'auth.perfil' in url_for.__globals__.get('current_app', {}).view_functions else '#' }}"
            class="nav-item {{ 'active' if request.endpoint == 'auth.perfil' }}">
           <div class="nav-icon">
             {% if current_user.is_authenticated %}

--- a/crunevo/templates/components/sidebar_right.html
+++ b/crunevo/templates/components/sidebar_right.html
@@ -128,10 +128,10 @@
     </div>
     <div class="card-body pt-3">
       <div class="d-grid gap-2">
-        <a href="{{ url_for('static_routes.terms') }}" class="btn btn-outline-secondary btn-sm rounded-pill">
+        <a href="{{ url_for('main.terms') }}" class="btn btn-outline-secondary btn-sm rounded-pill">
           <i class="bi bi-file-text"></i> Términos de uso
         </a>
-        <a href="{{ url_for('static_routes.privacy') }}" class="btn btn-outline-secondary btn-sm rounded-pill">
+        <a href="{{ url_for('main.privacy') }}" class="btn btn-outline-secondary btn-sm rounded-pill">
           <i class="bi bi-shield-check"></i> Privacidad
         </a>
         <a href="{{ url_for('about.index') }}" class="btn btn-outline-secondary btn-sm rounded-pill">

--- a/crunevo/templates/feed/trending.html
+++ b/crunevo/templates/feed/trending.html
@@ -293,6 +293,7 @@
           </div>
 
           {% for post in weekly_posts[:5] %}
+          {% set item = {'data': post} %}
           <div class="trending-card">
             <div class="trending-badge">#{{ loop.index }}</div>
             {% include 'components/post_card.html' with context %}


### PR DESCRIPTION
## Summary
- update sidebar links to use existing main endpoints
- fix trending post card include with item context
- allow empty missions list in profile
- add endpoint checks to mobile bottom nav
- calculate user level in perfil view
- document changes in AGENTS

## Testing
- `make fmt` *(fails: 22 errors in ruff)*
- `make test` *(fails: 22 errors in ruff)*

------
https://chatgpt.com/codex/tasks/task_e_68606a911044832596f8f0da6d432b74