### PR TITLE
Fix template links causing BuildError

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -393,3 +393,4 @@
 - Registered main blueprint and removed redundant home route to restore `main.index` endpoint (hotfix main-blueprint-register).
 - Added endpoint checks for footer and error pages to avoid BuildError when blueprints are missing (hotfix endpoint-checks).
 - Fixed sidebar links to terms/privacy, trending post includes item context, optional missions list and mobile nav endpoint checks. Added user_level calculation in perfil view (hotfix template-errors).
+- Fixed sidebar links: privacy uses 'main.privacidad' and removed obsolete admin.manage_comments link (hotfix template-link-fixes).

--- a/crunevo/templates/admin/partials/sidebar.html
+++ b/crunevo/templates/admin/partials/sidebar.html
@@ -12,9 +12,6 @@
       <span class="badge bg-danger ms-1">{{ URGENT_REPORTS }}</span>
     {% endif %}
   </a>
-  <a class="nav-link {% if request.endpoint == 'admin.manage_comments' %}active{% endif %}" href="{{ url_for('admin.manage_comments') }}">
-    <i class="ti ti-message-dots me-2"></i> Comentarios
-  </a>
   <a class="nav-link {% if request.endpoint == 'admin.admin_logs' %}active{% endif %}" href="{{ url_for('admin.admin_logs') }}">
     <i class="ti ti-clipboard-list me-2"></i> Auditoría
   </a>

--- a/crunevo/templates/components/sidebar_right.html
+++ b/crunevo/templates/components/sidebar_right.html
@@ -131,7 +131,7 @@
         <a href="{{ url_for('main.terms') }}" class="btn btn-outline-secondary btn-sm rounded-pill">
           <i class="bi bi-file-text"></i> Términos de uso
         </a>
-        <a href="{{ url_for('main.privacy') }}" class="btn btn-outline-secondary btn-sm rounded-pill">
+        <a href="{{ url_for('main.privacidad') }}" class="btn btn-outline-secondary btn-sm rounded-pill">
           <i class="bi bi-shield-check"></i> Privacidad
         </a>
         <a href="{{ url_for('about.index') }}" class="btn btn-outline-secondary btn-sm rounded-pill">


### PR DESCRIPTION
## Summary
- update privacy link to use `main.privacidad`
- remove deprecated `admin.manage_comments` link
- document changes in AGENTS.md

## Testing
- `make fmt` *(fails: ruff found errors)*
- `make test` *(fails: ruff and pytest errors)*
- `pytest -q` *(fails: OperationalError and assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_68606de31fcc8325a95c8c8f7ba26c72