### PR TITLE
Fix csrf macro in club post form

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -479,3 +479,4 @@
 - Wrapped ranking sidebar links with endpoint checks to prevent BuildError on admin instance (hotfix ranking-sidebar-link).
 
 - Improved error templates: centered with limited width, added close button and responsive wrapper (PR error-page-responsive).
+- Fixed club post creation form to import csrf macro and use csrf_field() (hotfix club-csrf).

--- a/crunevo/templates/club/detail.html
+++ b/crunevo/templates/club/detail.html
@@ -70,8 +70,8 @@
             <i class="bi bi-pencil"></i> Crear Publicación en {{ club.name }}
           </h6>
           <form method="POST" action="{{ url_for('club.create_club_post', club_id=club.id) }}">
-            {% include 'components/csrf.html' %}
-            {{ csrf.csrf_field() }}
+            {% from 'components/csrf.html' import csrf_field %}
+            {{ csrf_field() }}
             <div class="mb-3">
               <textarea class="form-control" 
                         name="content" 


### PR DESCRIPTION
## Summary
- import csrf macro and call `csrf_field()` in `club/detail.html`
- note change in `AGENTS.md`

## Testing
- `make fmt`
- `make test` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68633c6500d48325b5384a0393a040d7