### PR TITLE
Fix Fly health check endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -411,3 +411,4 @@
 - Fixed remaining dark mode issues: unified body and feed backgrounds, updated card and input styles, and forced text-dark to white (PR dark-mode-bugfix).
 - Adjusted feed selectors to use `html[data-bs-theme]` and ensured feed section background stays solid in dark mode (PR dark-mode-feed-css).
 - Reemplazadas plantillas de publicaciones con 'components/post_card.html' y eliminado diseño anterior y la clase hover-scale (PR post-card-modernization).
+- Added /health endpoint in wsgi.py and updated fly.toml to check it via HTTP (PR fix-health-check).

--- a/crunevo/wsgi.py
+++ b/crunevo/wsgi.py
@@ -1,3 +1,9 @@
 from crunevo.app import create_app
+from flask import Response
 
 app = create_app()
+
+
+@app.route("/health")
+def health() -> Response:
+    return Response("ok", status=200)

--- a/fly.toml
+++ b/fly.toml
@@ -38,8 +38,8 @@ primary_region = 'bog'
     timeout      = '2s'
     grace_period = '5s'
     method       = 'get'
-    path         = '/healthz'
-    protocol     = 'https'
+    path         = '/health'
+    protocol     = 'http'
 
 [[vm]]
   memory = '1gb'


### PR DESCRIPTION
## Summary
- add `/health` endpoint in `wsgi.py`
- update fly health check to target `/health` over HTTP
- record change in `AGENTS.md`

## Testing
- `make fmt`
- `make test` *(fails: 52 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6861c4f12fd8832598c071062d15db6d