### PR TITLE
Add background queue for feed items

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -460,3 +460,4 @@
 - Styled feed sidebar trend card with bi-fire icon before text (PR feed-sidebar-fire-icon).
 - Diagnóstico de carpeta components realizado; listado de archivos y detección de duplicados funcionales. Se sugirió refactorización (QA components-diagnosis).
 - Unificada la barra lateral del feed, eliminando la versión duplicada y actualizando las vistas a usar components/sidebar_left_feed.html (PR feed-sidebar-unify).
+- Introducida cola de tareas con RQ y worker para insertar publicaciones de feed asincrónamente; create_feed_item_for_all ahora encola la tarea (PR feed-queue-worker).

--- a/README.md
+++ b/README.md
@@ -97,6 +97,15 @@ Para correr Redis localmente de forma rápida:
 docker run -d --name redis -p 6379:6379 redis:7
 ```
 
+### Background worker
+
+Las publicaciones del feed se insertan en segundo plano usando **RQ**.
+Ejecuta un worker aparte para procesar la cola:
+
+```bash
+python scripts/run_feed_worker.py
+```
+
 ### Migrations
 
 Para crear una nueva migración y aplicarla:

--- a/crunevo/tasks.py
+++ b/crunevo/tasks.py
@@ -1,0 +1,57 @@
+import os
+from rq import Queue
+from redis import Redis
+from .extensions import db
+from .models import User, FeedItem, Note
+from .cache.feed_cache import push_items
+from .utils.scoring import compute_score
+import json
+
+# Redis connection and queue
+redis_conn = Redis.from_url(os.getenv("REDIS_URL", "redis://localhost:6379/0"))
+task_queue = Queue("crunevo", connection=redis_conn)
+
+
+def insert_feed_items(
+    item_type, ref_id, meta_dict=None, owner_ids=None, is_highlight=False
+):
+    """Insert feed items into the database and cache."""
+    if owner_ids is None:
+        owner_ids = [u.id for u in User.query.with_entities(User.id).all()]
+
+    meta_str = json.dumps(meta_dict) if meta_dict else None
+
+    base_score = 0
+    if item_type == "apunte":
+        note = Note.query.get(ref_id)
+        if note:
+            base_score = compute_score(
+                note.likes, note.downloads, note.comments_count, note.created_at
+            )
+
+    items = [
+        FeedItem(
+            owner_id=uid,
+            item_type=item_type,
+            ref_id=ref_id,
+            metadata=meta_str,
+            is_highlight=is_highlight,
+            score=base_score,
+        )
+        for uid in owner_ids
+    ]
+    if items:
+        db.session.add_all(items)
+        db.session.commit()
+        if item_type != "apunte":
+            for it in items:
+                push_items(
+                    it.owner_id,
+                    [
+                        {
+                            "score": it.score,
+                            "created_at": it.created_at,
+                            "payload": it.to_dict(),
+                        }
+                    ],
+                )

--- a/crunevo/utils/feed.py
+++ b/crunevo/utils/feed.py
@@ -1,53 +1,19 @@
-from crunevo.extensions import db
-from crunevo.models import User, FeedItem, Note
-from crunevo.cache.feed_cache import push_items
-from .scoring import compute_score
-import json
+from crunevo.models import User
+from crunevo.tasks import task_queue, insert_feed_items
 
 
 def create_feed_item_for_all(
     item_type, ref_id, meta_dict=None, owner_ids=None, is_highlight=False
 ):
-    """Create feed items for all or selected users.
-
-    TODO: move to async task queue when feed grows.
-    """
+    """Enqueue creation of feed items for all or selected users."""
     if owner_ids is None:
         owner_ids = [u.id for u in User.query.with_entities(User.id).all()]
 
-    meta_str = json.dumps(meta_dict) if meta_dict else None
-
-    base_score = 0
-    if item_type == "apunte":
-        note = Note.query.get(ref_id)
-        if note:
-            base_score = compute_score(
-                note.likes, note.downloads, note.comments_count, note.created_at
-            )
-
-    items = [
-        FeedItem(
-            owner_id=uid,
-            item_type=item_type,
-            ref_id=ref_id,
-            metadata=meta_str,
-            is_highlight=is_highlight,
-            score=base_score,
-        )
-        for uid in owner_ids
-    ]
-    if items:
-        db.session.add_all(items)
-        db.session.commit()
-        if item_type != "apunte":
-            for it in items:
-                push_items(
-                    it.owner_id,
-                    [
-                        {
-                            "score": it.score,
-                            "created_at": it.created_at,
-                            "payload": it.to_dict(),
-                        }
-                    ],
-                )
+    task_queue.enqueue(
+        insert_feed_items,
+        item_type,
+        ref_id,
+        meta_dict,
+        owner_ids,
+        is_highlight,
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,4 @@ reportlab==4.4.2
 qrcode[pil]
 reportlab
 openai>=1.0.0
+rq==2.4.0

--- a/scripts/run_feed_worker.py
+++ b/scripts/run_feed_worker.py
@@ -1,0 +1,7 @@
+from rq import Worker, Connection
+from crunevo.tasks import redis_conn, task_queue
+
+if __name__ == "__main__":
+    with Connection(redis_conn):
+        worker = Worker([task_queue.name])
+        worker.work()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,4 +64,15 @@ def another_user(db_session):
 def fake_redis(monkeypatch):
     r = fakeredis.FakeRedis()
     monkeypatch.setattr(feed_cache, "r", r)
+    from crunevo import tasks
+
+    monkeypatch.setattr(tasks, "redis_conn", r)
+    tasks.task_queue.connection = r
+
+    def immediate(func, *a, **kw):
+        return func(*a, **kw)
+
+    monkeypatch.setattr(
+        tasks.task_queue, "enqueue", lambda f, *a, **kw: immediate(f, *a, **kw)
+    )
     yield r


### PR DESCRIPTION
## Summary
- queue feed item creation using RQ
- create a feed worker script
- update README with worker instructions
- patch tests to run tasks synchronously
- note the change in AGENTS

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6862db6781608325a2b2d6b843591f08