### PR TITLE
Fix feed image previews and profile badge tooltip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -496,3 +496,4 @@
 - Corrigido preview de imágenes en el feed eliminando lógica duplicada en main.js y
   añadiendo aria-label al botón de borrar. Se ajustó la sección de estadísticas
   del perfil con layout horizontal scrollable. (PR profile-feed-fix)
+- Habilitada verificación con tooltip en perfil, removida tarjeta redundante y menú móvil ajustado más arriba. Vista previa de imágenes evita duplicados y botón de eliminar no dispara doble acción. (PR feed-profile-adjustments)

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -96,7 +96,13 @@ class FeedManager {
     input.addEventListener('change', (e) => {
       const files = Array.from(e.target.files);
       files.forEach((file) => {
-        if (file && file.type.startsWith('image/')) {
+        if (
+          file &&
+          file.type.startsWith('image/') &&
+          !this.imageFiles.some(
+            (f) => f.name === file.name && f.size === file.size && f.lastModified === file.lastModified
+          )
+        ) {
           this.imageFiles.push(file);
         }
       });
@@ -120,7 +126,8 @@ class FeedManager {
             <i class="bi bi-x"></i>
           </button>`;
         container.appendChild(div);
-        div.querySelector('button').addEventListener('click', () => {
+        div.querySelector('button').addEventListener('click', (ev) => {
+          ev.stopPropagation();
           this.removeImage(idx);
         });
       };

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -27,7 +27,7 @@
           <h3 class="fw-bold mb-3">
             {{ user.username }}
             {% if user.verification_level > 0 %}
-            <i class="bi bi-patch-check-fill text-primary ms-1"></i>
+            <i class="bi bi-check-circle-fill text-primary ms-1" data-bs-toggle="tooltip" title="Cuenta verificada"></i>
             {% endif %}
           </h3>
           <div class="row align-items-end">

--- a/crunevo/templates/auth/perfil_sidebar.html
+++ b/crunevo/templates/auth/perfil_sidebar.html
@@ -21,17 +21,6 @@
   </div>
 </div>
 
-<div class="card mt-4">
-  <div class="card-header">Verificación</div>
-  <div class="card-body text-center">
-    {% if current_user.verification_level >= 2 %}
-    <p class="mb-1">✅ Cuenta verificada.</p>
-    {% else %}
-    <p class="mb-1">Cuenta aún no verificada.</p>
-    <button class="btn btn-sm btn-outline-primary" disabled>Solicitar verificación</button>
-    {% endif %}
-  </div>
-</div>
 
 <div class="card mt-4">
   <div class="card-header">💳 Crolars</div>

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -125,7 +125,7 @@
     {% if request.endpoint not in ['auth.login', 'onboarding.register'] %}
     <button id="menuToggleBtn"
             class="btn btn-primary rounded-circle shadow position-fixed d-lg-none"
-            style="width: 48px; height: 48px; bottom: 16px; left: 16px; z-index: 1050;"
+            style="width: 48px; height: 48px; bottom: 88px; left: 16px; z-index: 1050;"
             aria-label="Menú"
             data-bs-toggle="offcanvas"
             data-bs-target="#mobileSidebar">

--- a/tests/test_user_verification.py
+++ b/tests/test_user_verification.py
@@ -16,7 +16,7 @@ def test_badge_visible(client, db_session):
     db_session.commit()
     client.post("/login", data={"username": "v", "password": "StrongPassw0rd!"})
     resp = client.get("/perfil")
-    assert b"bi-patch-check-fill" in resp.data
+    assert b"bi-check-circle-fill" in resp.data
 
 
 def test_badge_hidden(client, db_session):
@@ -26,7 +26,7 @@ def test_badge_hidden(client, db_session):
     db_session.commit()
     client.post("/login", data={"username": "n", "password": "StrongPassw0rd!"})
     resp = client.get("/perfil")
-    assert b"bi-patch-check-fill" not in resp.data
+    assert b"bi-check-circle-fill" not in resp.data
 
 
 def test_admin_can_approve(client, db_session):
@@ -50,7 +50,7 @@ def test_admin_can_approve(client, db_session):
     assert user.verification_level == 2
     client.post("/login", data={"username": "stud", "password": "pass"})
     resp = client.get("/perfil")
-    assert b"bi-patch-check-fill" in resp.data
+    assert b"bi-check-circle-fill" in resp.data
 
 
 def test_download_requires_verification(client, db_session):


### PR DESCRIPTION
## Summary
- show verified badge with tooltip in profile header
- remove verification card from sidebar
- prevent duplicate images and double-delete in feed preview
- move mobile menu toggle above bottom navigation
- update tests for new icon
- document recent changes in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6864571c8f048325b887ba8a5cb43b71