### PR TITLE
Fix notification badge errors with new count API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -488,3 +488,4 @@
 - Wrapped trending links with endpoint check to prevent BuildError when feed routes are missing (hotfix feed-trending-link).
 - Activado botón 'Publicar' si hay texto o archivo en el feed (hotfix feed-post-button).
 - Wrapped notes upload quick action link with endpoint check and added favicon files (hotfix notes-upload-link).
+- Added /notifications/api/count endpoint and updated mobile badge script with error handling (PR notifications-count-fix).

--- a/crunevo/routes/notifications_routes.py
+++ b/crunevo/routes/notifications_routes.py
@@ -60,3 +60,11 @@ def api_notifications():
             for n in unread
         ]
     )
+
+
+@noti_bp.route("/notifications/api/count")
+@login_required
+def api_notifications_count():
+    """Return the number of unread notifications for the current user."""
+    count = Notification.query.filter_by(user_id=current_user.id, is_read=False).count()
+    return jsonify({"count": count})

--- a/crunevo/templates/components/mobile_bottom_nav.html
+++ b/crunevo/templates/components/mobile_bottom_nav.html
@@ -202,19 +202,21 @@ body {
 // Update notification badge via AJAX
 function updateMobileNotificationBadge() {
   fetch('/notifications/api/count')
-    .then(response => response.json())
+    .then(r => (r.ok ? r.json() : null))
     .then(data => {
+      const count = data && typeof data.count === 'number' ? data.count : 0;
       const badge = document.getElementById('mobileNotificationBadge');
       if (badge) {
-        badge.textContent = data.count > 0 ? data.count : '';
-        badge.style.display = data.count > 0 ? 'flex' : 'none';
+        badge.textContent = count > 0 ? count : '';
+        badge.style.display = count > 0 ? 'flex' : 'none';
       }
     })
-    .catch(error => console.error('Error updating notification badge:', error));
+    .catch(() => {});
 }
 
 // Update every 30 seconds
 if (document.getElementById('mobileNotificationBadge')) {
+  updateMobileNotificationBadge();
   setInterval(updateMobileNotificationBadge, 30000);
 }
 </script>


### PR DESCRIPTION
## Summary
- add `/notifications/api/count` endpoint to return unread notification count
- update mobile bottom nav script to handle missing JSON and initialize on load
- document the change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6864413b65588325ab21e2e15a6a793c