### PR TITLE
Add password change option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -453,3 +453,4 @@
 - Added trending posts section to feed sidebar with weekly top posts (PR feed-sidebar-trending).
 - Added settings page '/configuracion' with authenticated route and sidebar. Updated user dropdown with copy, edit and configuración options (PR settings-page).
 - Removed copy and edit options from user dropdown and related JS listener (PR profile-menu-cleanup).
+- Added password change form and backend route under settings (PR settings-change-password).

--- a/crunevo/routes/settings_routes.py
+++ b/crunevo/routes/settings_routes.py
@@ -27,3 +27,25 @@ def update_personal():
     current_user.about = about
     db.session.commit()
     return jsonify(success=True)
+
+
+@settings_bp.route("/password", methods=["POST"])
+@login_required
+@activated_required
+def update_password():
+    current = request.form.get("current_password")
+    new_pw = request.form.get("new_password")
+    confirm = request.form.get("confirm_new")
+    if not current_user.check_password(current):
+        return (
+            jsonify(success=False, error="Contraseña actual incorrecta"),
+            400,
+        )
+    if not new_pw or new_pw != confirm:
+        return (
+            jsonify(success=False, error="Las contraseñas no coinciden"),
+            400,
+        )
+    current_user.set_password(new_pw)
+    db.session.commit()
+    return jsonify(success=True)

--- a/crunevo/templates/configuracion/cuenta.html
+++ b/crunevo/templates/configuracion/cuenta.html
@@ -4,7 +4,22 @@
       <h5 class="mb-0">Cuenta y seguridad</h5>
     </div>
     <div class="card-body">
-      <p class="text-muted">Próximamente podrás actualizar tu correo y contraseña.</p>
+      <form id="passwordForm" class="settings-form" method="post" action="{{ url_for('settings.update_password') }}">
+        {{ csrf.csrf_field() }}
+        <div class="mb-3">
+          <label for="current_password" class="form-label">Contraseña actual</label>
+          <input type="password" class="form-control" id="current_password" name="current_password" autocomplete="current-password">
+        </div>
+        <div class="mb-3">
+          <label for="new_password" class="form-label">Nueva contraseña</label>
+          <input type="password" class="form-control" id="new_password" name="new_password" autocomplete="new-password">
+        </div>
+        <div class="mb-3">
+          <label for="confirm_new" class="form-label">Confirmar nueva contraseña</label>
+          <input type="password" class="form-control" id="confirm_new" name="confirm_new" autocomplete="new-password">
+        </div>
+        <button type="submit" class="btn btn-primary">Cambiar contraseña</button>
+      </form>
     </div>
   </div>
 </section>

--- a/tests/test_settings_password.py
+++ b/tests/test_settings_password.py
@@ -1,0 +1,47 @@
+def login(client, username, password="secret"):
+    return client.post("/login", data={"username": username, "password": password})
+
+
+def test_change_password_success(client, db_session, test_user):
+    login(client, test_user.username)
+    resp = client.post(
+        "/configuracion/password",
+        data={
+            "current_password": "secret",
+            "new_password": "newsecret",
+            "confirm_new": "newsecret",
+        },
+    )
+    assert resp.status_code == 200
+    db_session.refresh(test_user)
+    assert test_user.check_password("newsecret")
+
+
+def test_change_password_wrong_current(client, db_session, test_user):
+    login(client, test_user.username)
+    resp = client.post(
+        "/configuracion/password",
+        data={
+            "current_password": "wrong",
+            "new_password": "newsecret",
+            "confirm_new": "newsecret",
+        },
+    )
+    assert resp.status_code == 400
+    db_session.refresh(test_user)
+    assert test_user.check_password("secret")
+
+
+def test_change_password_mismatch(client, db_session, test_user):
+    login(client, test_user.username)
+    resp = client.post(
+        "/configuracion/password",
+        data={
+            "current_password": "secret",
+            "new_password": "newsecret",
+            "confirm_new": "other",
+        },
+    )
+    assert resp.status_code == 400
+    db_session.refresh(test_user)
+    assert test_user.check_password("secret")


### PR DESCRIPTION
## Summary
- implement password update route
- add password change form in configuration
- test password updates
- document progress in AGENTS guidelines

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6862b0b4ac388325a6e7c0286d58e797