### PR TITLE
Move profile stats below username on desktop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -506,3 +506,4 @@
 - Displayed verified badge in own profile page using same markup as post cards and checking `verification_level >= 2`. (PR perfil-own-verify)
 - Moved username header with verification badge above description without interfering with avatar. (PR perfil-username-check)
 - Fixed feed form button enabling for text-only posts by adjusting feed.js textarea handler and removing default disabled attribute. (hotfix feed-text-posts)
+- Repositioned profile stats below username on desktop with responsive duplication. (PR perfil-stats-below)

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -61,8 +61,8 @@
                 </p>
                 {% endif %}
                 
-                <!-- Quick Stats -->
-                <div class="profile-stats d-flex text-center overflow-auto gap-2">
+                <!-- Quick Stats (mobile) -->
+                <div class="profile-stats d-flex text-center overflow-auto gap-2 d-sm-none">
                   <div class="flex-shrink-0">
                     <div class="stat-item">
                       <div class="fw-bold text-primary">{{ user.credits or 0 }}</div>
@@ -102,6 +102,24 @@
               </div>
             </div>
             {% endif %}
+          </div>
+          <div class="d-none d-sm-flex justify-content-center gap-3 mt-3">
+            <div class="text-center">
+              <h5 class="mb-0">{{ user.credits or 0 }}</h5>
+              <small>Crolars</small>
+            </div>
+            <div class="text-center">
+              <h5 class="mb-0">{{ user.notes|length }}</h5>
+              <small>Apuntes</small>
+            </div>
+            <div class="text-center">
+              <h5 class="mb-0">{{ user_clubs|length }}</h5>
+              <small>Clubes</small>
+            </div>
+            <div class="text-center">
+              <h5 class="mb-0">{{ completed_missions_count }}</h5>
+              <small>Misiones</small>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- shift profile stats block to display below user info on desktop
- add mobile-only class to original stats block
- document the change in AGENTS guidelines

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68647ca0476c832599ee216488cdae03