### PR TITLE
Fix mobile username alignment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -513,3 +513,4 @@
 - Improved email confirmation logging and resend feedback; send_email returns detailed errors and register links to reenviar (PR email-resend-debug)
 - Eliminada vista central de stats en perfil, mostradas en la barra lateral con puntos, crolars y apuntes como en el feed. Portada reducida y margen ajustado para mostrar el nombre sin superposición; columna principal centrada en móviles (PR perfil-sidebar-restore).
 - Sanitized recipient handling in `send_email` ensuring Resend receives a list of addresses (PR resend-to-list-fix).
+- Ajustado nombre de usuario a la izquierda en móviles dentro de perfil y descripción centrada. (PR perfil-mobile-name-align)

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -74,23 +74,25 @@
           </div>
 
           <!-- Mobile profile info -->
-          <div class="d-lg-none text-center mt-3">
-            <h3 class="fw-bold mb-1">
-              {{ user.username }}
-              {% if user.verification_level >= 2 %}
-                <span class="badge verified-badge">
-                  <i class="bi bi-check-circle-fill"></i>
-                </span>
+          <div class="d-lg-none mt-3">
+            <div class="d-flex justify-content-start align-items-center mb-2 px-3">
+              <h3 class="fw-bold mb-0 me-2">
+                {{ user.username }}
+                {% if user.verification_level >= 2 %}
+                  <span class="badge verified-badge">
+                    <i class="bi bi-check-circle-fill"></i>
+                  </span>
+                {% endif %}
+              </h3>
+            </div>
+            <p class="text-muted text-center px-3">
+              {% if user.about %}
+                {{ user.about }}
+              {% elif is_own_profile %}
+                <i>Añade una descripción sobre ti...</i>
+                <button class="btn btn-sm btn-outline-primary ms-2">Editar</button>
               {% endif %}
-            </h3>
-            {% if user.about %}
-            <p class="text-muted mb-2">{{ user.about }}</p>
-            {% elif is_own_profile %}
-            <p class="text-muted mb-2">
-              <i>Añade una descripción sobre ti...</i>
-              <button class="btn btn-sm btn-outline-primary ms-2">Editar</button>
             </p>
-            {% endif %}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- align profile username left on mobile with verification badge
- keep description centered under username
- document change in AGENTS log

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6864ac2f3dc48325a803788fa8ed9c7f