### PR TITLE
Fix dark mode background

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -408,3 +408,5 @@
 - Fixed dark mode selectors in style.css to target html[data-bs-theme], enabling consistent theme across pages (PR dark-mode-selector-fix).
 - Dark mode overhaul: unified dark backgrounds and comment box styles across templates (PR dark-mode-overhaul)
 - Feed dark mode: removed gradient background and set solid #0D1117 for feed section (PR dark-feed-solid-bg).
+- Fixed remaining dark mode issues: unified body and feed backgrounds, updated card and input styles, and forced text-dark to white (PR dark-mode-bugfix).
+- Adjusted feed selectors to use `html[data-bs-theme]` and ensured feed section background stays solid in dark mode (PR dark-mode-feed-css).

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -577,22 +577,14 @@ html {
 }
 
 /* Dark mode overhaul */
-body[data-bs-theme="dark"] {
-  background: #0d1117 !important;
+html[data-bs-theme="dark"] body,
+html[data-bs-theme="dark"] main,
+html[data-bs-theme="dark"] .feed-section,
+html[data-bs-theme="dark"] .main-content,
+html[data-bs-theme="dark"] .container-feed {
+  background-color: #0d1117 !important;
   background-image: none !important;
   color: #ffffff;
-}
-
-body[data-bs-theme="dark"] main {
-  background: #0d1117 !important;
-  background-image: none !important;
-}
-
-body[data-bs-theme="dark"] .post-input,
-body[data-bs-theme="dark"] .form-control {
-  background-color: #1e1e2f;
-  color: #ffffff;
-  border: 1px solid #333;
 }
 
 [data-bs-theme="dark"] .navbar {
@@ -605,30 +597,34 @@ body[data-bs-theme="dark"] .form-control {
   color: #ffffff;
 }
 
-body[data-bs-theme="dark"] .comment-box {
-  background-color: #1c1c2b;
-  color: #ffffff;
-}
-
-body[data-bs-theme="dark"] .btn {
+html[data-bs-theme="dark"] .btn {
   background-color: #24292f;
   color: #c9d1d9;
 }
 
-body[data-bs-theme="dark"] .btn:hover {
+html[data-bs-theme="dark"] .btn:hover {
   background-color: #30363d;
 }
 
-body[data-bs-theme="dark"] .sidebar-left,
-body[data-bs-theme="dark"] .card,
-body[data-bs-theme="dark"] .trending-card {
+html[data-bs-theme="dark"] .sidebar-left,
+html[data-bs-theme="dark"] .card,
+html[data-bs-theme="dark"] .post-card,
+html[data-bs-theme="dark"] .trending-card,
+html[data-bs-theme="dark"] .comment-box,
+html[data-bs-theme="dark"] .form-control,
+html[data-bs-theme="dark"] .post-input {
   background-color: #161b22;
   color: #ffffff;
   border: 1px solid #30363d;
 }
 
-body[data-bs-theme="dark"] .feed-section {
+html[data-bs-theme="dark"] .feed-section {
   background: #0d1117 !important;
   background-image: none !important;
+}
+
+html[data-bs-theme="dark"] .text-dark,
+html[data-bs-theme="dark"] .text-black {
+  color: #ffffff !important;
 }
 


### PR DESCRIPTION
## Summary
- adjust feed background rules using `html[data-bs-theme]`
- ensure `.main-content` and `.container-feed` also turn dark
- document dark mode feed patch in AGENTS guidelines

## Testing
- `make fmt`
- `make test` *(fails: AssertionError/TypeError)*

------
https://chatgpt.com/codex/tasks/task_e_6860fb22dc348325a434cdd624805f2c