### PR TITLE
Fix streak claim and redesign navbar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -399,3 +399,6 @@
 - Trimmed duplicate content in search/index.html to fix 'block title' error (hotfix search-template).
 - Added courses search support and moved search page JS to main.js for single DOMContentLoaded handler (hotfix search-modern)
 - Updated feed UI: replaced heart icons with fire, improved filter contrast and lighter gradient background (PR feed-ui-fire-icon)
+- Fixed streak claim button to call /api/reclamar-racha and redesigned main navbar:
+  centered links, smaller search bar, removed Crunebot link, added theme toggle
+  in user menu and softened the "Publicar" button color (PR navbar-streak-fix).

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -416,3 +416,12 @@
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
 }
+
+.feed-submit-btn {
+  background-color: var(--primary-light);
+  border-color: var(--primary-light);
+}
+.feed-submit-btn:hover {
+  background-color: var(--primary);
+  border-color: var(--primary);
+}

--- a/crunevo/static/css/navbar.css
+++ b/crunevo/static/css/navbar.css
@@ -13,6 +13,12 @@
   position: sticky;
 }
 
+@media (min-width: 992px) {
+  .navbar-search {
+    max-width: 200px;
+  }
+}
+
 @media (max-width: 768px) {
   .navbar-crunevo {
     min-height: 56px;

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -383,7 +383,7 @@ class FeedManager {
         claimBtn.disabled = true;
         claimBtn.innerHTML = '<div class="spinner-border spinner-border-sm"></div>';
 
-        const response = await this.fetchWithCSRF('/auth/claim_streak', {
+        const response = await this.fetchWithCSRF('/api/reclamar-racha', {
           method: 'POST'
         });
 

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -5,7 +5,7 @@
     </a>
 
     <!-- Global Search Bar -->
-    <div class="navbar-search d-none d-lg-block mx-auto" style="max-width: 400px; width: 100%;">
+    <div class="navbar-search d-none d-lg-block" style="max-width: 200px; width: 100%;">
       <div class="position-relative">
         <input type="text" id="globalSearch" class="form-control bg-light border-0 rounded-pill ps-4" 
                placeholder="Buscar en CRUNEVO..." autocomplete="off">
@@ -21,9 +21,9 @@
     </button>
 
     <div class="collapse navbar-collapse" id="navbarNav">
-      <ul class="navbar-nav ms-auto align-items-center">
+      <ul class="navbar-nav d-lg-none mb-2">
         {% if current_user.is_authenticated %}
-          <li class="nav-item d-lg-none">
+          <li class="nav-item">
             <form class="d-flex my-2">
               <input class="form-control me-2" type="search" placeholder="Buscar..." id="mobileSearch">
               <button class="btn btn-outline-light" type="button" onclick="performMobileSearch()">
@@ -31,60 +31,33 @@
               </button>
             </form>
           </li>
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('feed.feed_home') }}">Feed</a></li>
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('notes.list_notes') }}">Apuntes</a></li>
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('forum.list_questions') }}">Foro</a></li>
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('store.store_index') }}">Tienda</a></li>
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('ranking.show_ranking') }}">Ranking</a></li>
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('courses.list_courses') if 'courses.list_courses' in url_for.__globals__.get('current_app', {}).view_functions else '/cursos' }}">Cursos</a></li>
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.perfil', tab='misiones') }}">Misiones</a></li>
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('chat.chat_index') }}">Chat</a></li>
+        {% endif %}
+      </ul>
 
-          <li class="nav-item">
-            <a class="nav-link" href="{{ url_for('feed.feed_home') }}">
-              <i class="bi bi-house-door me-1"></i>
-              Feed
-            </a>
-          </li>
+      <div class="mx-auto d-none d-lg-flex gap-3">
+        <a class="nav-link" href="{{ url_for('feed.feed_home') }}"><i class="bi bi-house-door me-1"></i>Feed</a>
+        <a class="nav-link" href="{{ url_for('notes.list_notes') }}"><i class="bi bi-file-text me-1"></i>Apuntes</a>
+        <a class="nav-link" href="{{ url_for('forum.list_questions') }}"><i class="bi bi-chat-left-quote me-1"></i>Foro</a>
+        <a class="nav-link" href="{{ url_for('store.store_index') }}"><i class="bi bi-shop me-1"></i>Tienda</a>
+        <a class="nav-link" href="{{ url_for('ranking.show_ranking') }}"><i class="bi bi-trophy me-1"></i>Ranking</a>
+        <a class="nav-link" href="{{ url_for('courses.list_courses') if 'courses.list_courses' in url_for.__globals__.get('current_app', {}).view_functions else '/cursos' }}"><i class="bi bi-play-circle-fill me-1"></i>Cursos</a>
+        <a class="nav-link" href="{{ url_for('auth.perfil', tab='misiones') }}"><i class="bi bi-trophy-fill me-1"></i>Misiones</a>
+      </div>
 
