### PR TITLE
Fix username settings and profile banner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -454,3 +454,4 @@
 - Added settings page '/configuracion' with authenticated route and sidebar. Updated user dropdown with copy, edit and configuración options (PR settings-page).
 - Removed copy and edit options from user dropdown and related JS listener (PR profile-menu-cleanup).
 - Added password change form and backend route under settings (PR settings-change-password).
+- Split personal settings into separate username and description forms with real-time availability check and page reload on success. Updated profile header to show username overlay on banner (PR settings-username-fix).

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -15,7 +15,15 @@
     <div class="col-lg-6">
       <!-- Profile Header -->
       <div class="card border-0 shadow-sm mb-4">
-        <div class="profile-header-bg" style="height: 150px; background: linear-gradient(135deg, #667eea, #764ba2); border-radius: 16px 16px 0 0;"></div>
+        <div class="position-relative">
+          <div class="profile-header-bg" style="height: 150px; background: linear-gradient(135deg, #667eea, #764ba2); border-radius: 16px 16px 0 0;"></div>
+          <div class="username-display">
+            {{ user.username }}
+            {% if user.verification_level > 0 %}
+            <i class="bi bi-patch-check-fill ms-1"></i>
+            {% endif %}
+          </div>
+        </div>
         <div class="card-body p-4" style="margin-top: -75px;">
           <div class="row align-items-end">
             <div class="col-auto">
@@ -33,12 +41,6 @@
             </div>
             <div class="col">
               <div class="mt-3">
-                <div class="d-flex align-items-center gap-2 mb-2">
-                  <h2 class="fw-bold text-dark mb-0">{{ user.username }}</h2>
-                  {% if user.verification_level > 0 %}
-                  <i class="bi bi-patch-check-fill text-primary fs-4"></i>
-                  {% endif %}
-                </div>
                 
                 {% if user.about %}
                 <p class="text-muted mb-3">{{ user.about }}</p>
@@ -407,10 +409,23 @@
 <style>
 .profile-header-bg {
   position: relative;
+  z-index: 0;
 }
 
 .profile-avatar-container {
   z-index: 10;
+}
+
+.username-display {
+  position: absolute;
+  bottom: 12px;
+  left: 16px;
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  padding: 4px 8px;
+  border-radius: 8px;
+  font-weight: bold;
+  z-index: 2;
 }
 
 .stat-item {

--- a/crunevo/templates/configuracion/personal.html
+++ b/crunevo/templates/configuracion/personal.html
@@ -1,15 +1,30 @@
 <section id="personal" class="mb-4">
   <div class="card shadow-sm border-0">
     <div class="card-header bg-white">
-      <h5 class="mb-0">Información personal</h5>
+      <h5 class="mb-0">Nombre de usuario</h5>
     </div>
     <div class="card-body">
-      <form id="personalForm" class="settings-form" method="post" action="{{ url_for('settings.update_personal') }}">
+      <form id="usernameForm" class="settings-form" method="post" action="{{ url_for('settings.update_personal') }}">
         {{ csrf.csrf_field() }}
         <div class="mb-3">
           <label for="username" class="form-label">Nombre de usuario</label>
-          <input type="text" class="form-control" id="username" name="username" value="{{ current_user.username }}">
+          <input type="text" class="form-control" id="username" name="username" value="{{ current_user.username }}" data-current="{{ current_user.username }}">
+          <div id="usernameFeedback" class="form-text"></div>
         </div>
+        <button type="submit" class="btn btn-primary">Guardar</button>
+      </form>
+    </div>
+  </div>
+</section>
+
+<section id="descripcion" class="mb-4">
+  <div class="card shadow-sm border-0">
+    <div class="card-header bg-white">
+      <h5 class="mb-0">Descripción</h5>
+    </div>
+    <div class="card-body">
+      <form id="aboutForm" class="settings-form" method="post" action="{{ url_for('settings.update_personal') }}">
+        {{ csrf.csrf_field() }}
         <div class="mb-3">
           <label for="about" class="form-label">Descripción</label>
           <textarea class="form-control" id="about" name="about" rows="3">{{ current_user.about }}</textarea>


### PR DESCRIPTION
## Summary
- split personal settings into separate username and description cards
- add real-time username availability check with reload on change
- overlay username on banner in profile header to avoid overlap

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6862b463e6608325a9c5d654685ce47b