### PR TITLE
Fix admin user links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -436,3 +436,4 @@
 - Added admin.run_ranking route invoking calculate_weekly_ranking and linked from dashboard (hotfix admin-run-ranking-route).
 - Updated IA route headers to include Content-Type and switched model to "deepseek-chat" via OpenRouter (PR deepseek-openrouter).
 - Improved IA route error handling and added extra padding to chat messages to avoid footer overlap (PR deepseek-openrouter-ui-fix).
+- Fixed manage_users links to avoid BuildError when admin endpoints are missing (hotfix admin-user-links).

--- a/crunevo/templates/admin/manage_users.html
+++ b/crunevo/templates/admin/manage_users.html
@@ -53,13 +53,13 @@
             </td>
             <td>{{ user.created_at.strftime('%d/%m/%Y') if user.created_at else 'N/A' }}</td>
             <td>
-              <a href="{{ url_for('admin.user_activity', user_id=user.id) }}" class="btn btn-sm btn-outline-info">
+              <a href="{{ url_for('admin.user_activity', user_id=user.id) if 'admin.user_activity' in url_for.__globals__.get('current_app', {}).view_functions else '#' }}" class="btn btn-sm btn-outline-info">
                 <i class="bi bi-clock-history"></i> Historial
               </a>
               <a href="#" class="btn btn-sm btn-outline-primary" data-bs-toggle="modal" data-bs-target="#editRoleModal" data-user-id="{{ user.id }}" data-user-role="{{ user.role }}">
                 Cambiar Rol
               </a>
-              <a href="{{ url_for('admin.toggle_user_status', user_id=user.id) }}" class="btn btn-sm btn-outline-warning">
+              <a href="{{ url_for('admin.toggle_user_status', user_id=user.id) if 'admin.toggle_user_status' in url_for.__globals__.get('current_app', {}).view_functions else '#' }}" class="btn btn-sm btn-outline-warning">
                 {{ 'Desactivar' if user.activated else 'Activar' }}
               </a>
             </td>

--- a/crunevo/templates/admin/modals/edit_role.html
+++ b/crunevo/templates/admin/modals/edit_role.html
@@ -1,7 +1,7 @@
 {% import 'components/csrf.html' as csrf %}
 <div class="modal fade" id="editRoleModal{{ user.id }}" tabindex="-1">
   <div class="modal-dialog">
-    <form method="POST" action="{{ url_for('admin.update_user_role', user_id=user.id) }}">
+    <form method="POST" action="{{ url_for('admin.update_user_role', user_id=user.id) if 'admin.update_user_role' in url_for.__globals__.get('current_app', {}).view_functions else '#' }}">
       {{ csrf.csrf_field() }}
       <div class="modal-content">
         <div class="modal-header">


### PR DESCRIPTION
## Summary
- avoid BuildError in admin user management templates when optional routes are absent
- record the change in `AGENTS.md`

## Testing
- `make fmt`
- `make test` *(fails: 4 failed, 71 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686204f7afd883259100e975239a42ce