### PR TITLE
Add settings page and dropdown options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -451,3 +451,4 @@
 
 - Replaced notes sidebar in notes list with modern feed sidebar and adjusted layout (PR notes-modern-sidebar).
 - Added trending posts section to feed sidebar with weekly top posts (PR feed-sidebar-trending).
+- Added settings page '/configuracion' with authenticated route and sidebar. Updated user dropdown with copy, edit and configuración options (PR settings-page).

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -180,6 +180,7 @@ def create_app():
     from .routes.about_routes import about_bp
     from .routes.static_routes import static_bp
     from .routes.saved_routes import saved_bp
+    from .routes.settings_routes import settings_bp
     from .routes.main_routes import main_bp
 
     is_admin = os.environ.get("ADMIN_INSTANCE") == "1"
@@ -284,6 +285,7 @@ def create_app():
         app.register_blueprint(about_bp)
         app.register_blueprint(static_bp)
         app.register_blueprint(saved_bp)
+        app.register_blueprint(settings_bp)
         app.register_blueprint(errors_bp)
         if testing_env:
             app.register_blueprint(admin_bp)

--- a/crunevo/routes/settings_routes.py
+++ b/crunevo/routes/settings_routes.py
@@ -1,0 +1,29 @@
+from flask import Blueprint, render_template, request, jsonify
+from flask_login import login_required, current_user
+from crunevo.utils.helpers import activated_required
+from crunevo.extensions import db
+from crunevo.models import User
+
+settings_bp = Blueprint("settings", __name__, url_prefix="/configuracion")
+
+
+@settings_bp.route("/")
+@login_required
+@activated_required
+def index():
+    return render_template("configuracion/index.html")
+
+
+@settings_bp.route("/personal", methods=["POST"])
+@login_required
+@activated_required
+def update_personal():
+    username = request.form.get("username", "").strip()
+    about = request.form.get("about", "")
+    if username and username != current_user.username:
+        if User.query.filter_by(username=username).first():
+            return jsonify(success=False, error="Nombre de usuario no disponible"), 400
+        current_user.username = username
+    current_user.about = about
+    db.session.commit()
+    return jsonify(success=True)

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -607,6 +607,9 @@ document.addEventListener('DOMContentLoaded', () => {
     initFeedSearch();
   }
   initGlobalSearch();
+  if (typeof initSettingsPage === 'function') {
+    initSettingsPage();
+  }
 
   if (typeof initAdminCharts === 'function') {
     initAdminCharts();
@@ -665,6 +668,14 @@ document.addEventListener('DOMContentLoaded', () => {
       navigator.clipboard.writeText(window.location.href).then(() => {
         showToast('Enlace copiado');
       });
+    });
+  }
+
+  const copyProfile = document.getElementById('copyProfileUrl');
+  if (copyProfile && window.CURRENT_USER) {
+    copyProfile.addEventListener('click', () => {
+      const url = `${window.location.origin}/perfil/${window.CURRENT_USER.username}`;
+      navigator.clipboard.writeText(url).then(() => showToast('Enlace copiado'));
     });
   }
 

--- a/crunevo/static/js/settings.js
+++ b/crunevo/static/js/settings.js
@@ -1,0 +1,18 @@
+function initSettingsPage() {
+  document.querySelectorAll('.settings-form').forEach((form) => {
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const resp = await csrfFetch(form.action, {
+        method: 'POST',
+        body: new FormData(form),
+      });
+      if (resp.ok) {
+        showToast('Cambios guardados');
+      } else {
+        showToast('Error al guardar', { delay: 5000 });
+      }
+    });
+  });
+}
+window.initSettingsPage = initSettingsPage;
+

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -194,6 +194,7 @@
     <!-- App JavaScript with enhanced loading -->
     <script src="{{ url_for('static', filename='js/feed_toggle.js') }}" defer></script>
     <script src="{{ url_for('static', filename='js/feed.js') }}" defer></script>
