### PR TITLE
Redesign feed input

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -484,3 +484,4 @@
 - Wrapped IA chat link in feed sidebar with endpoint check and added /favicon.ico route to serve static icon (hotfix ia-sidebar-favicon).
 - Reemplazado formulario en el feed por botón que abre modal de creación con opciones de imagen, video, apunte o foro. Formulario usa POST a /feed y botón se habilita solo con contenido. (PR feed-post-modal)
 - Añadida ruta '/feed/post' para aceptar POST y modificado index del feed con caja de entrada y modal de publicación tipo Facebook. (PR feed-post-overlay)
+- Rediseñado input rápido del feed con botones visibles de Live, Foto/Video y Apuntes; botón Foto/Video abre el modal y selecciona imagen automáticamente. (PR feed-input-redesign)

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -18,6 +18,7 @@ class FeedManager {
     this.initStreakClaim();
     this.initModals();
     this.initTooltips();
+    this.initQuickButtons();
   }
 
   initFeedForm() {
@@ -518,6 +519,23 @@ class FeedManager {
     const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
     tooltipTriggerList.map(tooltipTriggerEl => {
       return new bootstrap.Tooltip(tooltipTriggerEl);
+    });
+  }
+
+  initQuickButtons() {
+    const modalEl = document.getElementById('crearPublicacionModal');
+    const photoBtn = document.getElementById('photoVideoBtn');
+    if (!modalEl || !photoBtn) return;
+    let openWithImage = false;
+    photoBtn.addEventListener('click', () => {
+      openWithImage = true;
+      bootstrap.Modal.getOrCreateInstance(modalEl).show();
+    });
+    modalEl.addEventListener('shown.bs.modal', () => {
+      if (openWithImage) {
+        document.getElementById('feedImageInput')?.click();
+        openWithImage = false;
+      }
     });
   }
 

--- a/crunevo/templates/feed/index.html
+++ b/crunevo/templates/feed/index.html
@@ -18,9 +18,25 @@
         <!-- Create Post Form -->
         {% if current_user.is_authenticated %}
         <div class="card mb-4 shadow-sm border-0 rounded-4">
-          <div class="card-body d-flex align-items-center gap-3">
-            <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle" width="48" height="48" alt="avatar">
-            <input type="text" class="form-control bg-light rounded-pill" placeholder="¿Qué estás pensando, {{ current_user.username }}?" readonly data-bs-toggle="modal" data-bs-target="#crearPublicacionModal" id="openPostModalInput">
+          <div class="card-body">
+            <div class="d-flex align-items-center gap-3 mb-3">
+              <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle" width="48" height="48" alt="avatar">
+              <input type="text" class="form-control bg-light rounded-pill" placeholder="¿Qué estás pensando, {{ current_user.username }}?" readonly data-bs-toggle="modal" data-bs-target="#crearPublicacionModal" id="openPostModalInput">
+            </div>
+            <div class="d-flex justify-content-between gap-2">
+              <button type="button" class="btn btn-light flex-fill d-flex align-items-center justify-content-center gap-2" disabled data-bs-toggle="tooltip" title="Próximamente">
+                <i class="bi bi-broadcast"></i>
+                <span class="small d-none d-md-inline">Video en vivo</span>
+              </button>
+              <button type="button" class="btn btn-light flex-fill d-flex align-items-center justify-content-center gap-2" id="photoVideoBtn">
+                <i class="bi bi-image"></i>
+                <span class="small d-none d-md-inline">Foto/Video</span>
+              </button>
+              <a href="{{ url_for('notes.upload_note') }}" class="btn btn-light flex-fill d-flex align-items-center justify-content-center gap-2">
+                <i class="bi bi-file-earmark-plus"></i>
+                <span class="small d-none d-md-inline">Apuntes</span>
+              </a>
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- redesign quick post card on feed with visible Live, Photo/Video and Notes buttons
- open create post modal and trigger image selection when clicking Photo/Video
- document redesign in AGENTS guidelines

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68635fc97e8083259fa221f033b965fe