### PR TITLE
Fix email resend debugging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -510,3 +510,4 @@
 - Cleaned profile header layout removing stats block, hiding sidebar numbers on /perfil and improving modal text post validation. (PR perfil-layout-cleanup)
 - Positioned username overlay with dark background over banner on desktop. (hotfix perfil-username-overlay)
 - Reorganized profile header placing username next to avatar on desktop and showing stats in a gray block. (hotfix perfil-header-restore)
+- Improved email confirmation logging and resend feedback; send_email returns detailed errors and register links to reenviar (PR email-resend-debug)

--- a/crunevo/routes/admin/email_routes.py
+++ b/crunevo/routes/admin/email_routes.py
@@ -22,12 +22,14 @@ def send_admin_email():
             flash("Todos los campos son obligatorios", "danger")
             return render_template("admin/send_email.html")
 
-        success = send_email(recipient, subject, html_content)
+        success, error = send_email(recipient, subject, html_content)
         if success:
             flash("Correo enviado correctamente", "success")
             record_auth_event(current_user, "admin_send_email")
         else:
             flash("No se pudo enviar el correo", "danger")
+            if error:
+                flash(error, "danger")
 
         return redirect(url_for("admin_email.send_admin_email"))
 

--- a/crunevo/templates/onboarding/register.html
+++ b/crunevo/templates/onboarding/register.html
@@ -199,6 +199,8 @@
 
       <div class="text-center">
         <a href="{{ url_for('auth.login') }}" class="link-sm">¿Ya tienes una cuenta? Inicia sesión</a>
+        <br>
+        <a href="{{ url_for('onboarding.pending') }}" class="link-sm tw-block tw-mt-2">¿No te llegó el correo? Haz clic aquí para reenviarlo</a>
       </div>
     </form>
   </div>

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -33,7 +33,10 @@ def test_resend_rate_limit(client, db_session):
     )
     from unittest.mock import patch
 
-    with patch("crunevo.routes.onboarding_routes.send_confirmation_email"):
+    with patch(
+        "crunevo.routes.onboarding_routes.send_confirmation_email",
+        return_value=(True, None),
+    ):
         for _ in range(3):
             client.post("/onboarding/resend")
         resp = client.post("/onboarding/resend")


### PR DESCRIPTION
## Summary
- improve resend mailer to return error details and better logging
- show resend errors during register/resend
- allow admin email to report errors
- link to resend confirmation from registration page
- document changes in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686499ff33908325afb2e4cc608db9e0