### PR TITLE
Hotfix OpenAI API call

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -442,3 +442,4 @@
 - Guarded Crunebot button and route on admin instance; restored admin store alias and verification routes; updated migrations with existence checks (PR admin-crunebot-fix).
 - Fixed TemplateSyntaxError in club list and added safety checks in migrations (PR template-migration-fixes).
 - Replaced OpenRouter integration with direct OpenAI ChatCompletion API and updated config, requirements and .env (PR openai-integration).
+- Updated ia_routes to use new openai.chat.completions API and fix crash (hotfix openai-api-call).

--- a/crunevo/routes/ia_routes.py
+++ b/crunevo/routes/ia_routes.py
@@ -21,7 +21,7 @@ def ia_ask():
         return jsonify({"error": "empty"}), 400
     try:
         openai.api_key = current_app.config.get("OPENAI_API_KEY")
-        completion = openai.ChatCompletion.create(
+        completion = openai.chat.completions.create(
             model="gpt-3.5-turbo",
             messages=[{"role": "user", "content": prompt}],
         )


### PR DESCRIPTION
## Summary
- update IA chat route to use `openai.chat.completions.create`
- document change in `AGENTS.md`

## Testing
- `make fmt`
- `make test` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686235f4ed0883259539d38ef3ac75e3