### PR TITLE
Move trending tab to ranking navbar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -422,3 +422,4 @@
 - Unified AI chat under /ia and removed /crunebot routes and templates; /crunebot now redirects to /ia (PR ia-chat-unification).
 - Ocultado navbar y navegación inferior en login y registro; se calcula padding superior dinámico con JS para la navbar fija (hotfix login-navbar-padding).
 - Verificado enlace al foro en navbar, feed sidebar y club list con comprobación de endpoint para evitar BuildError (hotfix forum-link-check).
+- Moved 'Ver tendencias 🔥' button from hero to ranking tabs next to 'Top Referidores' and styled as nav-link (PR trending-button-move).

--- a/crunevo/templates/ranking/index.html
+++ b/crunevo/templates/ranking/index.html
@@ -321,7 +321,6 @@
       <div class="ranking-hero">
         <div class="d-flex flex-wrap justify-content-center align-items-center gap-2">
           <h1 class="m-0">🏆 Ranking CRUNEVO</h1>
-          <a href="{{ url_for('feed.trending') }}" class="btn btn-sm btn-outline-warning ms-3">Ver tendencias 🔥</a>
         </div>
         <p>Descubre a los líderes y top contributors de nuestra comunidad educativa</p>
       </div>
@@ -342,6 +341,9 @@
         </a>
         <a class="nav-link" href="{{ url_for('ranking.top_referrers') }}">
           <i class="bi bi-people me-2"></i>Top Referidores
+        </a>
+        <a class="nav-link" href="{{ url_for('feed.trending') }}">
+          <i class="bi bi-fire me-2"></i>Ver tendencias 🔥
         </a>
       </div>
 


### PR DESCRIPTION
## Summary
- move "Ver tendencias" button from hero header into the ranking tabs
- record change history in `AGENTS.md`

## Testing
- `make fmt`
- `make test` *(fails: OperationalError & many tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_6861de1e97f48325be68cc44d3d05787