### PR TITLE
Fix chat footer layout and dynamic year

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -443,3 +443,4 @@
 - Fixed TemplateSyntaxError in club list and added safety checks in migrations (PR template-migration-fixes).
 - Replaced OpenRouter integration with direct OpenAI ChatCompletion API and updated config, requirements and .env (PR openai-integration).
 - Updated ia_routes to use new openai.chat.completions API and fix crash (hotfix openai-api-call).
+- Improved chat layout: added footer padding, dynamic year and footer styling (PR chat-footer-fix).

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -177,10 +177,14 @@ body {
 }
 
 .chat-container {
-  height: 300px;
+  max-height: calc(100vh - 160px);
   overflow-y: auto;
   border-radius: 12px;
   background: rgba(255, 255, 255, 0.02);
+}
+
+.chat-messages {
+  padding-bottom: 120px;
 }
 
 /* Modern messages with Messenger-style design */
@@ -626,5 +630,18 @@ html[data-bs-theme="dark"] .feed-section {
 html[data-bs-theme="dark"] .text-dark,
 html[data-bs-theme="dark"] .text-black {
   color: #ffffff !important;
+}
+
+footer {
+  position: relative;
+  z-index: 1000;
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(10px);
+  border-top: 1px solid #e0e0e0;
+}
+
+html[data-bs-theme="dark"] footer {
+  background: rgba(13, 17, 23, 0.95);
+  border-top-color: #30363d;
 }
 

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -86,11 +86,11 @@
     </main>
 
     <!-- Enhanced footer -->
-    <footer class="text-center py-4 mt-5" style="background: rgba(255,255,255,0.05); backdrop-filter: blur(10px);">
+    <footer class="text-center py-4 mt-5" style="position: relative; z-index: 1000; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); border-top: 1px solid #e0e0e0;">
       <div class="container">
         <div class="row align-items-center">
           <div class="col-md-6 text-md-start">
-            <span class="text-muted small">© 2024 Crunevo - Construyendo el futuro educativo</span>
+            <span class="text-muted small">© <span id="year"></span> Crunevo - Construyendo el futuro educativo</span>
           </div>
           <div class="col-md-6 text-md-end">
             <a href="{{ url_for('about.about') if 'about.about' in url_for.__globals__.get('current_app', {}).view_functions else '/about' }}" class="text-muted text-decoration-none me-3 small">Sobre Crunevo</a>
@@ -230,6 +230,9 @@
     <!-- Main app initialization -->
     <script src="{{ url_for('static', filename='js/main.js') }}" defer></script>
     <script src="{{ url_for('static', filename='js/share.js') }}" defer></script>
+    <script>
+      document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
 
     {% block body_end %}{% endblock %}
 </body>

--- a/crunevo/templates/chat/global.html
+++ b/crunevo/templates/chat/global.html
@@ -5,12 +5,12 @@
 {% block head_extra %}
 <style>
 .chat-container {
-  height: 500px;
+  max-height: calc(100vh - 160px);
   overflow-y: auto;
   border: 1px solid #dee2e6;
   border-radius: 12px;
   background: rgba(255,255,255,0.05);
-  padding: 1rem;
+  padding: 1rem 1rem 120px;
 }
 
 .message-item {

--- a/crunevo/templates/chat/private_chat.html
+++ b/crunevo/templates/chat/private_chat.html
@@ -14,7 +14,7 @@
 .chat-messages {
   height: 400px;
   overflow-y: auto;
-  padding: 1rem;
+  padding: 1rem 1rem 120px;
   background: rgba(255,255,255,0.02);
 }
 

--- a/crunevo/templates/ia/chat.html
+++ b/crunevo/templates/ia/chat.html
@@ -222,7 +222,7 @@
   overflow-y: auto;
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   background-attachment: fixed;
-  padding-bottom: 100px;
+  padding-bottom: 120px;
 }
 
 .message-container {
@@ -304,7 +304,7 @@
 @media (max-width: 991.98px) {
   .chat-messages {
     padding: 1rem;
-    padding-bottom: 100px;
+    padding-bottom: 120px;
   }
   
   .message-bubble {


### PR DESCRIPTION
## Summary
- keep footer above chat with solid background
- avoid chat overlap by adding extra padding
- cap chat container height
- update footer year dynamically
- document in AGENTS log

## Testing
- `make fmt`
- `make test` *(fails: OperationalError near "EXISTS" when running migrations)*

------
https://chatgpt.com/codex/tasks/task_e_68623724979c83258ff4cdc8f8c4330c