### PR TITLE
Implement per-user login attempt limiter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -447,3 +447,4 @@
 - Added CreditReasons.ACTIVIDAD_SOCIAL constant, handled OpenAI RateLimitError in ia_routes and skipped migration test when SQLite lacks IF NOT EXISTS support (hotfix social-credit-constant).
 - Store index uses Bootstrap carousel for hero, ofertas and premium blocks; product cards show first_image or default placeholder, navbar displays cart icon with badge and JS calls /store/api/cart_count (PR store-carousel-fixes).
 - Unified store carousel height, squared product images and improved dark mode styles (PR store-ui-consistency).
+- Replaced IP rate limit on login with per-user attempt tracking using Redis or memory cache, showing countdown on the login page (PR login-attempt-limit).

--- a/crunevo/cache/login_attempts.py
+++ b/crunevo/cache/login_attempts.py
@@ -1,0 +1,99 @@
+import os
+import time
+import logging
+import redis
+
+log = logging.getLogger(__name__)
+
+r = redis.from_url(os.getenv("REDIS_URL", "redis://localhost:6379/0"))
+
+ATTEMPT_PREFIX = "login_attempts:"
+BLOCK_LIMIT = 5
+BLOCK_TTL = 15 * 60  # 15 minutes
+
+_fallback = {}
+
+
+def _client():
+    from redis.exceptions import RedisError
+
+    try:
+        r.ping()
+        return r
+    except RedisError as exc:  # pragma: no cover - fakeredis won't hit
+        log.warning("Redis ping failed – using memory cache: %s", exc)
+        return None
+
+
+def record_fail(username: str) -> int:
+    """Increase failed attempts for username and return current count."""
+    cli = _client()
+    key = ATTEMPT_PREFIX + username
+    if cli:
+        try:
+            attempts = cli.incr(key)
+            if attempts == 1:
+                cli.expire(key, BLOCK_TTL)
+            return int(attempts)
+        except redis.RedisError:
+            pass
+    now = time.time()
+    count, expiry = _fallback.get(username, (0, now + BLOCK_TTL))
+    if now > expiry:
+        count, expiry = 0, now + BLOCK_TTL
+    count += 1
+    _fallback[username] = (count, expiry)
+    return count
+
+
+def reset(username: str) -> None:
+    """Clear stored attempts for user."""
+    cli = _client()
+    key = ATTEMPT_PREFIX + username
+    if cli:
+        try:
+            cli.delete(key)
+        except redis.RedisError:
+            pass
+    _fallback.pop(username, None)
+
+
+def get_attempts(username: str) -> int:
+    cli = _client()
+    key = ATTEMPT_PREFIX + username
+    if cli:
+        try:
+            val = cli.get(key)
+            return int(val) if val else 0
+        except redis.RedisError:
+            pass
+    if username in _fallback:
+        count, expiry = _fallback[username]
+        if time.time() > expiry:
+            del _fallback[username]
+            return 0
+        return count
+    return 0
+
+
+def get_remaining(username: str) -> int:
+    cli = _client()
+    key = ATTEMPT_PREFIX + username
+    if cli:
+        try:
+            ttl = cli.ttl(key)
+            return max(ttl, 0)
+        except redis.RedisError:
+            pass
+    if username in _fallback:
+        _, expiry = _fallback[username]
+        rem = int(expiry - time.time())
+        if rem < 0:
+            del _fallback[username]
+            return 0
+        return rem
+    return 0
+
+
+def is_blocked(username: str) -> bool:
+    return get_attempts(username) >= BLOCK_LIMIT

--- a/crunevo/templates/auth/login.html
+++ b/crunevo/templates/auth/login.html
@@ -13,6 +13,9 @@
     {% if error %}
       <div class="alert alert-danger" role="alert">
         {{ error }}
+        {% if wait %}
+          <span id="loginCountdown"></span>
+        {% endif %}
       </div>
     {% endif %}
     <form method="post" novalidate>
@@ -140,5 +143,20 @@
       localStorage.setItem('theme', next);
       setThemeIcon(next);
     });
+    {% if wait %}
+    (function() {
+      let remaining = {{ wait }};
+      const el = document.getElementById('loginCountdown');
+      function tick() {
+        if (!el) return;
+        const m = Math.floor(remaining / 60);
+        const s = remaining % 60;
+        el.textContent = ` ${m}:${s.toString().padStart(2, '0')}`;
+        if (remaining > 0) remaining--;
+      }
+      tick();
+      setInterval(tick, 1000);
+    })();
+    {% endif %}
   </script>
 {% endblock %}

--- a/crunevo/templates/auth/login_admin.html
+++ b/crunevo/templates/auth/login_admin.html
@@ -5,6 +5,11 @@
 {% block content %}
 <div class="tw-max-w-md tw-mx-auto tw-my-16 tw-rounded-2xl tw-shadow-sm tw-bg-white dark:tw-bg-gray-900 tw-p-4 tw-space-y-4">
   <h2>Acceso Privado CRUNEVO</h2>
+  {% if error %}
+    <div class="alert alert-danger" role="alert">
+      {{ error }}{% if wait %} <span id="loginCountdown"></span>{% endif %}
+    </div>
+  {% endif %}
   <form method="post" class="tw-space-y-4">
     {{ csrf.csrf_field() }}
     {{ forms.input('username', placeholder='Usuario') }}
@@ -12,4 +17,25 @@
     {{ btn.button('Entrar', type='submit') }}
   </form>
 </div>
+{% endblock %}
+
+{% block body_end %}
+  {{ super() }}
+  {% if wait %}
+  <script>
+    (function() {
+      let remaining = {{ wait }};
+      const el = document.getElementById('loginCountdown');
+      function tick() {
+        if (!el) return;
+        const m = Math.floor(remaining / 60);
+        const s = remaining % 60;
+        el.textContent = ` ${m}:${s.toString().padStart(2, '0')}`;
+        if (remaining > 0) remaining--;
+      }
+      tick();
+      setInterval(tick, 1000);
+    })();
+  </script>
+  {% endif %}
 {% endblock %}

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -5,7 +5,8 @@ def test_login_rate_limit(client):
     for _ in range(5):
         client.post("/login", data={"username": "none", "password": "wrong"})
     resp = client.post("/login", data={"username": "none", "password": "wrong"})
-    assert resp.status_code == 429
+    assert resp.status_code == 200
+    assert "Has excedido el número de intentos" in resp.get_data(as_text=True)
 
 
 def test_register_rate_limit(client):


### PR DESCRIPTION
## Summary
- add `login_attempts` cache module
- implement per-user login lockout in `auth_routes`
- show countdown when locked in login templates
- update rate-limit test and document in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6862a1dcb14883259140601ff27424f0