### PR TITLE
Centralize JS init in main handler

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -460,3 +460,4 @@
 - Styled feed sidebar trend card with bi-fire icon before text (PR feed-sidebar-fire-icon).
 - Diagnóstico de carpeta components realizado; listado de archivos y detección de duplicados funcionales. Se sugirió refactorización (QA components-diagnosis).
 - Unificada la barra lateral del feed, eliminando la versión duplicada y actualizando las vistas a usar components/sidebar_left_feed.html (PR feed-sidebar-unify).
+- Consolidated script initialization: moved DOMContentLoaded handlers from feed.js, notifications.js, share.js and chatia.js into main.js; modules expose init functions (PR unify-js-entry).

--- a/crunevo/static/js/chatia.js
+++ b/crunevo/static/js/chatia.js
@@ -1,4 +1,4 @@
-document.addEventListener('DOMContentLoaded', () => {
+function initChatIA() {
   const form = document.getElementById('aiForm');
   const input = document.getElementById('aiInput');
   const history = document.getElementById('aiHistory');
@@ -49,4 +49,5 @@ document.addEventListener('DOMContentLoaded', () => {
         showToast('Error de conexión');
       });
   });
-});
+}
+window.initChatIA = initChatIA;

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -720,8 +720,9 @@ style.textContent = `
 `;
 document.head.appendChild(style);
 
-// Initialize feed manager when DOM is ready
+// Feed manager initialization handled in main.js
 let feedManager;
-document.addEventListener('DOMContentLoaded', () => {
+function initFeedManager() {
   feedManager = new FeedManager();
-});
+}
+window.initFeedManager = initFeedManager;

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -574,6 +574,19 @@ document.addEventListener('DOMContentLoaded', () => {
     initNoteViewer();
   }
 
+  if (typeof initFeedManager === 'function') {
+    initFeedManager();
+  }
+  if (typeof initNotificationManager === 'function') {
+    initNotificationManager();
+  }
+  if (typeof initShareButtons === 'function') {
+    initShareButtons();
+  }
+  if (typeof initChatIA === 'function') {
+    initChatIA();
+  }
+
   document.querySelectorAll('.achievement-card').forEach((el) => {
     if (el.title && !bootstrap.Tooltip.getInstance(el)) {
       bootstrap.Tooltip.getOrCreateInstance(el);

--- a/crunevo/static/js/notifications.js
+++ b/crunevo/static/js/notifications.js
@@ -74,9 +74,10 @@ class NotificationManager {
     }
 }
 
-// Inicializar cuando el DOM esté listo
-document.addEventListener('DOMContentLoaded', () => {
+// Initialization handled in main.js
+function initNotificationManager() {
     if (window.CURRENT_USER_ID) {
         new NotificationManager();
     }
-});
+}
+window.initNotificationManager = initNotificationManager;

--- a/crunevo/static/js/share.js
+++ b/crunevo/static/js/share.js
@@ -54,10 +54,10 @@ function createToastContainer() {
 }
 
 // Add share buttons to posts and notes
-document.addEventListener('DOMContentLoaded', function() {
-  // Add share buttons to existing content
+function initShareButtons() {
   addShareButtons();
-});
+}
+window.initShareButtons = initShareButtons;
 
 function addShareButtons() {
   // Add to post cards


### PR DESCRIPTION
## Summary
- export init functions from chatia.js, feed.js, notifications.js and share.js
- invoke those init functions from the DOMContentLoaded handler in `main.js`
- note the update in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6862db62aef483259c3880e24a8ce95a