### PR TITLE
Fix verified badge display on profile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -501,3 +501,4 @@
 
 - Removed unused `perfil_sidebar.html` after verifying no includes or routes reference it. (QA perfil-sidebar-diagnosis)
 - Adjusted verified badges in feed posts to check `verification_level >= 2` and added tooltip. Removed duplicate image preview initialization in main.js. (PR feed-verify-fix)
+- Displayed verified badge in own profile page using same markup as post cards and checking `verification_level >= 2`. (PR perfil-own-verify)

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -24,10 +24,12 @@
           <div class="profile-header-bg" style="height: 150px; background: linear-gradient(135deg, #667eea, #764ba2); border-radius: 16px 16px 0 0;"></div>
         </div>
         <div class="card-body p-4" style="margin-top: -75px;">
-          <h3 class="fw-bold mb-3">
+          <h3 class="fw-bold d-flex align-items-center gap-2 mb-3">
             {{ user.username }}
-            {% if user.verification_level > 0 %}
-            <i class="bi bi-check-circle-fill text-primary ms-1" data-bs-toggle="tooltip" title="Cuenta verificada"></i>
+            {% if user.verification_level >= 2 %}
+            <span class="badge verified-badge" data-bs-toggle="tooltip" title="Cuenta verificada">
+              <i class="bi bi-check-circle-fill"></i>
+            </span>
             {% endif %}
           </h3>
           <div class="row align-items-end">


### PR DESCRIPTION
## Summary
- show verified badge on the own profile page similar to other views
- document the change in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68646e40b3e4832583b9b4945189df30