### PR TITLE
Fix profile username overlay

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -508,3 +508,4 @@
 - Fixed feed form button enabling for text-only posts by adjusting feed.js textarea handler and removing default disabled attribute. (hotfix feed-text-posts)
 - Repositioned profile stats below username on desktop with responsive duplication. (PR perfil-stats-below)
 - Cleaned profile header layout removing stats block, hiding sidebar numbers on /perfil and improving modal text post validation. (PR perfil-layout-cleanup)
+- Positioned username overlay with dark background over banner on desktop. (hotfix perfil-username-overlay)

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -24,7 +24,25 @@
           <div class="profile-header-bg" style="min-height: 180px; padding-top: 1rem; background: linear-gradient(135deg, #667eea, #764ba2); border-radius: 16px 16px 0 0;"></div>
         </div>
         <div class="card-body p-4" style="margin-top: -75px;">
-          
+
+          <!-- Username overlay on desktop -->
+          <div class="row">
+            <div class="col">
+              <div class="mt-3 position-relative z-2 d-none d-lg-block" style="margin-top: -60px;">
+                <div class="bg-dark bg-opacity-50 text-white px-3 py-1 rounded shadow d-inline-block">
+                  <h3 class="fw-bold d-flex align-items-center gap-2 mb-1">
+                    {{ user.username }}
+                    {% if user.verification_level >= 2 %}
+                    <span class="badge verified-badge" data-bs-toggle="tooltip" title="Cuenta verificada">
+                      <i class="bi bi-check-circle-fill"></i>
+                    </span>
+                    {% endif %}
+                  </h3>
+                </div>
+              </div>
+            </div>
+          </div>
+
           <div class="row align-items-center">
             <div class="col-auto">
               <div class="profile-avatar-container position-relative">
@@ -43,7 +61,7 @@
               <div class="mt-3">
 
                 <!-- Nombre de usuario con verificación -->
-                <h3 class="fw-bold d-flex align-items-center gap-2 mb-2">
+                <h3 class="fw-bold d-flex align-items-center gap-2 mb-2 d-lg-none">
                   {{ user.username }}
                   {% if user.verification_level >= 2 %}
                   <span class="badge verified-badge" data-bs-toggle="tooltip" title="Cuenta verificada">


### PR DESCRIPTION
## Summary
- overlay username and badge on top of profile banner
- note this change in AGENTS.md

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686493b1892c8325b60b68c961319c87