### PR TITLE
Fix admin build errors in links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -422,3 +422,4 @@
 - Unified AI chat under /ia and removed /crunebot routes and templates; /crunebot now redirects to /ia (PR ia-chat-unification).
 - Ocultado navbar y navegación inferior en login y registro; se calcula padding superior dinámico con JS para la navbar fija (hotfix login-navbar-padding).
 - Verificado enlace al foro en navbar, feed sidebar y club list con comprobación de endpoint para evitar BuildError (hotfix forum-link-check).
+- Redirected main.index to admin dashboard when ADMIN_INSTANCE and guarded store and stats links to avoid BuildError (hotfix admin-root-builderror).

--- a/crunevo/routes/main_routes.py
+++ b/crunevo/routes/main_routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template, redirect, url_for
+from flask import Blueprint, render_template, redirect, url_for, current_app
 from flask_login import current_user
 from crunevo.routes.feed_routes import feed_home
 
@@ -8,6 +8,8 @@ main_bp = Blueprint("main", __name__)
 @main_bp.route("/")
 def index():
     if current_user.is_authenticated:
+        if current_app.config.get("ADMIN_INSTANCE"):
+            return redirect(url_for("admin.dashboard"))
         return feed_home()
     return redirect(url_for("auth.login"))
 

--- a/crunevo/templates/admin/partials/sidebar.html
+++ b/crunevo/templates/admin/partials/sidebar.html
@@ -21,9 +21,11 @@
   <a class="nav-link {% if request.endpoint == 'admin.product_history' %}active{% endif %}" href="{{ url_for('admin.product_history') }}">
     <i class="ti ti-history me-2"></i> Historial tienda
   </a>
+  {% if 'admin.stats_page' in url_for.__globals__.get('current_app', {}).view_functions %}
   <a class="nav-link {% if request.endpoint == 'admin.stats_page' %}active{% endif %}" href="{{ url_for('admin.stats_page') }}">
     <i class="ti ti-chart-bar me-2"></i> Estadísticas
   </a>
+  {% endif %}
   <a class="nav-link {% if request.endpoint == 'admin.manage_credits' %}active{% endif %}" href="{{ url_for('admin.manage_credits') }}">
     <i class="ti ti-coin me-2"></i> Crolars
   </a>

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -201,7 +201,7 @@
                       <button class="btn btn-warning btn-sm">
                         <i class="bi bi-plus-circle"></i> Comprar más Crolars
                       </button>
-                      <a href="{{ url_for('store.store_index') }}" class="btn btn-outline-warning btn-sm">
+                      <a href="{{ url_for('store.store_index') if 'store.store_index' in url_for.__globals__.get('current_app', {}).view_functions else '/store' }}" class="btn btn-outline-warning btn-sm">
                         <i class="bi bi-shop"></i> Ir a la Tienda
                       </a>
                     </div>
@@ -387,7 +387,7 @@
               <a href="{{ url_for('club.list_clubs') }}" class="btn btn-outline-success btn-sm">
                 <i class="bi bi-people"></i> Buscar Clubes
               </a>
-              <a href="{{ url_for('store.store_index') }}" class="btn btn-outline-warning btn-sm">
+              <a href="{{ url_for('store.store_index') if 'store.store_index' in url_for.__globals__.get('current_app', {}).view_functions else '/store' }}" class="btn btn-outline-warning btn-sm">
                 <i class="bi bi-shop"></i> Tienda
               </a>
             </div>

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -33,7 +33,7 @@
           <li class="nav-item"><a class="nav-link" href="{{ url_for('feed.feed_home') }}">Feed</a></li>
           <li class="nav-item"><a class="nav-link" href="{{ url_for('notes.list_notes') if 'notes.list_notes' in url_for.__globals__.get('current_app', {}).view_functions else '/notes' }}">Apuntes</a></li>
           <li class="nav-item"><a class="nav-link" href="{{ url_for('forum.list_questions') if 'forum.list_questions' in url_for.__globals__.get('current_app', {}).view_functions else '/foro' }}">Foro</a></li>
-          <li class="nav-item"><a class="nav-link" href="{{ url_for('store.store_index') }}">Tienda</a></li>
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('store.store_index') if 'store.store_index' in url_for.__globals__.get('current_app', {}).view_functions else '/store' }}">Tienda</a></li>
           <li class="nav-item"><a class="nav-link" href="{{ url_for('ranking.show_ranking') }}">Ranking</a></li>
           <li class="nav-item"><a class="nav-link" href="{{ url_for('courses.list_courses') if 'courses.list_courses' in url_for.__globals__.get('current_app', {}).view_functions else '/cursos' }}">Cursos</a></li>
           <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.perfil', tab='misiones') }}">Misiones</a></li>
