### PR TITLE
Fix OpenRouter API integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,6 @@ SECRET_KEY=changeme
 DATABASE_URL=postgresql://user:password@localhost:5432/dbname
 CLOUDINARY_URL=cloudinary://APIKEY:SECRET@cloudname
 RESEND_API_KEY=
+OPENROUTER_API_KEY=
 MAIL_USERNAME=noreply@crunevo.com
 MAIL_PROVIDER=resend

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -432,3 +432,4 @@
 - Imported reactions macro in _post_modal.html to fix UndefinedError (hotfix reactions-import).
 - Fixed dashboard template variable names to match admin route and replaced stats.users usage with new_users_week (hotfix admin-dashboard-stats).
 - Redesigned comment modal using feed post card layout and fixed share modal backdrop removal (PR share-modal-redesign).
+- Updated IA route to use OpenRouter chat completions API, added OPENROUTER_API_KEY config and CSP connect-src entry (PR openrouter-api-fix).

--- a/crunevo/config.py
+++ b/crunevo/config.py
@@ -36,6 +36,7 @@ class Config:
     MAIL_DEFAULT_SENDER = os.getenv("MAIL_SENDER", f"Crunevo <{MAIL_USERNAME}>")
 
     RESEND_API_KEY = os.getenv("RESEND_API_KEY")
+    OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
     MAIL_PROVIDER = os.getenv("MAIL_PROVIDER", "smtp")
     USE_RESEND = MAIL_PROVIDER == "resend" or RESEND_API_KEY is not None
     MAIL_SUPPRESS_SEND = (
@@ -74,7 +75,11 @@ class Config:
             "https://cdn.jsdelivr.net",
             "https://unpkg.com",
         ],
-        "connect-src": ["'self'", "https://res.cloudinary.com"],
+        "connect-src": [
+            "'self'",
+            "https://res.cloudinary.com",
+            "https://openrouter.ai",
+        ],
         "frame-src": ["'self'", "https://res.cloudinary.com"],
     }
 

--- a/crunevo/routes/ia_routes.py
+++ b/crunevo/routes/ia_routes.py
@@ -20,22 +20,19 @@ def ia_ask():
     if not prompt:
         return jsonify({"error": "empty"}), 400
     try:
+        api_key = current_app.config.get("OPENROUTER_API_KEY")
         resp = requests.post(
-            "https://openrouter.ai/deepseek/deepseek-chat-v3-0324:free/api",
+            "https://openrouter.ai/api/v1/chat/completions",
+            headers={"Authorization": f"Bearer {api_key}"} if api_key else None,
             json={
-                "model": "deepseek/deepseek-chat:free",
-                "api_key": "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",
-                "prompt": prompt,
+                "model": "deepseek/deepseek-chat",
+                "messages": [{"role": "user", "content": prompt}],
             },
             timeout=15,
         )
         resp.raise_for_status()
         data = resp.json()
-        answer = (
-            data.get("answer")
-            or data.get("choices", [{}])[0].get("message", {}).get("content")
-            or ""
-        )
+        answer = data.get("choices", [{}])[0].get("message", {}).get("content", "")
         return jsonify({"answer": answer})
     except Exception:
         current_app.logger.exception("AI request failed")


### PR DESCRIPTION
## Summary
- fix IA route to use OpenRouter chat completions endpoint
- configure `OPENROUTER_API_KEY` and allow OpenRouter in CSP
- add variable to `.env.example`
- document change in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6861fa3b98c48325b0b20b7b109c967d