### PR TITLE
Update notes sidebar and add feed trending

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -448,3 +448,6 @@
 - Store index uses Bootstrap carousel for hero, ofertas and premium blocks; product cards show first_image or default placeholder, navbar displays cart icon with badge and JS calls /store/api/cart_count (PR store-carousel-fixes).
 - Unified store carousel height, squared product images and improved dark mode styles (PR store-ui-consistency).
 - Replaced IP rate limit on login with per-user attempt tracking using Redis or memory cache, showing countdown on the login page (PR login-attempt-limit).
+
+- Replaced notes sidebar in notes list with modern feed sidebar and adjusted layout (PR notes-modern-sidebar).
+- Added trending posts section to feed sidebar with weekly top posts (PR feed-sidebar-trending).

--- a/crunevo/routes/feed_routes.py
+++ b/crunevo/routes/feed_routes.py
@@ -261,6 +261,11 @@ def view_feed():
 
     reaction_map = PostReaction.counts_for_posts(post_ids)
     user_reactions = PostReaction.reactions_for_user_posts(current_user.id, post_ids)
+    trending_posts = get_weekly_top_posts(limit=3)
+    trending_counts = PostReaction.counts_for_posts([p.id for p in trending_posts])
+    trending_user_reactions = PostReaction.reactions_for_user_posts(
+        current_user.id, [p.id for p in trending_posts]
+    )
 
     streak = current_user.login_streak
     show_streak = (
@@ -277,6 +282,9 @@ def view_feed():
         reaction_counts=reaction_map,
         user_reactions=user_reactions,
         show_streak_claim=show_streak,
+        trending_posts=trending_posts,
+        trending_counts=trending_counts,
+        trending_user_reactions=trending_user_reactions,
         streak_day=streak.current_day if streak else 1,
         streak_reward=reward,
     )

--- a/crunevo/templates/components/sidebar_left_feed.html
+++ b/crunevo/templates/components/sidebar_left_feed.html
@@ -123,6 +123,23 @@
       </ul>
     </nav>
 
+    {% if trending_posts is defined and trending_posts %}
+    <div class="trending-section mt-4 pt-4 border-top">
+      <h6 class="small text-muted mb-3 fw-bold">
+        <i class="bi bi-fire"></i> Tendencias
+      </h6>
+      <div class="d-flex flex-column gap-3">
+        {% for post in trending_posts %}
+        {% set item = {'data': post} %}
+        {% set reaction_counts = trending_counts %}
+        {% set user_reactions = trending_user_reactions %}
+        {% include 'components/post_card.html' with context %}
+        {% endfor %}
+        <a href="{{ url_for('feed.trending') }}" class="btn btn-outline-primary btn-sm rounded-pill">Ver más</a>
+      </div>
+    </div>
+    {% endif %}
+
     <!-- Quick Actions -->
     <div class="quick-actions mt-4 pt-4 border-top">
       <h6 class="small text-muted mb-3 fw-bold">Acciones rápidas</h6>

--- a/crunevo/templates/notes/list.html
+++ b/crunevo/templates/notes/list.html
@@ -2,11 +2,11 @@
 {% block content %}
 <div class="row">
   <!-- Lado izquierdo (menú lateral) -->
-  <div class="col-lg-2 d-none d-lg-block">
-    {% include 'components/sidebar_left.html' %}
+  <div class="col-lg-3 d-none d-lg-block">
+    {% include 'components/sidebar_left_feed.html' %}
   </div>
   <!-- Contenido central -->
-  <div class="col-lg-7 col-md-12">
+  <div class="col-lg-9 col-md-12">
     <h2 class="mb-3">Apuntes</h2>
     <div class="d-flex flex-wrap gap-2 mb-3 justify-content-center">
       <a href="{{ url_for('notes.list_notes', filter='recientes', tag=selected_tag) }}" class="btn btn-outline-primary {% if filter == 'recientes' %}active{% endif %}">📅 Recientes</a>


### PR DESCRIPTION
## Summary
- modernize notes sidebar using feed sidebar
- display weekly trending posts in feed sidebar
- document changes in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6862a70b2bf08325a32debac972e0285