+    <script src="{{ url_for('static', filename='js/settings.js') }}" defer></script>
 
     <!-- Configuration variables -->
     <script>

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -90,6 +90,16 @@
               <span class="d-none d-lg-inline">{{ current_user.username }}</span>
             </a>
             <ul class="dropdown-menu dropdown-menu-end">
+              <li>
+                <button class="dropdown-item" id="copyProfileUrl" type="button">
+                  <i class="bi bi-clipboard me-2"></i>Copiar
+                </button>
+              </li>
+              <li>
+                <a class="dropdown-item" href="{{ url_for('auth.perfil') }}?edit=1">
+                  <i class="bi bi-pencil-square me-2"></i>Editar
+                </a>
+              </li>
               <li><a class="dropdown-item" href="{{ url_for('auth.perfil') }}">
                 <i class="bi bi-person me-2"></i>Mi Perfil
               </a></li>
@@ -103,6 +113,10 @@
               <li><span class="dropdown-item-text">
                 <i class="bi bi-coin me-2"></i>{{ current_user.credits }} Crolars
               </span></li>
+              <li><hr class="dropdown-divider"></li>
+              <li><a class="dropdown-item" href="{{ url_for('settings.index') }}">
+                <i class="bi bi-gear me-2"></i>Configuración
+              </a></li>
               <li><hr class="dropdown-divider"></li>
               <li>
                 <button class="dropdown-item d-flex align-items-center gap-2" type="button" data-theme-toggle>

--- a/crunevo/templates/configuracion/cuenta.html
+++ b/crunevo/templates/configuracion/cuenta.html
@@ -1,0 +1,10 @@
+<section id="account" class="mb-4">
+  <div class="card shadow-sm border-0">
+    <div class="card-header bg-white">
+      <h5 class="mb-0">Cuenta y seguridad</h5>
+    </div>
+    <div class="card-body">
+      <p class="text-muted">Próximamente podrás actualizar tu correo y contraseña.</p>
+    </div>
+  </div>
+</section>

--- a/crunevo/templates/configuracion/index.html
+++ b/crunevo/templates/configuracion/index.html
@@ -1,0 +1,38 @@
+{% extends 'base.html' %}
+{% import 'components/csrf.html' as csrf %}
+
+{% block title %}Configuración{% endblock %}
+
+{% block content %}
+<div class="container-fluid py-4" style="background-color:#f5f0ff;">
+  <div class="row g-4">
+    <div class="col-lg-3">
+      <div class="list-group mb-4">
+        <a href="#personal" class="list-group-item list-group-item-action">Información personal</a>
+        <a href="#account" class="list-group-item list-group-item-action">Cuenta y seguridad</a>
+        <a href="#verificacion" class="list-group-item list-group-item-action">Verificación</a>
+        <a href="#notificaciones" class="list-group-item list-group-item-action">Notificaciones</a>
+        <a href="#plus" class="list-group-item list-group-item-action">CRUNEVO+</a>
+        <a href="#legal" class="list-group-item list-group-item-action">Centro de ayuda / Legal</a>
+      </div>
+    </div>
+    <div class="col-lg-9">
+      <div class="d-flex align-items-center mb-4">
+        <i class="bi bi-gear-fill fs-2 me-2"></i>
+        <h2 class="mb-0 flex-grow-1">Configuración</h2>
+        <a href="{{ url_for('auth.perfil') }}" class="btn btn-outline-secondary">Volver al perfil</a>
+      </div>
+      {% include 'configuracion/personal.html' %}
+      {% include 'configuracion/cuenta.html' %}
+      {% include 'configuracion/verificacion.html' %}
+      {% include 'configuracion/notificaciones.html' %}
+      {% include 'configuracion/plus.html' %}
+      {% include 'configuracion/legal.html' %}
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block body_end %}
+<script src="{{ url_for('static', filename='js/settings.js') }}" defer></script>
+{% endblock %}

