### PR TITLE
Add admin run ranking route

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -432,3 +432,4 @@
 - Imported reactions macro in _post_modal.html to fix UndefinedError (hotfix reactions-import).
 - Fixed dashboard template variable names to match admin route and replaced stats.users usage with new_users_week (hotfix admin-dashboard-stats).
 - Redesigned comment modal using feed post card layout and fixed share modal backdrop removal (PR share-modal-redesign).
+- Added admin.run_ranking route invoking calculate_weekly_ranking and linked from dashboard (hotfix admin-run-ranking-route).

--- a/crunevo/routes/admin_routes.py
+++ b/crunevo/routes/admin_routes.py
@@ -17,6 +17,7 @@ from crunevo.models import (
 )
 from crunevo.utils.helpers import admin_required
 from crunevo.utils.credits import add_credit
+from crunevo.utils.ranking import calculate_weekly_ranking
 from crunevo.constants.credit_reasons import CreditReasons
 from datetime import datetime, timedelta
 import csv
@@ -280,6 +281,15 @@ def admin_logs():
         .all()
     )
     return render_template("admin/admin_logs.html", logs=logs)
+
+
+@admin_bp.route("/run-ranking")
+def run_ranking():
+    """Manually recalculate the weekly ranking."""
+    calculate_weekly_ranking()
+    log_admin_action("Recalcul\u00f3 ranking semanal")
+    flash("Ranking recalculado", "success")
+    return redirect(url_for("admin.dashboard"))
 
 
 @admin_bp.route(


### PR DESCRIPTION
## Summary
- add admin.run_ranking route that executes `calculate_weekly_ranking`
- log the action and flash success message
- document the change in `AGENTS.md`

## Testing
- `make fmt`
- `pytest -q` *(fails: OperationalError in migrations tests, moderator read-only, user verification)*

------
https://chatgpt.com/codex/tasks/task_e_6861f939fb4883258f4a6a3f2ce38c1f