### PR TITLE
Fix dark mode feed gradient

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -407,3 +407,4 @@
 - Further dark mode tweaks: override bg-light classes and navbar primary color, ensure textarea and badges adapt to dark theme (PR dark-mode-tweak).
 - Fixed dark mode selectors in style.css to target html[data-bs-theme], enabling consistent theme across pages (PR dark-mode-selector-fix).
 - Dark mode overhaul: unified dark backgrounds and comment box styles across templates (PR dark-mode-overhaul)
+- Feed dark mode: removed gradient background and set solid #0D1117 for feed section (PR dark-feed-solid-bg).

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -578,12 +578,14 @@ html {
 
 /* Dark mode overhaul */
 body[data-bs-theme="dark"] {
-  background-color: #0d1117;
+  background: #0d1117 !important;
+  background-image: none !important;
   color: #ffffff;
 }
 
 body[data-bs-theme="dark"] main {
-  background-color: #0d1117;
+  background: #0d1117 !important;
+  background-image: none !important;
 }
 
 body[data-bs-theme="dark"] .post-input,
@@ -623,5 +625,10 @@ body[data-bs-theme="dark"] .trending-card {
   background-color: #161b22;
   color: #ffffff;
   border: 1px solid #30363d;
+}
+
+body[data-bs-theme="dark"] .feed-section {
+  background: #0d1117 !important;
+  background-image: none !important;
 }
 


### PR DESCRIPTION
## Summary
- remove light gradient in dark theme feed
- update AGENTS log

## Testing
- `make fmt`
- `make test` *(fails: 52 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6860f7d35498832590f4435b67d6e711