### PR TITLE
Responsive error page wrapper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -476,3 +476,4 @@
 - Added dynamic link previews for pasted URLs using BeautifulSoup and Redis cache (PR link-preview).
 - Refined mobile sidebar toggle button with fixed 48px circle and removed excessive click area (PR mobile-menu-button-fix).
 - Added graceful fallback to in-memory task queue when Redis unavailable (PR redis-fallback).
+- Improved error templates: centered with limited width, added close button and responsive wrapper (PR error-page-responsive).

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -645,3 +645,19 @@ html[data-bs-theme="dark"] footer {
   border-top-color: #30363d;
 }
 
+@media (min-width: 768px) {
+  .error-page {
+    max-width: 500px;
+    margin: 0 auto;
+    border-radius: 12px;
+    padding: 2rem;
+    box-shadow: 0 0 10px rgba(0,0,0,0.2);
+  }
+  .error-wrapper {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 80vh;
+    background-color: #fff;
+  }
+}

--- a/crunevo/templates/errors/404.html
+++ b/crunevo/templates/errors/404.html
@@ -4,10 +4,9 @@
 {% block title %}Página no encontrada - Crunevo{% endblock %}
 
 {% block content %}
-<div class="container mt-5">
-  <div class="row justify-content-center">
-    <div class="col-lg-6 text-center">
-      <div class="error-page">
+<div class="error-wrapper tw-flex tw-items-center tw-justify-center">
+  <div class="error-page position-relative text-center">
+    <button class="btn-close position-absolute top-0 end-0 m-3" onclick="this.closest('.error-wrapper').remove()" aria-label="Cerrar error"></button>
         <div class="error-icon mb-4">
           <i class="bi bi-compass display-1 text-primary"></i>
         </div>
@@ -46,9 +45,6 @@
             </a>
           </div>
         </div>
-      </div>
-    </div>
-  </div>
 </div>
 
 <style>

--- a/crunevo/templates/errors/500.html
+++ b/crunevo/templates/errors/500.html
@@ -4,10 +4,9 @@
 {% block title %}Error del servidor - Crunevo{% endblock %}
 
 {% block content %}
-<div class="container mt-5">
-  <div class="row justify-content-center">
-    <div class="col-lg-6 text-center">
-      <div class="error-page">
+<div class="error-wrapper tw-flex tw-items-center tw-justify-center">
+  <div class="error-page position-relative text-center">
+    <button class="btn-close position-absolute top-0 end-0 m-3" onclick="this.closest('.error-wrapper').remove()" aria-label="Cerrar error"></button>
         <div class="error-icon mb-4">
           <i class="bi bi-exclamation-triangle display-1 text-warning"></i>
         </div>
@@ -31,8 +30,6 @@
           <a href="mailto:soporte@crunevo.com" class="text-primary">soporte@crunevo.com</a>
         </p>
       </div>
-    </div>
-  </div>
 </div>
 
 <style>


### PR DESCRIPTION
## Summary
- center error pages with a wrapper and add close button
- keep mobile red screen but limit width on desktop
- document in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686339e42e4083258089a9530275e2db