### PR TITLE
Fix feed post button enabling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -505,3 +505,4 @@
 
 - Displayed verified badge in own profile page using same markup as post cards and checking `verification_level >= 2`. (PR perfil-own-verify)
 - Moved username header with verification badge above description without interfering with avatar. (PR perfil-username-check)
+- Fixed feed form button enabling for text-only posts by adjusting feed.js textarea handler and removing default disabled attribute. (hotfix feed-text-posts)

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -35,7 +35,7 @@ class FeedManager {
     const textarea = form.querySelector('textarea[name="content"]');
     if (textarea) {
       textarea.addEventListener('input', () => {
-        this.autoResizeTextarea.call(textarea);
+        this.autoResizeTextarea(textarea);
         this.updatePostButtonState();
       });
     }
@@ -568,8 +568,7 @@ class FeedManager {
   }
 
   // Utility methods
-  autoResizeTextarea(e) {
-    const textarea = e.target;
+  autoResizeTextarea(textarea) {
     textarea.style.height = 'auto';
     textarea.style.height = Math.min(textarea.scrollHeight, 150) + 'px';
   }

--- a/crunevo/templates/feed/index.html
+++ b/crunevo/templates/feed/index.html
@@ -74,7 +74,7 @@
                 </div>
                 <div class="modal-footer">
                   <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-                  <button type="submit" class="btn btn-primary feed-submit-btn" disabled>
+                  <button type="submit" class="btn btn-primary feed-submit-btn">
                     <span class="submit-text">Publicar</span>
                     <div class="spinner-border spinner-border-sm d-none" role="status">
                       <span class="visually-hidden">Cargando...</span>


### PR DESCRIPTION
## Summary
- fix textarea auto-resize handler in feed.js to prevent errors
- remove `disabled` attribute from feed submit button
- document update in `AGENTS.md`

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686478ad64d48325947e941189811379