--- a/crunevo/templates/configuracion/legal.html
+++ b/crunevo/templates/configuracion/legal.html
@@ -1,0 +1,14 @@
+<section id="legal" class="mb-4">
+  <div class="card shadow-sm border-0">
+    <div class="card-header bg-white">
+      <h5 class="mb-0">Centro de ayuda / Legal</h5>
+    </div>
+    <div class="card-body">
+      <ul class="list-unstyled">
+        <li><a href="{{ url_for('main.terminos') if 'main.terminos' in url_for.__globals__.get('current_app', {}).view_functions else '/terminos' }}">Términos y condiciones</a></li>
+        <li><a href="{{ url_for('main.privacidad') if 'main.privacidad' in url_for.__globals__.get('current_app', {}).view_functions else '/privacidad' }}">Política de privacidad</a></li>
+        <li><a href="{{ url_for('static_pages.cookies') if 'static_pages.cookies' in url_for.__globals__.get('current_app', {}).view_functions else '/cookies' }}">Política de cookies</a></li>
+      </ul>
+    </div>
+  </div>
+</section>

--- a/crunevo/templates/configuracion/notificaciones.html
+++ b/crunevo/templates/configuracion/notificaciones.html
@@ -1,0 +1,10 @@
+<section id="notificaciones" class="mb-4">
+  <div class="card shadow-sm border-0">
+    <div class="card-header bg-white">
+      <h5 class="mb-0">Notificaciones</h5>
+    </div>
+    <div class="card-body">
+      <p class="text-muted">Configura tus preferencias de notificación.</p>
+    </div>
+  </div>
+</section>

--- a/crunevo/templates/configuracion/personal.html
+++ b/crunevo/templates/configuracion/personal.html
@@ -1,0 +1,21 @@
+<section id="personal" class="mb-4">
+  <div class="card shadow-sm border-0">
+    <div class="card-header bg-white">
+      <h5 class="mb-0">Información personal</h5>
+    </div>
+    <div class="card-body">
+      <form id="personalForm" class="settings-form" method="post" action="{{ url_for('settings.update_personal') }}">
+        {{ csrf.csrf_field() }}
+        <div class="mb-3">
+          <label for="username" class="form-label">Nombre de usuario</label>
+          <input type="text" class="form-control" id="username" name="username" value="{{ current_user.username }}">
+        </div>
+        <div class="mb-3">
+          <label for="about" class="form-label">Descripción</label>
+          <textarea class="form-control" id="about" name="about" rows="3">{{ current_user.about }}</textarea>
+        </div>
+        <button type="submit" class="btn btn-primary">Guardar</button>
+      </form>
+    </div>
+  </div>
+</section>

--- a/crunevo/templates/configuracion/plus.html
+++ b/crunevo/templates/configuracion/plus.html
@@ -1,0 +1,10 @@
+<section id="plus" class="mb-4">
+  <div class="card shadow-sm border-0">
+    <div class="card-header bg-white">
+      <h5 class="mb-0">CRUNEVO+</h5>
+    </div>
+    <div class="card-body">
+      <p class="text-muted">Plan actual: Gratuito</p>
+    </div>
+  </div>
+</section>

--- a/crunevo/templates/configuracion/verificacion.html
+++ b/crunevo/templates/configuracion/verificacion.html
@@ -1,0 +1,12 @@
+<section id="verificacion" class="mb-4">
+  <div class="card shadow-sm border-0">
+    <div class="card-header bg-white">
+      <h5 class="mb-0">Verificación</h5>
+    </div>
+    <div class="card-body">
+      <p class="text-muted">Estado de verificación:
+        {% if current_user.verification_level > 0 %}Verificado{% else %}No verificado{% endif %}
+      </p>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- implement `/configuracion` route and settings blueprint
- create settings templates and JS for AJAX save
- load `settings.js` globally and initialize from `main.js`
- extend navbar dropdown with copy, edit and settings links
- document changes in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6862abd07e9c8325af42ceaebd9ac4ad