### PR TITLE
Fix admin dashboard stats variables

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -430,3 +430,4 @@
 - Added environment variable overrides in create_app and implemented admin delete routes. Fixed missing csrf_field in club detail. Migrations use if_not_exists and safe drop to avoid errors.
 - Wrapped admin sidebar link to 'admin.manage_achievements' with endpoint check to avoid BuildError when route is absent (hotfix admin-sidebar-achievements).
 - Imported reactions macro in _post_modal.html to fix UndefinedError (hotfix reactions-import).
+- Fixed dashboard template variable names to match admin route and replaced stats.users usage with new_users_week (hotfix admin-dashboard-stats).

--- a/crunevo/templates/admin/dashboard.html
+++ b/crunevo/templates/admin/dashboard.html
@@ -36,10 +36,10 @@
           <div class="d-flex justify-content-between align-items-center">
             <div>
               <div class="text-white-75 small fw-bold">Total Usuarios</div>
-              <div class="display-6 fw-bold">{{ users_total }}</div>
+              <div class="display-6 fw-bold">{{ total_users }}</div>
               <div class="small">
                 <i class="bi bi-arrow-up text-success"></i>
-                +{{ stats.users|length if stats.users else 0 }} esta semana
+                +{{ new_users_week }} esta semana
               </div>
             </div>
             <i class="bi bi-people display-4 text-white-50"></i>
@@ -60,7 +60,7 @@
           <div class="d-flex justify-content-between align-items-center">
             <div>
               <div class="text-white-75 small fw-bold">Apuntes Subidos</div>
-              <div class="display-6 fw-bold">{{ notes_total }}</div>
+              <div class="display-6 fw-bold">{{ total_notes }}</div>
               <div class="small">
                 <i class="bi bi-arrow-up text-info"></i>
                 Material educativo activo
@@ -84,7 +84,7 @@
           <div class="d-flex justify-content-between align-items-center">
             <div>
               <div class="text-white-75 small fw-bold">Posts Publicados</div>
-              <div class="display-6 fw-bold">{{ comments_total }}</div>
+              <div class="display-6 fw-bold">{{ total_posts }}</div>
               <div class="small">
                 <i class="bi bi-heart text-danger"></i>
                 Interacciones sociales
@@ -108,7 +108,7 @@
           <div class="d-flex justify-content-between align-items-center">
             <div>
               <div class="text-white-75 small fw-bold">Crolars en Circulación</div>
-              <div class="display-6 fw-bold">{{ credits_total }}</div>
+              <div class="display-6 fw-bold">{{ total_crolars_circulation }}</div>
               <div class="small">
                 <i class="bi bi-coin text-warning"></i>
                 Economía interna activa


### PR DESCRIPTION
## Summary
- align variable names in admin dashboard template with route output
- replace stale `stats.users` reference with `new_users_week`
- document fix in AGENTS

## Testing
- `make fmt`
- `make test` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6861f401dccc8325839c87fa58f72848