### PR TITLE
Fix comment modal shows full post

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -424,3 +424,4 @@
 - Verificado enlace al foro en navbar, feed sidebar y club list con comprobación de endpoint para evitar BuildError (hotfix forum-link-check).
 - Moved 'Ver tendencias 🔥' button from hero to ranking tabs next to 'Top Referidores' and styled as nav-link (PR trending-button-move).
 - Redirected main.index to admin dashboard when ADMIN_INSTANCE and guarded store and stats links to avoid BuildError (hotfix admin-root-builderror).
+- Fixed comment modal to display complete post detail via new /feed/api/post endpoint and ensured closing works correctly (PR comment-modal-full-post).

--- a/crunevo/routes/feed_routes.py
+++ b/crunevo/routes/feed_routes.py
@@ -497,6 +497,26 @@ def api_comments(post_id):
     )
 
 
+@feed_bp.route("/api/post/<int:post_id>")
+@activated_required
+def api_post_detail(post_id: int):
+    """Return rendered HTML for a post used in the comment modal."""
+    post = Post.query.get_or_404(post_id)
+    counts = PostReaction.count_for_post(post.id)
+    my_reaction = (
+        PostReaction.query.with_entities(PostReaction.reaction_type)
+        .filter_by(user_id=current_user.id, post_id=post.id)
+        .scalar()
+    )
+    html = render_template(
+        "feed/_post_modal.html",
+        post=post,
+        reaction_counts=counts,
+        user_reaction=my_reaction,
+    )
+    return jsonify({"html": html})
+
+
 @feed_bp.route("/save/<int:post_id>", methods=["POST"])
 @activated_required
 def toggle_save(post_id):

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -233,16 +233,29 @@ class FeedManager {
 
   openCommentModal(e) {
     const postId = e.currentTarget.dataset.postId;
-    this.loadComments(postId);
-    
-    const modal = new bootstrap.Modal(document.getElementById('commentModal'));
+    const modalEl = document.getElementById('commentModal');
+    const bodyEl = document.getElementById('commentModalBody');
+    if (!modalEl || !bodyEl) return;
+    bodyEl.innerHTML = '<div class="text-center p-3"><div class="spinner-border"></div></div>';
+    const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
     modal.show();
-    
-    // Focus on comment input
-    setTimeout(() => {
-      const input = document.querySelector('#commentForm input[name="body"]');
-      if (input) input.focus();
-    }, 300);
+
+    fetch(`/feed/api/post/${postId}`)
+      .then((r) => r.json())
+      .then((data) => {
+        bodyEl.innerHTML = data.html;
+        const form = bodyEl.querySelector('#commentForm');
+        if (form) {
+          form.onsubmit = (ev) => this.submitComment(ev, postId);
+        }
+        setTimeout(() => {
+          const input = bodyEl.querySelector('#commentForm input[name="body"]');
+          if (input) input.focus();
+        }, 300);
+      })
+      .catch(() => {
+        bodyEl.innerHTML = '<div class="text-center text-muted p-3">Error al cargar publicación</div>';
+      });
   }
 
   async loadComments(postId) {

--- a/crunevo/templates/feed/_post_modal.html
+++ b/crunevo/templates/feed/_post_modal.html
@@ -1,0 +1,67 @@
+{% import 'components/csrf.html' as csrf %}
+<div class="card mb-4 shadow-sm border-0 rounded-4">
+  <div class="card-body p-4">
+    <div class="d-flex align-items-center mb-2">
+      {% set author = post.author %}
+      {% if author %}
+      <img loading="lazy" src="{{ author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
+      <a href="{{ url_for('auth.profile_by_username', username=author.username) }}" class="me-auto text-decoration-none">
+        <strong>{{ author.username }}</strong>
+      </a>
+      {% else %}
+      <img loading="lazy" src="{{ url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
+      <span class="me-auto text-muted">Usuario eliminado</span>
+      {% endif %}
+      <small class="text-muted">{{ post.created_at.strftime('%Y-%m-%d') }}{% if post.edited %} • Editado{% endif %}</small>
+    </div>
+    <p class="card-text">{{ post.content }}</p>
+      {% if post.file_url %}
+        {% if post.file_url.endswith('.pdf') %}
+        <a href="{{ post.file_url }}" target="_blank" class="btn btn-outline-primary mb-2">Ver PDF</a>
+        {% else %}
+        <img loading="lazy" src="{{ post.file_url }}" class="feed-image img-fluid rounded mb-2">
+        {% endif %}
+      {% endif %}
+      {% set counts = reaction_counts %}
+      {{ react.reaction_container(post, counts, user_reaction) }}
+
+      <div class="d-flex gap-2 my-3">
+        <button type="button" class="btn btn-outline-secondary btn-sm share-btn" data-share-url="{{ url_for('feed.view_post', post_id=post.id, _external=True) }}">
+          <i class="bi bi-share"></i> Compartir
+        </button>
+        {% if author %}
+        <a href="{{ url_for('auth.profile_by_username', username=author.username) }}" class="btn btn-outline-info btn-sm">Ver perfil</a>
+        <a href="{{ url_for('feed.user_posts', user_id=author.id) }}" class="btn btn-outline-primary btn-sm">
+          Ver más publicaciones de este usuario
+        </a>
+        {% endif %}
+      </div>
+
+      <h6 class="mt-3 mb-2">Comentarios</h6>
+      <div id="commentsContainer" class="comment-container" data-post-id="{{ post.id }}">
+        {% if post.comments %}
+          {% for c in post.comments|sort(attribute='timestamp', reverse=True) %}
+          <div class="d-flex mb-3 comment comment-item comment-box">
+            <img loading="lazy" src="{{ c.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
+            <div>
+              <div class="small text-muted">
+                <a href="{{ url_for('auth.profile_by_username', username=c.author.username) }}" class="text-decoration-none">{{ c.author.username }}</a> • {{ c.timestamp.strftime('%Y-%m-%d %H:%M') }}
+              </div>
+              <div>{{ c.body }}</div>
+            </div>
+          </div>
+          {% endfor %}
+        {% else %}
+          <p class="text-muted" data-empty-msg>Sé el primero en comentar esta publicación.</p>
+        {% endif %}
+      </div>
+      <form id="commentForm" method="post" action="{{ url_for('feed.comment_post', post_id=post.id) }}">
+        {{ csrf.csrf_field() }}
+        <div class="input-group mb-2">
+          <input type="text" name="body" class="form-control" placeholder="Añadir comentario" required>
+          <button class="btn btn-primary" type="submit">Enviar</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/crunevo/templates/feed/index.html
+++ b/crunevo/templates/feed/index.html
@@ -158,25 +158,14 @@
 
 <!-- Comment Modal -->
 <div class="modal fade" id="commentModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered">
+  <div class="modal-dialog modal-dialog-centered modal-lg">
     <div class="modal-content border-0 rounded-4">
       <div class="modal-header border-0 pb-0">
         <h5 class="modal-title">💬 Comentarios</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
       </div>
-      <div class="modal-body">
-        <div id="commentsContainer" class="mb-3" style="max-height: 300px; overflow-y: auto;">
-          <!-- Comments will be loaded here -->
-        </div>
-        <form id="commentForm" class="d-flex gap-2">
-          {{ csrf.csrf_field() }}
-          <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" 
-               class="rounded-circle" width="32" height="32">
-          <input type="text" name="body" class="form-control rounded-pill" placeholder="Escribe un comentario..." required>
-          <button type="submit" class="btn btn-primary rounded-circle" style="width: 40px; height: 40px;">
-            <i class="bi bi-send"></i>
-          </button>
-        </form>
+      <div id="commentModalBody" class="modal-body p-0">
+        <!-- Post detail will load here -->
       </div>
     </div>
   </div>
@@ -381,9 +370,55 @@ function initPostInteractions() {
 }
 
 function openCommentModal(postId) {
-  const modal = new bootstrap.Modal(document.getElementById('commentModal'));
-  // Load comments logic here
+  const modalEl = document.getElementById('commentModal');
+  const bodyEl = document.getElementById('commentModalBody');
+  if (!modalEl || !bodyEl) return;
+  bodyEl.innerHTML = '<div class="text-center p-3"><div class="spinner-border"></div></div>';
+  const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
   modal.show();
+  fetch(`/feed/api/post/${postId}`)
+    .then(r => r.json())
+    .then(data => {
+      bodyEl.innerHTML = data.html;
+      const form = bodyEl.querySelector('#commentForm');
+      if (form) {
+        form.addEventListener('submit', ev => {
+          ev.preventDefault();
+          // simple ajax submit
+          const input = form.querySelector('input[name="body"]');
+          if (!input.value.trim()) return;
+          const fd = new FormData();
+          fd.append('body', input.value.trim());
+          fd.append('csrf_token', document.querySelector('[name="csrf_token"]').value);
+          fetch(`/feed/comment/${postId}`, { method: 'POST', body: fd })
+            .then(r => r.json())
+            .then(c => {
+              const container = bodyEl.querySelector('#commentsContainer');
+              if (container) {
+                container.insertAdjacentHTML('afterbegin', `
+                  <div class="comment-item d-flex gap-3 mb-3 comment-box">
+                    <img src="${c.avatar || '/static/img/default.png'}" class="rounded-circle" width="32" height="32">
+                    <div class="flex-grow-1">
+                      <div class="comment-box p-3 rounded-3">
+                        <div class="fw-semibold small mb-1">${c.author}</div>
+                        <div class="small">${c.body}</div>
+                      </div>
+                      <div class="small text-muted mt-1">ahora</div>
+                    </div>
+                  </div>`);
+              }
+              input.value = '';
+            });
+        });
+      }
+      setTimeout(() => {
+        const input = bodyEl.querySelector('#commentForm input[name="body"]');
+        if (input) input.focus();
+      }, 300);
+    })
+    .catch(() => {
+      bodyEl.innerHTML = '<div class="text-center text-muted p-3">Error al cargar publicación</div>';
+    });
 }
 
 function openShareModal(url) {


### PR DESCRIPTION
## Summary
- add `/feed/api/post/<id>` endpoint to render post detail for modal
- create `_post_modal.html` partial for comment modal
- load full post content in comment modal via JS and fix closing issue
- document task in AGENTS guidelines

## Testing
- `make fmt`
- `make test` *(fails: table already exists, CSRF and login issues)*

------
https://chatgpt.com/codex/tasks/task_e_6861e1c89d8883259dcb37126e273d72