### PR TITLE
Fix events and cookies paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -415,3 +415,4 @@
 - Restored admin.logs and product_history routes to fix BuildError
 - Simplified health endpoint to return plain tuple as instructed (PR fix-health-return).
 - Removed references to deprecated admin.manage_store endpoint, linking to PUBLIC_BASE_URL/store instead (hotfix admin-store-links).
+- Registered static_pages blueprint to enable /cookies page and added /events alias to /eventos with updated sidebar link (PR events-cookies-fix).

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -161,12 +161,12 @@ def create_app():
     from .routes.health_routes import health_bp
     from .routes.club_routes import club_bp
     from .routes.forum_routes import forum_bp
-    from .routes.event_routes import event_bp
+    from .routes.event_routes import event_bp, list_events
     from .routes.about_routes import about_bp
+    from .routes.static_routes import static_bp
     from .routes.crunebot_routes import crunebot_bp
     from .routes.saved_routes import saved_bp
     from .routes.main_routes import main_bp
-
 
     is_admin = os.environ.get("ADMIN_INSTANCE") == "1"
     testing_env = os.environ.get("PYTEST_CURRENT_TEST") is not None
@@ -263,7 +263,13 @@ def create_app():
         app.register_blueprint(club_bp)
         app.register_blueprint(forum_bp)
         app.register_blueprint(event_bp)
+        app.add_url_rule(
+            "/events",
+            endpoint="event.list_events_alias",
+            view_func=list_events,
+        )
         app.register_blueprint(about_bp)
+        app.register_blueprint(static_bp)
         app.register_blueprint(crunebot_bp)
         app.register_blueprint(saved_bp)
         app.register_blueprint(errors_bp)

--- a/crunevo/templates/components/sidebar_left_feed.html
+++ b/crunevo/templates/components/sidebar_left_feed.html
@@ -77,7 +77,7 @@
         </li>
 
         <li>
-          <a href="{{ url_for('event_bp.list_events') if 'event_bp.list_events' in url_for.__globals__.get('current_app', {}).view_functions else '/events' }}" class="nav-link {{ 'active' if request.endpoint == 'event_bp.list_events' }}">
+          <a href="{{ url_for('event.list_events') if 'event.list_events' in url_for.__globals__.get('current_app', {}).view_functions else '/eventos' }}" class="nav-link {{ 'active' if request.endpoint == 'event.list_events' }}">
             <i class="bi bi-calendar-event"></i>
             <span class="fw-semibold">Eventos</span>
           </a>


### PR DESCRIPTION
## Summary
- register `static_pages` blueprint and alias `/events` to `/eventos`
- update sidebar to use correct events endpoint
- document route fixes in `AGENTS.md`

## Testing
- `make fmt`
- `make test` *(fails: OperationalError etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6861cf04eb548325bd1508158ffad6bc