### PR TITLE
Fix admin credit history route

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -424,3 +424,5 @@
 - Verificado enlace al foro en navbar, feed sidebar y club list con comprobación de endpoint para evitar BuildError (hotfix forum-link-check).
 - Moved 'Ver tendencias 🔥' button from hero to ranking tabs next to 'Top Referidores' and styled as nav-link (PR trending-button-move).
 - Redirected main.index to admin dashboard when ADMIN_INSTANCE and guarded store and stats links to avoid BuildError (hotfix admin-root-builderror).
+
+- Restored /admin/credits routes and export CSV to fix BuildError (hotfix manage-credits-route).


### PR DESCRIPTION
## Summary
- restore `manage_credits` route with `/creditos` alias and CSV export
- document change in `AGENTS.md`

## Testing
- `make fmt`
- `make test` *(fails: 52 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6861e1e3dc7c8325b79dc059c0751105