### PR TITLE
Fix dark mode background

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -408,3 +408,4 @@
 - Fixed dark mode selectors in style.css to target html[data-bs-theme], enabling consistent theme across pages (PR dark-mode-selector-fix).
 - Dark mode overhaul: unified dark backgrounds and comment box styles across templates (PR dark-mode-overhaul)
 - Feed dark mode: removed gradient background and set solid #0D1117 for feed section (PR dark-feed-solid-bg).
+- Fixed remaining dark mode issues: unified body and feed backgrounds, updated card and input styles, and forced text-dark to white (PR dark-mode-bugfix).

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -577,22 +577,12 @@ html {
 }
 
 /* Dark mode overhaul */
-body[data-bs-theme="dark"] {
-  background: #0d1117 !important;
+body[data-bs-theme="dark"],
+body[data-bs-theme="dark"] main,
+body[data-bs-theme="dark"] .feed-section {
+  background-color: #0d1117 !important;
   background-image: none !important;
   color: #ffffff;
-}
-
-body[data-bs-theme="dark"] main {
-  background: #0d1117 !important;
-  background-image: none !important;
-}
-
-body[data-bs-theme="dark"] .post-input,
-body[data-bs-theme="dark"] .form-control {
-  background-color: #1e1e2f;
-  color: #ffffff;
-  border: 1px solid #333;
 }
 
 [data-bs-theme="dark"] .navbar {
@@ -602,11 +592,6 @@ body[data-bs-theme="dark"] .form-control {
 
 [data-bs-theme="dark"] .navbar .form-control {
   background-color: #0d1117;
-  color: #ffffff;
-}
-
-body[data-bs-theme="dark"] .comment-box {
-  background-color: #1c1c2b;
   color: #ffffff;
 }
 
@@ -621,7 +606,11 @@ body[data-bs-theme="dark"] .btn:hover {
 
 body[data-bs-theme="dark"] .sidebar-left,
 body[data-bs-theme="dark"] .card,
-body[data-bs-theme="dark"] .trending-card {
+body[data-bs-theme="dark"] .post-card,
+body[data-bs-theme="dark"] .trending-card,
+body[data-bs-theme="dark"] .comment-box,
+body[data-bs-theme="dark"] .form-control,
+body[data-bs-theme="dark"] .post-input {
   background-color: #161b22;
   color: #ffffff;
   border: 1px solid #30363d;
@@ -630,5 +619,10 @@ body[data-bs-theme="dark"] .trending-card {
 body[data-bs-theme="dark"] .feed-section {
   background: #0d1117 !important;
   background-image: none !important;
+}
+
+body[data-bs-theme="dark"] .text-dark,
+body[data-bs-theme="dark"] .text-black {
+  color: #ffffff !important;
 }
 


### PR DESCRIPTION
## Summary
- adjust dark mode background for body, main and feed section
- standardize card/button/input colors in dark theme
- force `.text-dark` and `.text-black` to white in dark theme
- note changes in AGENTS guidelines

## Testing
- `make fmt`
- `make test` *(fails: AssertionError / AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_6860fb22dc348325a434cdd624805f2c