### PR TITLE
Fix feed preview duplication and verification badge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -500,3 +500,4 @@
 - Fixed SQLAlchemy case usage in search routes, replacing func.case with case to avoid TypeError logs (PR search-case-fix).
 
 - Removed unused `perfil_sidebar.html` after verifying no includes or routes reference it. (QA perfil-sidebar-diagnosis)
+- Adjusted verified badges in feed posts to check `verification_level >= 2` and added tooltip. Removed duplicate image preview initialization in main.js. (PR feed-verify-fix)

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -782,9 +782,6 @@ document.addEventListener('DOMContentLoaded', () => {
   if (typeof initQuickFilters === 'function') {
     initQuickFilters();
   }
-  if (typeof initImagePreview === 'function') {
-    initImagePreview();
-  }
   if (typeof initFeedSearch === 'function') {
     initFeedSearch();
   }

--- a/crunevo/templates/components/post_card.html
+++ b/crunevo/templates/components/post_card.html
@@ -18,8 +18,8 @@
               {{ post.author.username }}
             </a>
           </h6>
-          {% if post.author.verified %}
-          <span class="badge verified-badge">
+          {% if post.author.verification_level >= 2 %}
+          <span class="badge verified-badge" data-bs-toggle="tooltip" title="Cuenta verificada">
             <i class="bi bi-check-circle-fill"></i> Verificado
           </span>
           {% endif %}

--- a/crunevo/templates/feed/_post_modal.html
+++ b/crunevo/templates/feed/_post_modal.html
@@ -14,8 +14,10 @@
             <a href="{{ url_for('auth.profile_by_username', username=author.username) }}"
                class="text-decoration-none text-dark">{{ author.username }}</a>
           </h6>
-          {% if author.verified %}
-          <span class="badge verified-badge"><i class="bi bi-check-circle-fill"></i> Verificado</span>
+          {% if author.verification_level >= 2 %}
+          <span class="badge verified-badge" data-bs-toggle="tooltip" title="Cuenta verificada">
+            <i class="bi bi-check-circle-fill"></i> Verificado
+          </span>
           {% endif %}
         </div>
         <small class="text-muted">


### PR DESCRIPTION
## Summary
- stop calling `initImagePreview` twice from `main.js`
- show verification badge when `verification_level >= 2` with tooltip
- note new guidelines in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68645f3566908325a2cf34a98a8d8411