### PR TITLE
Update feed like icon and style

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -398,3 +398,4 @@
 - Registered courses blueprint and added English path aliases; updated sidebar link (PR courses-aliases).
 - Trimmed duplicate content in search/index.html to fix 'block title' error (hotfix search-template).
 - Added courses search support and moved search page JS to main.js for single DOMContentLoaded handler (hotfix search-modern)
+- Updated feed UI: replaced heart icons with fire, improved filter contrast and lighter gradient background (PR feed-ui-fire-icon)

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -39,18 +39,29 @@
   border-radius: 20px;
   padding: 0.5rem 1rem;
   border: none;
-  background: rgba(255, 255, 255, 0.1);
-  color: rgba(255, 255, 255, 0.8);
+  background: rgba(255, 255, 255, 0.2);
+  color: #333;
   transition: all 0.3s ease;
 }
 
 #quickFilters button:hover {
-  background: rgba(255, 255, 255, 0.2);
-  color: #fff;
+  background: rgba(255, 255, 255, 0.3);
+  color: #111;
 }
 
 #quickFilters button.active {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: rgba(255, 255, 255, 0.3);
+  color: #111;
+}
+
+[data-bs-theme="dark"] #quickFilters button {
+  background: rgba(255, 255, 255, 0.1);
+  color: #f1f5f9;
+}
+
+[data-bs-theme="dark"] #quickFilters button:hover,
+[data-bs-theme="dark"] #quickFilters button.active {
+  background: rgba(255, 255, 255, 0.2);
   color: #fff;
 }
 

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -17,7 +17,7 @@ body[data-bs-theme="dark"] {
 }
 
 body {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: linear-gradient(135deg, #E3F2FD 0%, #F3E5F5 100%);
   padding-top: 64px;
   font-family: "Inter", system-ui, sans-serif;
   min-height: 100vh;

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -213,13 +213,13 @@ class FeedManager {
       const icon = btn.querySelector('i');
       if (data.status === 'added') {
         btn.classList.add('active');
-        if (icon) icon.classList.add('bi-heart-fill', 'text-danger');
-        if (icon) icon.classList.remove('bi-heart');
-        this.animateButton(btn, '❤️');
+        if (icon) icon.classList.add('bi-fire', 'text-danger');
+        if (icon) icon.classList.remove('bi-heart', 'bi-heart-fill');
+        this.animateButton(btn, '🔥');
       } else if (data.status === 'removed') {
         btn.classList.remove('active');
-        if (icon) icon.classList.remove('bi-heart-fill', 'text-danger');
-        if (icon) icon.classList.add('bi-heart');
+        if (icon) icon.classList.remove('bi-fire', 'text-danger');
+        if (icon) icon.classList.add('bi-fire');
       }
 
       this.showToast(data.status === 'added' ? '¡Te gusta esta publicación!' : 'Ya no te gusta esta publicación', 'success');

--- a/crunevo/templates/components/post_card.html
+++ b/crunevo/templates/components/post_card.html
@@ -113,10 +113,10 @@
     <div class="post-actions d-flex align-items-center gap-1 border-top pt-3">
       <!-- Like Button -->
       {% set user_reaction = user_reactions.get(post.id) %}
-      <button class="btn btn-ghost flex-fill d-flex align-items-center justify-content-center gap-2 like-btn {{ 'active' if user_reaction else '' }}" 
-              data-post-id="{{ post.id }}" 
+      <button class="btn btn-ghost flex-fill d-flex align-items-center justify-content-center gap-2 like-btn {{ 'active' if user_reaction else '' }}"
+              data-post-id="{{ post.id }}"
               data-reaction="👍">
-        <i class="bi bi-heart{% if user_reaction %}-fill text-danger{% endif %}"></i>
+        <i class="bi bi-fire{% if user_reaction %} text-danger{% endif %}"></i>
         <span class="d-none d-sm-inline">Me gusta</span>
         <span id="likeCount{{ post.id }}" class="badge bg-light text-dark rounded-pill">{{ post.likes or 0 }}</span>
       </button>

--- a/crunevo/templates/feed/_trending_posts.html
+++ b/crunevo/templates/feed/_trending_posts.html
@@ -24,7 +24,7 @@
 
   <div class="d-flex align-items-center justify-content-between">
     <div class="d-flex gap-3">
-      <span class="text-danger"><i class="bi bi-heart-fill me-1"></i>{{ post.likes or 0 }}</span>
+      <span class="text-danger"><i class="bi bi-fire me-1"></i>{{ post.likes or 0 }}</span>
       <span class="text-primary"><i class="bi bi-chat me-1"></i>{{ post.comment_count or 0 }}</span>
     </div>
     <a href="{{ url_for('feed.view_post', post_id=post.id) }}" class="btn btn-sm btn-outline-primary rounded-pill">

--- a/crunevo/templates/feed/trending.html
+++ b/crunevo/templates/feed/trending.html
@@ -184,7 +184,7 @@
             <i class="bi bi-calendar-month me-1"></i> Este mes
           </button>
           <button class="btn btn-outline-primary" data-filter="populares">
-            <i class="bi bi-heart me-1"></i> Más likes
+            <i class="bi bi-fire me-1"></i> Más likes
           </button>
           <button class="btn btn-outline-primary" data-filter="comentarios">
             <i class="bi bi-chat me-1"></i> Más comentarios
@@ -226,7 +226,7 @@
 
                 <div class="d-flex align-items-center justify-content-between">
                   <div class="d-flex gap-3">
-                    <span class="text-danger"><i class="bi bi-heart-fill me-1"></i>{{ post.likes or 0 }}</span>
+                    <span class="text-danger"><i class="bi bi-fire me-1"></i>{{ post.likes or 0 }}</span>
                     <span class="text-primary"><i class="bi bi-chat me-1"></i>{{ post.comment_count or 0 }}</span>
                   </div>
                   <a href="{{ url_for('feed.view_post', post_id=post.id) }}" class="btn btn-sm btn-outline-primary rounded-pill">


### PR DESCRIPTION
## Summary
- use fire icon for likes in post cards and trending pages
- brighten feed background gradient and improve filter button styles
- show fire animation when liking a post
- document change in `AGENTS.md`

## Testing
- `make fmt` *(fails: ruff found errors)*
- `make test` *(fails: ruff found errors)*

------
https://chatgpt.com/codex/tasks/task_e_6860d036c620832588a5aa8cf2b61276