### PR TITLE
Fix about link in sidebar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -394,3 +394,4 @@
 - Added endpoint checks for footer and error pages to avoid BuildError when blueprints are missing (hotfix endpoint-checks).
 - Fixed sidebar links to terms/privacy, trending post includes item context, optional missions list and mobile nav endpoint checks. Added user_level calculation in perfil view (hotfix template-errors).
 - Fixed sidebar links: privacy uses 'main.privacidad' and removed obsolete admin.manage_comments link (hotfix template-link-fixes).
+- Fixed about link in sidebar to use 'about.about' and avoid BuildError (hotfix about-link-fix).

--- a/crunevo/templates/components/sidebar_right.html
+++ b/crunevo/templates/components/sidebar_right.html
@@ -134,7 +134,7 @@
         <a href="{{ url_for('main.privacidad') }}" class="btn btn-outline-secondary btn-sm rounded-pill">
           <i class="bi bi-shield-check"></i> Privacidad
         </a>
-        <a href="{{ url_for('about.index') }}" class="btn btn-outline-secondary btn-sm rounded-pill">
+        <a href="{{ url_for('about.about') }}" class="btn btn-outline-secondary btn-sm rounded-pill">
           <i class="bi bi-info-circle"></i> Acerca de CRUNEVO
         </a>
         <a href="mailto:soporte@crunevo.com" class="btn btn-outline-secondary btn-sm rounded-pill">


### PR DESCRIPTION
## Summary
- point sidebar about link to `about.about`
- document change in AGENTS.md

## Testing
- `make fmt` *(fails: F841 and E712 errors)*
- `make test` *(fails: F841 and E712 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686070c9ba1083258a68164207d0df3b