### PR TITLE
Fix post button activation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -486,3 +486,4 @@
 - Añadida ruta '/feed/post' para aceptar POST y modificado index del feed con caja de entrada y modal de publicación tipo Facebook. (PR feed-post-overlay)
 - Rediseñado input rápido del feed con botones visibles de Live, Foto/Video y Apuntes; botón Foto/Video abre el modal y selecciona imagen automáticamente. (PR feed-input-redesign)
 - Wrapped trending links with endpoint check to prevent BuildError when feed routes are missing (hotfix feed-trending-link).
+- Activado botón 'Publicar' si hay texto o archivo en el feed (hotfix feed-post-button).

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -129,15 +129,21 @@ class FeedManager {
   updatePostButtonState() {
     const form = document.getElementById('feedForm');
     if (!form) return;
-    const text = form.querySelector('textarea[name="content"]')?.value.trim();
+
+    const content = form.querySelector('textarea[name="content"]').value.trim();
+    const fileInputs = form.querySelectorAll('input[type="file"]');
     let hasFile = false;
-    form.querySelectorAll('input[type="file"]').forEach((inp) => {
+
+    fileInputs.forEach(inp => {
       if (inp.files && inp.files.length > 0) {
         hasFile = true;
       }
     });
-    const btn = form.querySelector('.feed-submit-btn');
-    if (btn) btn.disabled = !(text || hasFile);
+
+    const submitBtn = form.querySelector('button[type="submit"]');
+    if (submitBtn) {
+      submitBtn.disabled = !(content || hasFile);
+    }
   }
 
   initFeedFilters() {


### PR DESCRIPTION
## Summary
- fix updatePostButtonState to enable Publish when text or file present
- note the change in AGENTS guidelines

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686366c1c5ec8325b85eb17df5e0d556