### PR TITLE
Fix feed post method and redesign modal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -483,3 +483,4 @@
 - Adjusted footer colors for dark theme, ensuring readable text and subtle border (PR dark-footer-fix).
 - Wrapped IA chat link in feed sidebar with endpoint check and added /favicon.ico route to serve static icon (hotfix ia-sidebar-favicon).
 - Reemplazado formulario en el feed por botón que abre modal de creación con opciones de imagen, video, apunte o foro. Formulario usa POST a /feed y botón se habilita solo con contenido. (PR feed-post-modal)
+- Añadida ruta '/feed/post' para aceptar POST y modificado index del feed con caja de entrada y modal de publicación tipo Facebook. (PR feed-post-overlay)

--- a/crunevo/templates/feed/index.html
+++ b/crunevo/templates/feed/index.html
@@ -17,10 +17,11 @@
       <div class="px-3 px-lg-4">
         <!-- Create Post Form -->
         {% if current_user.is_authenticated %}
-        <div class="d-grid mb-4">
-          <button class="btn btn-primary rounded-pill" data-bs-toggle="modal" data-bs-target="#crearPublicacionModal">
-            <i class="bi bi-pencil-square me-2"></i> Publicar algo
-          </button>
+        <div class="card mb-4 shadow-sm border-0 rounded-4">
+          <div class="card-body d-flex align-items-center gap-3">
+            <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle" width="48" height="48" alt="avatar">
+            <input type="text" class="form-control bg-light rounded-pill" placeholder="¿Qué estás pensando, {{ current_user.username }}?" readonly data-bs-toggle="modal" data-bs-target="#crearPublicacionModal" id="openPostModalInput">
+          </div>
         </div>
 
         <div class="modal fade" id="crearPublicacionModal" tabindex="-1" aria-labelledby="crearPublicacionLabel" aria-hidden="true">
@@ -30,27 +31,29 @@
                 <h5 class="modal-title" id="crearPublicacionLabel">Crear publicación</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
               </div>
-              <form method="post" action="{{ url_for('feed.view_feed') }}" enctype="multipart/form-data" id="feedForm">
+              <form method="post" action="{{ url_for('feed.create_post') }}" enctype="multipart/form-data" id="feedForm">
                 {{ csrf.csrf_field() }}
                 <div class="modal-body">
                   <textarea name="content" class="form-control border-0 bg-light rounded-3 shadow-none resize-none" rows="3" placeholder="¿Qué estás pensando, {{ current_user.username }}?" style="min-height: 80px;"></textarea>
                   <div id="previewContainer" class="mt-3"></div>
-                  <div class="mt-3 d-flex gap-2 justify-content-around">
-                    <label class="btn btn-outline-primary d-flex align-items-center gap-1 mb-0">
-                      📄 <span class="d-none d-sm-inline">Apunte</span>
-                      <input type="file" name="file" accept=".pdf,.txt,.doc,.docx" class="d-none" id="feedNoteInput">
-                    </label>
-                    <label class="btn btn-outline-success d-flex align-items-center gap-1 mb-0">
-                      🖼 <span class="d-none d-sm-inline">Imagen</span>
+                  <div class="mt-3 d-flex flex-wrap gap-2">
+                    <label class="btn btn-light border d-flex align-items-center gap-2 mb-0">
+                      <i class="bi bi-image"></i> <span class="small">Agregar Imagen</span>
                       <input type="file" name="file" accept="image/*" class="d-none" id="feedImageInput">
                     </label>
-                    <label class="btn btn-outline-warning d-flex align-items-center gap-1 mb-0">
-                      🎥 <span class="d-none d-sm-inline">Video</span>
+                    <label class="btn btn-light border d-flex align-items-center gap-2 mb-0">
+                      <i class="bi bi-camera-video"></i> <span class="small">Agregar Video</span>
                       <input type="file" name="file" accept="video/*" class="d-none" id="feedVideoInput">
                     </label>
-                    <a href="{{ url_for('forum.ask_question') }}" class="btn btn-outline-info d-flex align-items-center gap-1">
-                      ❓ <span class="d-none d-sm-inline">Foro</span>
+                    <a href="{{ url_for('notes.upload_note') }}" class="btn btn-light border d-flex align-items-center gap-2">
+                      <i class="bi bi-file-earmark-plus"></i> <span class="small">Subir Apunte</span>
                     </a>
+                    <button type="button" class="btn btn-light border d-flex align-items-center gap-2" disabled>
+                      <i class="bi bi-broadcast"></i> <span class="small">Video en vivo</span>
+                    </button>
+                    <button type="button" class="btn btn-light border d-flex align-items-center gap-2">
+                      <i class="bi bi-plus-circle"></i> <span class="small">Más opciones</span>
+                    </button>
                   </div>
                 </div>
                 <div class="modal-footer">


### PR DESCRIPTION
## Summary
- add `/feed/post` route to accept POST
- redesign feed index with always-visible input and overlay modal
- link upload note button to `notes.upload_note`
- update agent history

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686351b03cf0832583aea46f8fd6063c