### PR TITLE
chat-enhancements-phase1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -472,3 +472,4 @@
 - Corregido formulario de reseña en view_product.html eliminando repetición de 'Comentario' y texto 'div>' sobrante.
 - Replaced print statements in crunevo/utils/image_optimizer.py with logging and added logger import (PR image-logging-fix).
 - Fixed profile header overlay by raising username z-index and moving styles to perfil.css. Computed club and mission counts in auth.perfil, showing participation percentage (PR profile-fixes).
+- Improved chat: sanitized messages, active user ping with Redis fallback, real-time UI updates and message button on profiles (PR chat-enhancements-phase1).

--- a/crunevo/cache/active_users.py
+++ b/crunevo/cache/active_users.py
@@ -1,0 +1,51 @@
+import os
+import time
+import logging
+import redis
+
+log = logging.getLogger(__name__)
+
+r = redis.from_url(os.getenv("REDIS_URL", "redis://localhost:6379/0"))
+
+KEY_PREFIX = "chat_active:"
+TTL = 90  # seconds
+
+_fallback = {}
+
+
+def _client():
+    from redis.exceptions import RedisError
+
+    try:
+        r.ping()
+        return r
+    except RedisError as exc:  # pragma: no cover - fakeredis won't hit
+        log.warning("Redis ping failed – using memory cache: %s", exc)
+        return None
+
+
+def mark_online(user_id: int) -> None:
+    cli = _client()
+    if cli:
+        try:
+            cli.setex(KEY_PREFIX + str(user_id), TTL, 1)
+            return
+        except redis.RedisError:
+            pass
+    _fallback[user_id] = time.time() + TTL
+
+
+def get_active_ids() -> list[int]:
+    cli = _client()
+    now = time.time()
+    if cli:
+        try:
+            keys = cli.keys(KEY_PREFIX + "*")
+            ids = [int(k.decode().split(":", 1)[1]) for k in keys]
+            return ids
+        except redis.RedisError:
+            pass
+    expired = [uid for uid, exp in _fallback.items() if exp < now]
+    for uid in expired:
+        _fallback.pop(uid, None)
+    return list(_fallback.keys())

--- a/crunevo/templates/chat/global.html
+++ b/crunevo/templates/chat/global.html
@@ -121,9 +121,9 @@
         
         <div class="chat-input">
           <form id="messageForm" class="d-flex gap-2">
-            <input type="text" id="messageInput" class="form-control" 
+            <input type="text" id="messageInput" class="form-control rounded-pill"
                    placeholder="Escribe un mensaje..." maxlength="1000" required>
-            <button type="submit" class="btn btn-primary">
+            <button type="submit" class="btn btn-primary rounded-pill">
               <i class="bi bi-send"></i>
             </button>
           </form>
@@ -192,6 +192,7 @@ document.addEventListener('DOMContentLoaded', function() {
     .then(data => {
       if (data.status === 'ok') {
         input.value = '';
+        addMessage(data.message);
         lastMessageId = data.message.id;
       }
     })
@@ -212,6 +213,31 @@ document.addEventListener('DOMContentLoaded', function() {
     })
     .catch(console.error);
   }, 2000);
+
+  // Ping and update active users
+  function refreshActiveUsers() {
+    fetch('/chat/ping', { method: 'POST' });
+    fetch('/chat/usuarios/activos')
+      .then(r => r.json())
+      .then(list => {
+        const box = document.querySelector('.active-users');
+        if (!box) return;
+        box.innerHTML = list.map(u => `
+          <div class="user-item" onclick="startPrivateChat(${u.id})">
+            <div class="position-relative">
+              <img src="${u.avatar_url || '/static/img/default.png'}" class="user-avatar" alt="${u.username}">
+              <div class="status-indicator"></div>
+            </div>
+            <div class="flex-grow-1">
+              <div class="fw-semibold">${u.username}</div>
+              <small class="text-muted">${u.role.charAt(0).toUpperCase() + u.role.slice(1)}</small>
+            </div>
+          </div>
+        `).join('');
+      });
+  }
+  refreshActiveUsers();
+  setInterval(refreshActiveUsers, 15000);
   
   function addMessage(message) {
     const messageDiv = document.createElement('div');

--- a/crunevo/templates/perfil_publico.html
+++ b/crunevo/templates/perfil_publico.html
@@ -23,6 +23,7 @@
       {{ csrf.csrf_field() }}
       <button class="btn btn-primary" type="submit">Agradecer</button>
     </form>
+    <a href="{{ url_for('chat.private_chat_username', username=user.username) }}" class="btn btn-outline-primary ms-2">Enviar mensaje privado</a>
     {% endif %}
   </div>
 

--- a/crunevo/utils/content_filter.py
+++ b/crunevo/utils/content_filter.py
@@ -1,0 +1,16 @@
+import re
+
+BANNED_WORDS = [
+    "tonto",
+    "idiota",
+    "imbecil",
+]
+
+_pattern = re.compile("|".join(re.escape(w) for w in BANNED_WORDS), re.IGNORECASE)
+
+
+def sanitize_message(text: str) -> str:
+    """Replace banned words with asterisks."""
+    if not text:
+        return text
+    return _pattern.sub(lambda m: "*" * len(m.group()), text)


### PR DESCRIPTION
## Summary
- filter offensive content with `sanitize_message`
- track active chat users via Redis with memory fallback
- update global chat template with live message and active user updates
- add private message button on profile pages
- expose new chat endpoints for pings and username-based chats
- document new chat features in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686330319e648325a2f5b8b3c2ef7913