@@ -44,7 +44,7 @@
         <a class="nav-link" href="{{ url_for('feed.feed_home') }}"><i class="bi bi-house-door me-1"></i>Feed</a>
         <a class="nav-link" href="{{ url_for('notes.list_notes') if 'notes.list_notes' in url_for.__globals__.get('current_app', {}).view_functions else '/notes' }}"><i class="bi bi-file-text me-1"></i>Apuntes</a>
         <a class="nav-link" href="{{ url_for('forum.list_questions') if 'forum.list_questions' in url_for.__globals__.get('current_app', {}).view_functions else '/foro' }}"><i class="bi bi-chat-left-quote me-1"></i>Foro</a>
-        <a class="nav-link" href="{{ url_for('store.store_index') }}"><i class="bi bi-shop me-1"></i>Tienda</a>
+        <a class="nav-link" href="{{ url_for('store.store_index') if 'store.store_index' in url_for.__globals__.get('current_app', {}).view_functions else '/store' }}"><i class="bi bi-shop me-1"></i>Tienda</a>
         <a class="nav-link" href="{{ url_for('ranking.show_ranking') }}"><i class="bi bi-trophy me-1"></i>Ranking</a>
         <a class="nav-link" href="{{ url_for('courses.list_courses') if 'courses.list_courses' in url_for.__globals__.get('current_app', {}).view_functions else '/cursos' }}"><i class="bi bi-play-circle-fill me-1"></i>Cursos</a>
         <a class="nav-link" href="{{ url_for('auth.perfil', tab='misiones') }}"><i class="bi bi-trophy-fill me-1"></i>Misiones</a>

--- a/crunevo/templates/components/navbar_crunevo_fixed.html
+++ b/crunevo/templates/components/navbar_crunevo_fixed.html
@@ -17,7 +17,7 @@
       <li class="nav-item"><a class="nav-link" href="{{ url_for('feed.feed_home') }}"><i class="bi bi-house-door"></i></a></li>
       <li class="nav-item"><a class="nav-link" href="{{ url_for('feed.trending') }}"><i class="bi bi-fire"></i></a></li>
       <li class="nav-item"><a class="nav-link" href="{{ url_for('notes.list_notes') if 'notes.list_notes' in url_for.__globals__.get('current_app', {}).view_functions else '/notes' }}"><i class="bi bi-journal-text"></i></a></li>
-      <li class="nav-item"><a class="nav-link" href="{{ url_for('store.store_index') }}"><i class="bi bi-bag"></i></a></li>
+      <li class="nav-item"><a class="nav-link" href="{{ url_for('store.store_index') if 'store.store_index' in url_for.__globals__.get('current_app', {}).view_functions else '/store' }}"><i class="bi bi-bag"></i></a></li>
       <li class="nav-item"><a class="nav-link" href="{{ url_for('chat.chat_index') }}"><i class="bi bi-chat-dots"></i></a></li>
       {% if current_user.is_authenticated %}
       <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.logout') }}">Salir</a></li>

--- a/crunevo/templates/components/sidebar_left_feed.html
+++ b/crunevo/templates/components/sidebar_left_feed.html
@@ -90,7 +90,7 @@
           </a>
         </li>
         <li>
-          <a href="{{ url_for('store.store_index') }}" class="nav-link {{ 'active' if request.endpoint == 'store.store_index' }}">
+          <a href="{{ url_for('store.store_index') if 'store.store_index' in url_for.__globals__.get('current_app', {}).view_functions else '/store' }}" class="nav-link {{ 'active' if request.endpoint == 'store.store_index' }}">
             <i class="bi bi-shop"></i>
             <span class="fw-semibold">Tienda</span>
             {% if session.get('cart_count', 0) > 0 %}

--- a/crunevo/templates/feed/sidebar_left_feed.html
+++ b/crunevo/templates/feed/sidebar_left_feed.html
@@ -11,7 +11,7 @@
   <a class="nav-link d-flex align-items-center gap-2" href="#" data-bs-toggle="tooltip" title="Clubes">
     <i class="bi bi-people"></i><span>Clubes</span>
   </a>
-  <a class="nav-link d-flex align-items-center gap-2" href="{{ url_for('store.store_index') }}" data-bs-toggle="tooltip" title="Tienda">
+  <a class="nav-link d-flex align-items-center gap-2" href="{{ url_for('store.store_index') if 'store.store_index' in url_for.__globals__.get('current_app', {}).view_functions else '/store' }}" data-bs-toggle="tooltip" title="Tienda">
     <i class="bi bi-bag"></i><span>Tienda</span>
   </a>
   <a class="nav-link d-flex align-items-center gap-2" href="{{ url_for('ranking.index') if 'ranking.index' in url_for.__globals__.get('current_app', {}).view_functions else '#' }}" data-bs-toggle="tooltip" title="Ranking">


### PR DESCRIPTION
## Summary
- redirect main index to admin dashboard in admin mode
- guard store and stats links so templates render without BuildError
- document changes in `AGENTS.md`

## Testing
- `make fmt`
- `make test` *(fails: 52 failed, 23 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6861de0befb8832583b836d3b265e54d