### PR TITLE
Fix IA chat link and favicon route

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -481,3 +481,4 @@
 - Improved error templates: centered with limited width, added close button and responsive wrapper (PR error-page-responsive).
 - Fixed club post creation form to import csrf macro and use csrf_field() (hotfix club-csrf).
 - Adjusted footer colors for dark theme, ensuring readable text and subtle border (PR dark-footer-fix).
+- Wrapped IA chat link in feed sidebar with endpoint check and added /favicon.ico route to serve static icon (hotfix ia-sidebar-favicon).

--- a/crunevo/routes/main_routes.py
+++ b/crunevo/routes/main_routes.py
@@ -5,6 +5,11 @@ from crunevo.routes.feed_routes import feed_home
 main_bp = Blueprint("main", __name__)
 
 
+@main_bp.route("/favicon.ico")
+def favicon():
+    return redirect(url_for("static", filename="img/favicon.ico"))
+
+
 @main_bp.route("/")
 def index():
     if current_user.is_authenticated:

--- a/crunevo/templates/components/sidebar_left_feed.html
+++ b/crunevo/templates/components/sidebar_left_feed.html
@@ -113,6 +113,7 @@
           </a>
         </li>
 
+        {% if 'ia.ia_chat' in url_for.__globals__.get('current_app', {}).view_functions %}
         <li>
           <a href="{{ url_for('ia.ia_chat') }}" class="nav-link {{ 'active' if request.endpoint == 'ia.ia_chat' }}">
             <i class="bi bi-robot"></i>
@@ -120,6 +121,7 @@
             <span class="badge bg-success rounded-pill ms-auto">AI</span>
           </a>
         </li>
+        {% endif %}
       </ul>
     </nav>
 


### PR DESCRIPTION
## Summary
- hide IA chat menu item when endpoint missing to prevent BuildError
- serve /favicon.ico via main blueprint
- document sidebar link fix in AGENTS notes

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6863417262088325a771218d11093711