### PR TITLE
Fix Resend to list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -512,3 +512,4 @@
 - Reorganized profile header placing username next to avatar on desktop and showing stats in a gray block. (hotfix perfil-header-restore)
 - Improved email confirmation logging and resend feedback; send_email returns detailed errors and register links to reenviar (PR email-resend-debug)
 - Eliminada vista central de stats en perfil, mostradas en la barra lateral con puntos, crolars y apuntes como en el feed. Portada reducida y margen ajustado para mostrar el nombre sin superposición; columna principal centrada en móviles (PR perfil-sidebar-restore).
+- Sanitized recipient handling in `send_email` ensuring Resend receives a list of addresses (PR resend-to-list-fix).

--- a/crunevo/utils/mailer.py
+++ b/crunevo/utils/mailer.py
@@ -15,6 +15,14 @@ def send_email(to, subject, html):
 
     key = current_app.config.get("RESEND_API_KEY")
     provider = current_app.config.get("MAIL_PROVIDER")
+    if isinstance(to, str):
+        to_list = [to.strip()]
+    else:
+        try:
+            to_list = [str(addr).strip() for addr in to if addr]
+        except TypeError:
+            to_list = [str(to).strip()]
+
     if provider == "resend" and not key:
         current_app.logger.error(
             "MAIL_PROVIDER=resend pero RESEND_API_KEY no est\xc3\xa1 configurada"
@@ -28,7 +36,7 @@ def send_email(to, subject, html):
                 headers={"Authorization": f"Bearer {key}"},
                 json={
                     "from": f"CRUNEVO <{sender}>",
-                    "to": [to],
+                    "to": to_list,
                     "subject": subject,
                     "html": html,
                 },
@@ -51,7 +59,7 @@ def send_email(to, subject, html):
             current_app.logger.error("Email error: %s", e)
             return False, str(e)
 
-    msg = Message(subject=subject, recipients=[to], html=html)
+    msg = Message(subject=subject, recipients=to_list, html=html)
     try:
         mail.send(msg)
         return True, None


### PR DESCRIPTION
## Summary
- sanitize email recipient input in mailer and always send list to Resend
- document fix in AGENTS guidelines

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6864a9e6e9b88325bd004e8defcd265a