### PR TITLE
Implement club creation route and template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -466,3 +466,4 @@
 
 - Removed "Misiones" link from navbar, added mobile offcanvas sidebar toggle, redirected /register to onboarding and relaxed password policy to 6+ chars with letters and numbers (PR mobile-sidebar-register-fix).
 - Removed duplicate 'reportlab' entry from requirements.txt (PR requirements-cleanup).
+- Added user-facing club creation route, form template and updated sidebar button (PR create-club-route).

--- a/crunevo/forms/__init__.py
+++ b/crunevo/forms/__init__.py
@@ -1,4 +1,5 @@
 from .feed_note_form import FeedNoteForm
 from .feed_image_form import FeedImageForm
+from .club_form import ClubForm
 
-__all__ = ["FeedNoteForm", "FeedImageForm"]
+__all__ = ["FeedNoteForm", "FeedImageForm", "ClubForm"]

--- a/crunevo/forms/club_form.py
+++ b/crunevo/forms/club_form.py
@@ -1,0 +1,10 @@
+from flask_wtf import FlaskForm
+from wtforms import StringField, TextAreaField, SubmitField
+from wtforms.validators import DataRequired, Optional
+
+
+class ClubForm(FlaskForm):
+    name = StringField("Nombre", validators=[DataRequired()])
+    career = StringField("Carrera", validators=[DataRequired()])
+    description = TextAreaField("Descripción", validators=[Optional()])
+    submit = SubmitField("Crear Club")

--- a/crunevo/templates/club/create_club.html
+++ b/crunevo/templates/club/create_club.html
@@ -1,0 +1,32 @@
+{% extends 'base.html' %}
+{% from 'components/csrf.html' import csrf_field %}
+
+{% block content %}
+<div class="container py-5">
+  <div class="row justify-content-center">
+    <div class="col-md-8 col-lg-6">
+      <div class="card shadow-lg border-0 mb-3">
+        <div class="card-body p-4 p-md-5">
+          <h3 class="card-title mb-4 text-center">Crear Nuevo Club</h3>
+          <form method="post">
+            {{ csrf_field() }}
+            <div class="mb-3">
+              {{ form.name.label(class="form-label") }}
+              {{ form.name(class="form-control") }}
+            </div>
+            <div class="mb-3">
+              {{ form.career.label(class="form-label") }}
+              {{ form.career(class="form-control") }}
+            </div>
+            <div class="mb-3">
+              {{ form.description.label(class="form-label") }}
+              {{ form.description(class="form-control", rows=4) }}
+            </div>
+            <button type="submit" class="btn btn-primary w-100">{{ form.submit.label.text }}</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/crunevo/templates/club/list.html
+++ b/crunevo/templates/club/list.html
@@ -160,9 +160,9 @@
               <i class="bi bi-lightning"></i> Acciones Rápidas
             </h6>
             <div class="d-grid gap-2">
-              <button class="btn btn-outline-primary btn-sm" onclick="showCreateClubModal()">
+              <a href="{{ url_for('club.create_club') }}" class="btn btn-outline-primary btn-sm">
                 <i class="bi bi-plus-circle"></i> Crear Club
-              </button>
+              </a>
               <a href="{{ url_for('forum.list_questions') if 'forum.list_questions' in url_for.__globals__.get('current_app', {}).view_functions else '/foro' }}" class="btn btn-outline-success btn-sm">
                 <i class="bi bi-chat-dots"></i> Ir al Foro
               </a>


### PR DESCRIPTION
## Summary
- add ClubForm to handle new club creation
- expose `create_club` route and template
- update club list sidebar button to link to new route
- document change in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6862e01c76488325a8cb643f80e3fff1