### PR TITLE
Fix OpenRouter referer fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,5 +5,6 @@ DATABASE_URL=postgresql://user:password@localhost:5432/dbname
 CLOUDINARY_URL=cloudinary://APIKEY:SECRET@cloudname
 RESEND_API_KEY=
 OPENROUTER_API_KEY=
+OPENROUTER_MODEL=deepseek-chat
 MAIL_USERNAME=noreply@crunevo.com
 MAIL_PROVIDER=resend

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -438,3 +438,4 @@
 - Improved IA route error handling and added extra padding to chat messages to avoid footer overlap (PR deepseek-openrouter-ui-fix).
 - Added HTTP-Referer and X-Title headers when calling OpenRouter to satisfy API requirements (hotfix openrouter-headers).
 - Fixed manage_users links to avoid BuildError when admin endpoints are missing (hotfix admin-user-links).
+- Adjusted IA referer header fallback to request.url_root and added OPENROUTER_MODEL config (hotfix openrouter-referer-model).

--- a/crunevo/config.py
+++ b/crunevo/config.py
@@ -37,6 +37,7 @@ class Config:
 
     RESEND_API_KEY = os.getenv("RESEND_API_KEY")
     OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
+    OPENROUTER_MODEL = os.getenv("OPENROUTER_MODEL", "deepseek-chat")
     MAIL_PROVIDER = os.getenv("MAIL_PROVIDER", "smtp")
     USE_RESEND = MAIL_PROVIDER == "resend" or RESEND_API_KEY is not None
     MAIL_SUPPRESS_SEND = (

--- a/crunevo/routes/ia_routes.py
+++ b/crunevo/routes/ia_routes.py
@@ -21,17 +21,20 @@ def ia_ask():
         return jsonify({"error": "empty"}), 400
     try:
         api_key = current_app.config.get("OPENROUTER_API_KEY")
+        base_url = current_app.config.get("PUBLIC_BASE_URL") or request.url_root.rstrip(
+            "/"
+        )
         headers = {
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
-            "HTTP-Referer": current_app.config.get("PUBLIC_BASE_URL"),
+            "HTTP-Referer": base_url,
             "X-Title": "Crunebot",
         }
         resp = requests.post(
             "https://openrouter.ai/api/v1/chat/completions",
             headers=headers,
             json={
-                "model": "deepseek-chat",
+                "model": current_app.config.get("OPENROUTER_MODEL", "deepseek-chat"),
                 "messages": [{"role": "user", "content": prompt}],
             },
             timeout=15,


### PR DESCRIPTION
## Summary
- compute OpenRouter HTTP-Referer from PUBLIC_BASE_URL or request.url_root
- allow configuring OPENROUTER_MODEL
- document the change and update example env file

## Testing
- `make fmt`
- `make test` *(fails: test_alembic_upgrade, test_moderator_read_only, test_admin_can_approve, test_admin_verification_csrf)*

------
https://chatgpt.com/codex/tasks/task_e_68620abc11c483258088d37db7696661