### PR TITLE
Fix dark footer style

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -480,3 +480,4 @@
 
 - Improved error templates: centered with limited width, added close button and responsive wrapper (PR error-page-responsive).
 - Fixed club post creation form to import csrf macro and use csrf_field() (hotfix club-csrf).
+- Adjusted footer colors for dark theme, ensuring readable text and subtle border (PR dark-footer-fix).

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -642,7 +642,11 @@ footer {
 
 html[data-bs-theme="dark"] footer {
   background: rgba(13, 17, 23, 0.95);
-  border-top-color: #30363d;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+html[data-bs-theme="dark"] footer,
+html[data-bs-theme="dark"] footer a {
+  color: #ccc !important;
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- adjust footer border color and link text in dark mode

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68633dec991c8325906b9abf45311a8e