### PR TITLE
Fix BuildError on missing feed routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -485,3 +485,4 @@
 - Reemplazado formulario en el feed por botón que abre modal de creación con opciones de imagen, video, apunte o foro. Formulario usa POST a /feed y botón se habilita solo con contenido. (PR feed-post-modal)
 - Añadida ruta '/feed/post' para aceptar POST y modificado index del feed con caja de entrada y modal de publicación tipo Facebook. (PR feed-post-overlay)
 - Rediseñado input rápido del feed con botones visibles de Live, Foto/Video y Apuntes; botón Foto/Video abre el modal y selecciona imagen automáticamente. (PR feed-input-redesign)
+- Wrapped trending links with endpoint check to prevent BuildError when feed routes are missing (hotfix feed-trending-link).

--- a/crunevo/templates/components/navbar_crunevo_fixed.html
+++ b/crunevo/templates/components/navbar_crunevo_fixed.html
@@ -15,7 +15,7 @@
 
     <ul id="navLinks" class="navbar-nav flex-row align-items-center gap-3 d-none d-md-flex">
       <li class="nav-item"><a class="nav-link" href="{{ url_for('feed.feed_home') }}"><i class="bi bi-house-door"></i></a></li>
-      <li class="nav-item"><a class="nav-link" href="{{ url_for('feed.trending') }}"><i class="bi bi-fire"></i></a></li>
+      <li class="nav-item"><a class="nav-link" href="{{ url_for('feed.trending') if 'feed.trending' in url_for.__globals__.get('current_app', {}).view_functions else '/feed/trending' }}"><i class="bi bi-fire"></i></a></li>
       <li class="nav-item"><a class="nav-link" href="{{ url_for('notes.list_notes') if 'notes.list_notes' in url_for.__globals__.get('current_app', {}).view_functions else '/notes' }}"><i class="bi bi-journal-text"></i></a></li>
       <li class="nav-item"><a class="nav-link" href="{{ url_for('store.store_index') if 'store.store_index' in url_for.__globals__.get('current_app', {}).view_functions else '/store' }}"><i class="bi bi-bag"></i></a></li>
       <li class="nav-item"><a class="nav-link" href="{{ url_for('chat.chat_index') }}"><i class="bi bi-chat-dots"></i></a></li>

--- a/crunevo/templates/components/sidebar_left_feed.html
+++ b/crunevo/templates/components/sidebar_left_feed.html
@@ -133,7 +133,7 @@
           </h6>
           <small class="text-muted">Temas populares de la semana</small>
         </div>
-        <a href="{{ url_for('feed.trending') }}" class="btn btn-sm btn-outline-primary">Ir</a>
+        <a href="{{ url_for('feed.trending') if 'feed.trending' in url_for.__globals__.get('current_app', {}).view_functions else '/feed/trending' }}" class="btn btn-sm btn-outline-primary">Ir</a>
       </div>
     </div>
 

--- a/crunevo/templates/components/sidebar_right.html
+++ b/crunevo/templates/components/sidebar_right.html
@@ -37,7 +37,7 @@
           </div>
         </div>
         
-        <a href="{{ url_for('feed.trending') }}" class="btn btn-outline-primary w-100">Ver más tendencias</a>
+        <a href="{{ url_for('feed.trending') if 'feed.trending' in url_for.__globals__.get('current_app', {}).view_functions else '/feed/trending' }}" class="btn btn-outline-primary w-100">Ver más tendencias</a>
       </div>
     </div>
   </div>

--- a/crunevo/templates/ranking/index.html
+++ b/crunevo/templates/ranking/index.html
@@ -342,7 +342,7 @@
         <a class="nav-link" href="{{ url_for('ranking.top_referrers') }}">
           <i class="bi bi-people me-2"></i>Top Referidores
         </a>
-        <a class="nav-link" href="{{ url_for('feed.trending') }}">
+        <a class="nav-link" href="{{ url_for('feed.trending') if 'feed.trending' in url_for.__globals__.get('current_app', {}).view_functions else '/feed/trending' }}">
           <i class="bi bi-fire me-2"></i>Ver tendencias 🔥
         </a>
       </div>


### PR DESCRIPTION
## Summary
- avoid BuildError in templates when feed.trending route isn't registered
- document fix in AGENTS

## Testing
- `make fmt`
- `make test` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68636511c82c83258f6596f2f7f31d95