-          <li class="nav-item">
-            <a class="nav-link" href="{{ url_for('notes.list_notes') }}">
-              <i class="bi bi-file-text me-1"></i>
-              Apuntes
-            </a>
-          </li>
-
-          <li class="nav-item">
-            <a class="nav-link" href="{{ url_for('forum.list_questions') }}">
-              <i class="bi bi-chat-left-quote me-1"></i>
-              Foro
-            </a>
-          </li>
-
-          <li class="nav-item">
-            <a class="nav-link" href="{{ url_for('store.store_index') }}">
-              <i class="bi bi-shop me-1"></i>
-              Tienda
-            </a>
-          </li>
-
-          <li class="nav-item">
-            <a class="nav-link" href="{{ url_for('ranking.show_ranking') }}">
-              <i class="bi bi-trophy me-1"></i>
-              Ranking
-            </a>
-          </li>
-
-          <li class="nav-item">
-            <a class="nav-link" href="{{ url_for('courses.list_courses') if 'courses.list_courses' in url_for.__globals__.get('current_app', {}).view_functions else '/cursos' }}">
-              <i class="bi bi-play-circle-fill me-1"></i>Cursos
-            </a>
-          </li>
-
-          <li class="nav-item">
+      <ul class="navbar-nav ms-auto align-items-center gap-2">
+          <li class="nav-item d-none d-lg-block">
             <a class="nav-link" href="{{ url_for('chat.chat_index') }}">
-              <i class="bi bi-chat-dots-fill me-1"></i>Chat
+              <i class="bi bi-chat-dots-fill"></i>
             </a>
           </li>
-
-          <li class="nav-item">
-            <a class="nav-link" href="{{ url_for('crunebot.crunebot_chat') }}">
-              <i class="bi bi-robot me-1"></i>Crunebot
-            </a>
-          </li>
-
           <!-- Notifications -->
           <li class="nav-item dropdown">
             <a class="nav-link position-relative" href="#" id="notificationsDropdown" role="button" data-bs-toggle="dropdown">
@@ -124,6 +97,12 @@
               <li><span class="dropdown-item-text">
                 <i class="bi bi-coin me-2"></i>{{ current_user.credits }} Crolars
               </span></li>
+              <li><hr class="dropdown-divider"></li>
+              <li>
+                <button class="dropdown-item d-flex align-items-center gap-2" type="button" data-theme-toggle>
+                  <i class="bi bi-sun"></i>Tema claro / oscuro
+                </button>
+              </li>
               <li><hr class="dropdown-divider"></li>
               {% if current_user.role == 'admin' and config.ADMIN_INSTANCE %}
               <li><a class="dropdown-item" href="{{ url_for('admin.dashboard') }}">

--- a/crunevo/templates/feed/index.html
+++ b/crunevo/templates/feed/index.html
@@ -401,7 +401,7 @@ function initStreakClaim() {
     this.innerHTML = '<div class="spinner-border spinner-border-sm"></div>';
     
     try {
-      const response = await fetch('/auth/claim_streak', {
+      const response = await fetch('/api/reclamar-racha', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- connect streak claim button to `/api/reclamar-racha`
- redesign navbar with centered links and chat/notification/profile on the right
- add theme toggle back into profile dropdown
- style publish button with lighter color
- document changes in `AGENTS.md`

## Testing
- `make fmt` *(fails: ruff found 22 errors)*
- `make test` *(fails: ruff found 22 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6860d43839a0832594c5e99ebde0f352