### PR TITLE
Fix perfil stats layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -511,3 +511,4 @@
 - Positioned username overlay with dark background over banner on desktop. (hotfix perfil-username-overlay)
 - Reorganized profile header placing username next to avatar on desktop and showing stats in a gray block. (hotfix perfil-header-restore)
 - Improved email confirmation logging and resend feedback; send_email returns detailed errors and register links to reenviar (PR email-resend-debug)
+- Eliminada vista central de stats en perfil, mostradas en la barra lateral con puntos, crolars y apuntes como en el feed. Portada reducida y margen ajustado para mostrar el nombre sin superposición; columna principal centrada en móviles (PR perfil-sidebar-restore).

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -17,13 +17,13 @@
     </div>
 
     <!-- Main Content -->
-    <div class="col-lg-6">
+    <div class="col-12 col-lg-6 mx-auto">
       <!-- Profile Header -->
       <div class="card border-0 shadow-sm mb-4">
         <div class="position-relative">
-          <div class="profile-header-bg" style="min-height: 180px; padding-top: 1rem; background: linear-gradient(135deg, #667eea, #764ba2); border-radius: 16px 16px 0 0;"></div>
+          <div class="profile-header-bg" style="min-height: 150px; padding-top: 1rem; background: linear-gradient(135deg, #667eea, #764ba2); border-radius: 16px 16px 0 0;"></div>
         </div>
-        <div class="card-body p-4" style="margin-top: -75px;">
+        <div class="card-body p-4" style="margin-top: -60px;">
 
           <div class="row align-items-center">
             <div class="col-auto">
@@ -57,12 +57,6 @@
                     <button class="btn btn-sm btn-outline-primary ms-2">Editar</button>
                   </p>
                   {% endif %}
-                  <div class="bg-light rounded py-2 px-3 d-flex flex-wrap gap-3 small text-muted">
-                    <span><i class="bi bi-cash-coin"></i> {{ user.credits or 0 }} Crolars</span>
-                    <span><i class="bi bi-file-earmark-text"></i> {{ user.notes|length }} Apuntes</span>
-                    <span><i class="bi bi-people"></i> {{ user_clubs|length }} Clubes</span>
-                    <span><i class="bi bi-flag"></i> {{ completed_missions_count }} Misiones</span>
-                  </div>
                 </div>
               </div>
               {% if is_own_profile %}
@@ -97,12 +91,6 @@
               <button class="btn btn-sm btn-outline-primary ms-2">Editar</button>
             </p>
             {% endif %}
-            <div class="small text-muted">
-              <div>{{ user.credits or 0 }} Crolars</div>
-              <div>{{ user.notes|length }} Apuntes</div>
-              <div>{{ user_clubs|length }} Clubes</div>
-              <div>{{ completed_missions_count }} Misiones</div>
-            </div>
           </div>
         </div>
       </div>

--- a/crunevo/templates/components/sidebar_left_feed.html
+++ b/crunevo/templates/components/sidebar_left_feed.html
@@ -15,7 +15,6 @@
       </div>
 
       <!-- Profile Stats -->
-      {% if request.endpoint != 'auth.perfil' %}
       <div class="profile-stats row g-2 text-center">
         <div class="col-4">
           <div class="stat-item">
@@ -36,7 +35,6 @@
           </div>
         </div>
       </div>
-      {% endif %}
     </div>
 
     <!-- Navigation Menu -->


### PR DESCRIPTION
## Summary
- restore profile sidebar stats card
- remove redundant stats from profile header
- center profile column on mobile and adjust cover size
- record latest changes in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6864a476e4a88325a25b6e7b4b70b9bd