### PR TITLE
Hide navbar on auth pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -419,3 +419,4 @@
 - Navbar redesigned: centered search bar, mobile modal search, trending links updated in sidebar and ranking hero (PR trending-navbar-update).
 - Prevented BuildError in templates by checking 'feed.view_feed' exists before linking (hotfix feed-link-check).
 - Fixed links to 'notes.list_notes' in navbar and sidebar templates with endpoint checks to avoid BuildError on admin instance (hotfix notes-sidebar-link).
+- Ocultado navbar y navegación inferior en login y registro; se calcula padding superior dinámico con JS para la navbar fija (hotfix login-navbar-padding).

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -522,6 +522,10 @@ document.addEventListener('DOMContentLoaded', () => {
   if (navigator.hardwareConcurrency && navigator.hardwareConcurrency <= 4) {
     document.body.classList.add('no-anim');
   }
+  const fixedNav = document.querySelector('.navbar.fixed-top');
+  if (fixedNav) {
+    document.body.style.paddingTop = fixedNav.offsetHeight + 'px';
+  }
   if (window.NEW_ACHIEVEMENTS && window.NEW_ACHIEVEMENTS.length > 0) {
     showAchievementPopup(window.NEW_ACHIEVEMENTS[0]);
   }

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -56,7 +56,8 @@
 </head>
 <body class="d-flex flex-column min-vh-100">
     <!-- Navigation -->
-    {% if not request.path.startswith('/admin') %}
+    {% if not request.path.startswith('/admin')
+          and request.endpoint not in ['auth.login', 'onboarding.register'] %}
       {% if config.ADMIN_INSTANCE %}
         {% include 'components/navbar_admin.html' %}
       {% else %}
@@ -135,7 +136,9 @@
     {% endif %}
 
     <!-- Mobile bottom navigation -->
+    {% if request.endpoint not in ['auth.login', 'onboarding.register'] %}
     {% include 'components/mobile_bottom_nav.html' %}
+    {% endif %}
 
     <!-- Floating Crunebot Button -->
     {% if current_user.is_authenticated %}


### PR DESCRIPTION
## Summary
- hide the main navbar and mobile nav on login and register pages
- apply dynamic padding to body based on the fixed-top navbar height
- document new rule in AGENTS.md

## Testing
- `make fmt`
- `make test` *(fails: table already exists / numerous assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_6861d6fdb2908325bb688ffa831ecff9