### PR TITLE
Fix accessibility warnings and CSP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -489,3 +489,4 @@
 - Activado botón 'Publicar' si hay texto o archivo en el feed (hotfix feed-post-button).
 - Wrapped notes upload quick action link with endpoint check and added favicon files (hotfix notes-upload-link).
 - Added /notifications/api/count endpoint and updated mobile badge script with error handling (PR notifications-count-fix).
+- Solucionados warnings de autofocus oculto, soporte Safari de backdrop-filter y fuentes en CSP (PR accessibility-fixes).

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -10,7 +10,8 @@ from flask_wtf.csrf import CSRFError
 DEFAULT_CSP = {
     "default-src": "'self'",
     "img-src": ["'self'", "data:", "https://res.cloudinary.com"],
-    "style-src": ["'self'", "'unsafe-inline'"],
+    "style-src": ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
+    "font-src": ["'self'", "https://fonts.gstatic.com"],
     "script-src": ["'self'", "'unsafe-inline'"],
     "connect-src": "'self'",
 }

--- a/crunevo/config.py
+++ b/crunevo/config.py
@@ -68,6 +68,11 @@ class Config:
             "'unsafe-inline'",
             "https://cdn.jsdelivr.net",
             "https://unpkg.com",
+            "https://fonts.googleapis.com",
+        ],
+        "font-src": [
+            "'self'",
+            "https://fonts.gstatic.com",
         ],
         "script-src": [
             "'self'",

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -228,6 +228,7 @@
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
   backdrop-filter: blur(20px);
   z-index: 100;
+  -webkit-backdrop-filter: blur(20px);
   top: -60px;
   left: 0;
   display: grid;

--- a/crunevo/static/css/login.css
+++ b/crunevo/static/css/login.css
@@ -45,6 +45,7 @@ body {
   border: 1px solid rgba(255, 255, 255, 0.2);
   backdrop-filter: blur(12px);
   border-radius: 16px;
+  -webkit-backdrop-filter: blur(12px);
   padding: 32px;
   width: 100%;
   max-width: 450px;
@@ -55,6 +56,7 @@ body {
 [data-bs-theme="dark"] .login-card {
   background: rgba(0, 0, 0, 0.8);
   backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
   border: 1px solid rgba(255, 255, 255, 0.1);
   color: #fff;
 }
@@ -236,6 +238,7 @@ body {
   top: 1rem;
   right: 1rem;
   background: rgba(255, 255, 255, 0.3);
+  -webkit-backdrop-filter: blur(4px);
   backdrop-filter: blur(4px);
   border: none;
   border-radius: 50%;
@@ -268,6 +271,7 @@ body {
   font-weight: 600;
   padding: 8px 16px;
   background: rgba(255, 255, 255, 0.9);
+  -webkit-backdrop-filter: blur(10px);
   border-radius: 20px;
   backdrop-filter: blur(10px);
   transition: all 0.3s ease;

--- a/crunevo/static/css/register.css
+++ b/crunevo/static/css/register.css
@@ -41,6 +41,7 @@ body {
   border: 1px solid rgba(255, 255, 255, 0.2);
   backdrop-filter: blur(12px);
   border-radius: 16px;
+  -webkit-backdrop-filter: blur(12px);
   padding: 32px;
   width: 100%;
   max-width: 500px;
@@ -52,6 +53,7 @@ body {
 [data-bs-theme="dark"] .register-card {
   background: rgba(0, 0, 0, 0.8);
   backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
   border: 1px solid rgba(255, 255, 255, 0.1);
   color: #fff;
 }
@@ -226,6 +228,7 @@ body {
   top: 1rem;
   right: 1rem;
   background: rgba(255, 255, 255, 0.3);
+  -webkit-backdrop-filter: blur(4px);
   backdrop-filter: blur(4px);
   border: none;
   border-radius: 50%;
@@ -255,6 +258,7 @@ body {
   font-weight: 600;
   padding: 8px 16px;
   background: rgba(255, 255, 255, 0.9);
+  -webkit-backdrop-filter: blur(10px);
   border-radius: 20px;
   backdrop-filter: blur(10px);
   transition: all 0.3s ease;

--- a/crunevo/static/css/search.css
+++ b/crunevo/static/css/search.css
@@ -51,6 +51,7 @@
   background: var(--card-bg);
   border: 1px solid var(--border-color);
   backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
   max-height: 300px;
   overflow-y: auto;
 }

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -58,6 +58,7 @@ body {
 .card {
   background: rgba(255, 255, 255, 0.98);
   backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
   border: 1px solid rgba(0, 0, 0, 0.1);
   border-radius: 16px;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
@@ -194,6 +195,7 @@ body {
   margin-bottom: 0.75rem;
   max-width: 75%;
   background: rgba(255, 255, 255, 0.9);
+  -webkit-backdrop-filter: blur(10px);
   backdrop-filter: blur(10px);
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
   animation: slideIn 0.3s ease;
@@ -207,6 +209,7 @@ body {
 }
 
 .message.received {
+  -webkit-backdrop-filter: blur(10px);
   background: rgba(233, 236, 239, 0.9);
   backdrop-filter: blur(10px);
   border-bottom-left-radius: 6px;
@@ -233,6 +236,7 @@ body {
   z-index: 1000;
   top: 100%;
   max-height: 300px;
+  -webkit-backdrop-filter: blur(20px);
   overflow-y: auto;
   background: rgba(255, 255, 255, 0.95);
   backdrop-filter: blur(20px);
@@ -248,6 +252,7 @@ body {
 
 /* Enhanced form controls with better contrast */
 .form-control {
+  -webkit-backdrop-filter: blur(10px);
   border-radius: 12px;
   border: 2px solid #cbd5e1;
   background: #ffffff;
@@ -297,6 +302,7 @@ body {
   background-color: #343a40 !important;
   color: #f8f9fa !important;
 }
+  -webkit-backdrop-filter: blur(20px);
 
 /* Chat input styling */
 .chat-input-container {
@@ -347,6 +353,7 @@ body {
   transition: all 0.3s ease;
 }
 
+  -webkit-backdrop-filter: blur(20px);
 /* Mobile bottom navigation */
 .mobile-overlay-btn {
   z-index: 1040;
@@ -415,6 +422,7 @@ html {
   background-color: #121212 !important;
   border-bottom: 1px solid #333;
 }
+  -webkit-backdrop-filter: blur(10px);
 
 /* Enhanced notification styles */
 .notification-card {
@@ -491,6 +499,7 @@ html {
   color: #64748b;
 }
 
+  -webkit-backdrop-filter: blur(20px);
 /* Tooltip enhancements */
 .tooltip {
   font-size: 0.875rem;
@@ -628,6 +637,7 @@ html[data-bs-theme="dark"] .feed-section {
 }
 
 html[data-bs-theme="dark"] .text-dark,
+  -webkit-backdrop-filter: blur(10px);
 html[data-bs-theme="dark"] .text-black {
   color: #ffffff !important;
 }

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -552,6 +552,7 @@ function initNavbarSearchLegacy() {
   }
 
   const mobileSearchInput = document.getElementById('mobileSearchInput');
+  const mobileSearchModal = document.getElementById('mobileSearchModal');
   if (mobileSearchInput) {
     mobileSearchInput.addEventListener('keypress', (e) => {
       if (e.key === 'Enter') {
@@ -559,6 +560,11 @@ function initNavbarSearchLegacy() {
         performMobileSearch();
       }
     });
+    if (mobileSearchModal) {
+      mobileSearchModal.addEventListener('shown.bs.modal', () => {
+        mobileSearchInput.focus();
+      });
+    }
   }
 
   async function perform(query) {

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="csrf-token" content="{{ csrf_token() }}">
-    <meta name="theme-color" content="#667eea">
+    <meta name="theme-color" content="#667eea"> {# Firefox ignores this tag #}
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
 
@@ -86,7 +86,7 @@
     </main>
 
     <!-- Enhanced footer -->
-    <footer class="text-center py-4 mt-5" style="position: relative; z-index: 1000; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); border-top: 1px solid #e0e0e0;">
+    <footer class="text-center py-4 mt-5" style="position: relative; z-index: 1000; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); border-top: 1px solid #e0e0e0;">
       <div class="container">
         <div class="row align-items-center">
           <div class="col-md-6 text-md-start">

--- a/crunevo/templates/components/mobile_bottom_nav.html
+++ b/crunevo/templates/components/mobile_bottom_nav.html
@@ -78,6 +78,7 @@
 .mobile-bottom-nav .navbar {
   background: rgba(255, 255, 255, 0.98) !important;
   backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
   border-top: 1px solid rgba(102, 126, 234, 0.1);
   padding: 8px 0;
   min-height: 60px;

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -140,7 +140,7 @@
   <div class="modal-dialog modal-fullscreen-sm-down">
     <div class="modal-content bg-body">
       <div class="modal-header border-0">
-        <input type="search" id="mobileSearchInput" class="form-control" placeholder="Buscar en CRUNEVO..." autofocus>
+        <input type="search" id="mobileSearchInput" class="form-control" placeholder="Buscar en CRUNEVO...">
         <button type="button" class="btn-close ms-2" data-bs-dismiss="modal" aria-label="Cerrar"></button>
       </div>
     </div>

--- a/crunevo/templates/components/sidebar_left_feed.html
+++ b/crunevo/templates/components/sidebar_left_feed.html
@@ -169,6 +169,7 @@
 .sidebar-left {
   background: rgba(255, 255, 255, 0.98) !important;
   backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
 }
 
 [data-bs-theme="dark"] .sidebar-left {

--- a/crunevo/templates/components/sidebar_right.html
+++ b/crunevo/templates/components/sidebar_right.html
@@ -157,6 +157,7 @@
 .sidebar-right .card {
   background: rgba(255, 255, 255, 0.98);
   backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
 }
 
 [data-bs-theme="dark"] .sidebar-right .card {

--- a/crunevo/templates/courses/course_card.html
+++ b/crunevo/templates/courses/course_card.html
@@ -59,6 +59,7 @@
 
 .save-course-btn {
   backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
   background: rgba(255, 255, 255, 0.1) !important;
   border: 1px solid rgba(255, 255, 255, 0.2) !important;
 }


### PR DESCRIPTION
## Summary
- remove autofocus from hidden mobile search input and focus when modal opens
- allow Google Fonts in CSP config
- add `-webkit-backdrop-filter` fallback in styles
- note unsupported theme-color meta
- log changes for reference in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686442d0e3e483259339e9eaf2499c6b