### PR TITLE
Fix admin achievements link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -427,3 +427,4 @@
 
 - Restored /admin/credits routes and export CSV to fix BuildError (hotfix manage-credits-route).
 - Fixed comment modal to display complete post detail via new /feed/api/post endpoint and ensured closing works correctly (PR comment-modal-full-post).
+- Wrapped admin sidebar link to 'admin.manage_achievements' with endpoint check to avoid BuildError when route is absent (hotfix admin-sidebar-achievements).

--- a/crunevo/templates/admin/partials/sidebar.html
+++ b/crunevo/templates/admin/partials/sidebar.html
@@ -35,9 +35,11 @@
 
   <span class="text-muted fw-bold small mt-4 mb-2">🏅 Comunidad</span>
   <a class="nav-link disabled"><i class="ti ti-check me-2"></i> Verificaciones</a>
+  {% if 'admin.manage_achievements' in url_for.__globals__.get('current_app', {}).view_functions %}
   <a class="nav-link {% if request.endpoint == 'admin.manage_achievements' %}active{% endif %}" href="{{ url_for('admin.manage_achievements') }}">
     <i class="ti ti-award me-2"></i> Logros
   </a>
+  {% endif %}
   <a class="nav-link {% if request.endpoint == 'admin.manage_missions' %}active{% endif %}" href="{{ url_for('admin.manage_missions') }}">
     <i class="ti ti-target me-2"></i> Misiones
   </a>


### PR DESCRIPTION
## Summary
- avoid BuildError when admin achievements route is missing by checking endpoint in sidebar
- document fix in `AGENTS.md`

## Testing
- `make fmt`
- `make test` *(fails: AssertionError, AttributeError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6861ee27372483259c8c3d1c4089f515