### PR TITLE
Add email change link on pending confirmation page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -515,3 +515,4 @@
 - Sanitized recipient handling in `send_email` ensuring Resend receives a list of addresses (PR resend-to-list-fix).
 - Ajustado nombre de usuario a la izquierda en móviles dentro de perfil y descripción centrada. (PR perfil-mobile-name-align)
 - Mostrar múltiples imágenes en cada tarjeta de publicación con galería modal y estilos en feed.css. (PR feed-gallery-display)
+- Añadido enlace para cambiar email en pending.html debajo de 'Volver al inicio' (PR pending-change-email-link).

--- a/crunevo/templates/onboarding/pending.html
+++ b/crunevo/templates/onboarding/pending.html
@@ -10,4 +10,10 @@
   </form>
   {{ btn.button('Volver al inicio', href=url_for('feed.feed_home')) }}
 </div>
+<div class="text-center mt-4">
+  <p class="text-muted small">
+    ¿Te equivocaste al escribir tu correo?
+    <a href="{{ url_for('auth.register') }}" class="text-decoration-underline">Cambiar dirección de correo</a>
+  </p>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow users to change their email from pending confirmation page
- document the change in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6864ca407c9083259a660a76b5c41e08