### PR TITLE
Fix admin store links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -414,3 +414,4 @@
 - Added /health endpoint in wsgi.py and updated fly.toml to check it via HTTP (PR fix-health-check).
 - Restored admin.logs and product_history routes to fix BuildError
 - Simplified health endpoint to return plain tuple as instructed (PR fix-health-return).
+- Removed references to deprecated admin.manage_store endpoint, linking to PUBLIC_BASE_URL/store instead (hotfix admin-store-links).

--- a/crunevo/templates/admin/add_edit_product.html
+++ b/crunevo/templates/admin/add_edit_product.html
@@ -46,5 +46,5 @@
   <a href="{{ PUBLIC_BASE_URL }}/store/product/{{ product.id }}" target="_blank" class="btn btn-outline-info ms-2">Ver en tienda</a>
   {% endif %}
 </form>
-<a href="{{ url_for('admin.manage_store') }}" class="btn btn-link mt-2">&larr; Volver a tienda</a>
+<a href="{{ PUBLIC_BASE_URL }}/store" class="btn btn-link mt-2" target="_blank">&larr; Ir a tienda</a>
 {% endblock %}

--- a/crunevo/templates/admin/dashboard.html
+++ b/crunevo/templates/admin/dashboard.html
@@ -256,8 +256,8 @@
             <a href="{{ url_for('admin.manage_users') }}" class="btn btn-outline-primary btn-sm">
               <i class="bi bi-people me-1"></i> Gestionar Usuarios
             </a>
-            <a href="{{ url_for('admin.manage_store') }}" class="btn btn-outline-success btn-sm">
-              <i class="bi bi-shop me-1"></i> Gestionar Tienda
+            <a href="{{ PUBLIC_BASE_URL }}/store" class="btn btn-outline-success btn-sm" target="_blank">
+              <i class="bi bi-shop me-1"></i> Ver Tienda
             </a>
             <a href="{{ url_for('admin.manage_reports') }}" class="btn btn-outline-warning btn-sm">
               <i class="bi bi-flag me-1"></i> Ver Reportes

--- a/crunevo/templates/admin/partials/sidebar.html
+++ b/crunevo/templates/admin/partials/sidebar.html
@@ -15,7 +15,7 @@
   <a class="nav-link {% if request.endpoint == 'admin.admin_logs' %}active{% endif %}" href="{{ url_for('admin.admin_logs') }}">
     <i class="ti ti-clipboard-list me-2"></i> Auditoría
   </a>
-  <a class="nav-link {% if request.endpoint == 'admin.manage_store' %}active{% endif %}" href="{{ url_for('admin.manage_store') }}">
+  <a class="nav-link" href="{{ PUBLIC_BASE_URL }}/store" target="_blank">
     <i class="ti ti-building-store me-2"></i> Tienda
   </a>
   <a class="nav-link {% if request.endpoint == 'admin.product_history' %}active{% endif %}" href="{{ url_for('admin.product_history') }}">


### PR DESCRIPTION
## Summary
- replace admin.manage_store link with PUBLIC_BASE_URL
- note change in AGENTS guidelines

## Testing
- `make fmt` *(fails: would reformat many files)*
- `make test` *(fails: 20 files would be reformatted)*

------
https://chatgpt.com/codex/tasks/task_e_6861cc22987083258035733f873991bb