### PR TITLE
Add feed post modal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -482,3 +482,4 @@
 - Fixed club post creation form to import csrf macro and use csrf_field() (hotfix club-csrf).
 - Adjusted footer colors for dark theme, ensuring readable text and subtle border (PR dark-footer-fix).
 - Wrapped IA chat link in feed sidebar with endpoint check and added /favicon.ico route to serve static icon (hotfix ia-sidebar-favicon).
+- Reemplazado formulario en el feed por botón que abre modal de creación con opciones de imagen, video, apunte o foro. Formulario usa POST a /feed y botón se habilita solo con contenido. (PR feed-post-modal)

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -32,8 +32,17 @@ class FeedManager {
     // Auto-resize textarea
     const textarea = form.querySelector('textarea[name="content"]');
     if (textarea) {
-      textarea.addEventListener('input', this.autoResizeTextarea);
+      textarea.addEventListener('input', () => {
+        this.autoResizeTextarea.call(textarea);
+        this.updatePostButtonState();
+      });
     }
+
+    form.querySelectorAll('input[type="file"]').forEach((inp) => {
+      inp.addEventListener('change', () => this.updatePostButtonState());
+    });
+
+    this.updatePostButtonState();
   }
 
   async submitPost(form) {
@@ -55,6 +64,7 @@ class FeedManager {
         this.showToast('¡Publicación creada exitosamente! 🎉', 'success');
         form.reset();
         this.clearImagePreview();
+        this.updatePostButtonState();
         // Reload feed or add new post to top
         setTimeout(() => window.location.reload(), 1000);
       } else {
@@ -66,6 +76,7 @@ class FeedManager {
       this.showToast('Error de conexión. Intenta nuevamente.', 'error');
     } finally {
       this.setButtonLoading(submitBtn, false);
+      this.updatePostButtonState();
     }
   }
 
@@ -111,6 +122,21 @@ class FeedManager {
     const input = document.getElementById('feedImageInput');
     if (preview) preview.innerHTML = '';
     if (input) input.value = '';
+    this.updatePostButtonState();
+  }
+
+  updatePostButtonState() {
+    const form = document.getElementById('feedForm');
+    if (!form) return;
+    const text = form.querySelector('textarea[name="content"]')?.value.trim();
+    let hasFile = false;
+    form.querySelectorAll('input[type="file"]').forEach((inp) => {
+      if (inp.files && inp.files.length > 0) {
+        hasFile = true;
+      }
+    });
+    const btn = form.querySelector('.feed-submit-btn');
+    if (btn) btn.disabled = !(text || hasFile);
   }
 
   initFeedFilters() {

--- a/crunevo/templates/feed/index.html
+++ b/crunevo/templates/feed/index.html
@@ -17,46 +17,53 @@
       <div class="px-3 px-lg-4">
         <!-- Create Post Form -->
         {% if current_user.is_authenticated %}
-        <div class="card mb-4 shadow-sm border-0 rounded-4 feed-create-card">
-          <div class="card-body p-4">
-            <form method="post" enctype="multipart/form-data" id="feedForm">
-              {{ csrf.csrf_field() }}
-              <div class="d-flex gap-3 align-items-start">
-                <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" 
-                     alt="Tu avatar" class="feed-avatar rounded-circle" width="48" height="48">
-                <div class="flex-grow-1">
-                  <textarea 
-                    name="content" 
-                    id="content" 
-                    class="form-control post-input border-0 bg-light rounded-3 shadow-none resize-none"
-                    rows="3" 
-                    placeholder="¿Qué quieres compartir con la comunidad educativa?"
-                    style="min-height: 80px;"></textarea>
+        <div class="d-grid mb-4">
+          <button class="btn btn-primary rounded-pill" data-bs-toggle="modal" data-bs-target="#crearPublicacionModal">
+            <i class="bi bi-pencil-square me-2"></i> Publicar algo
+          </button>
+        </div>
 
+        <div class="modal fade" id="crearPublicacionModal" tabindex="-1" aria-labelledby="crearPublicacionLabel" aria-hidden="true">
+          <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+              <div class="modal-header">
+                <h5 class="modal-title" id="crearPublicacionLabel">Crear publicación</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+              </div>
+              <form method="post" action="{{ url_for('feed.view_feed') }}" enctype="multipart/form-data" id="feedForm">
+                {{ csrf.csrf_field() }}
+                <div class="modal-body">
+                  <textarea name="content" class="form-control border-0 bg-light rounded-3 shadow-none resize-none" rows="3" placeholder="¿Qué estás pensando, {{ current_user.username }}?" style="min-height: 80px;"></textarea>
                   <div id="previewContainer" class="mt-3"></div>
-
-                  <div class="d-flex justify-content-between align-items-center mt-3">
-                    <div class="d-flex gap-2">
-                      <label class="btn btn-outline-primary btn-sm rounded-pill d-flex align-items-center gap-1 cursor-pointer">
-                        <i class="bi bi-image"></i>
-                        <span class="d-none d-sm-inline">Imagen</span>
-                        <input type="file" name="file" accept="image/*" class="d-none" id="feedImageInput">
-                      </label>
-                      <button type="button" class="btn btn-outline-secondary btn-sm rounded-pill d-flex align-items-center gap-1" disabled>
-                        <i class="bi bi-camera-video"></i>
-                        <span class="d-none d-sm-inline">Video</span>
-                      </button>
-                    </div>
-                    <button type="submit" class="btn btn-primary btn-sm rounded-pill px-4 fw-semibold feed-submit-btn">
-                      <span class="submit-text">Publicar</span>
-                      <div class="spinner-border spinner-border-sm d-none" role="status">
-                        <span class="visually-hidden">Cargando...</span>
-                      </div>
-                    </button>
+                  <div class="mt-3 d-flex gap-2 justify-content-around">
+                    <label class="btn btn-outline-primary d-flex align-items-center gap-1 mb-0">
+                      📄 <span class="d-none d-sm-inline">Apunte</span>
+                      <input type="file" name="file" accept=".pdf,.txt,.doc,.docx" class="d-none" id="feedNoteInput">
+                    </label>
+                    <label class="btn btn-outline-success d-flex align-items-center gap-1 mb-0">
+                      🖼 <span class="d-none d-sm-inline">Imagen</span>
+                      <input type="file" name="file" accept="image/*" class="d-none" id="feedImageInput">
+                    </label>
+                    <label class="btn btn-outline-warning d-flex align-items-center gap-1 mb-0">
+                      🎥 <span class="d-none d-sm-inline">Video</span>
+                      <input type="file" name="file" accept="video/*" class="d-none" id="feedVideoInput">
+                    </label>
+                    <a href="{{ url_for('forum.ask_question') }}" class="btn btn-outline-info d-flex align-items-center gap-1">
+                      ❓ <span class="d-none d-sm-inline">Foro</span>
+                    </a>
                   </div>
                 </div>
-              </div>
-            </form>
+                <div class="modal-footer">
+                  <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                  <button type="submit" class="btn btn-primary feed-submit-btn" disabled>
+                    <span class="submit-text">Publicar</span>
+                    <div class="spinner-border spinner-border-sm d-none" role="status">
+                      <span class="visually-hidden">Cargando...</span>
+                    </div>
+                  </button>
+                </div>
+              </form>
+            </div>
           </div>
         </div>
         {% endif %}


### PR DESCRIPTION
## Summary
- create modern post creation modal
- disable publish button until content or file selected
- ensure feed form posts to `/feed`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68634449bf048325a4e3cfb91239bbb6