### PR TITLE
Fix Resend invalid to field

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -516,3 +516,4 @@
 - Ajustado nombre de usuario a la izquierda en móviles dentro de perfil y descripción centrada. (PR perfil-mobile-name-align)
 - Mostrar múltiples imágenes en cada tarjeta de publicación con galería modal y estilos en feed.css. (PR feed-gallery-display)
 - Añadido enlace para cambiar email en pending.html debajo de 'Volver al inicio' (PR pending-change-email-link).
+- Validación de formato de correo en /onboarding/register y prueba unitaria correspondiente (PR email-format-validation).

--- a/crunevo/routes/onboarding_routes.py
+++ b/crunevo/routes/onboarding_routes.py
@@ -20,6 +20,7 @@ from flask_limiter.util import get_remote_address
 from crunevo.models import User, EmailToken
 from crunevo.utils.mailer import send_email
 from crunevo.utils.audit import record_auth_event
+import re
 from sqlalchemy.exc import IntegrityError
 
 bp = Blueprint("onboarding", __name__, url_prefix="/onboarding")
@@ -49,6 +50,9 @@ def _user_key():
 def register():
     if request.method == "POST":
         email = request.form["email"]
+        if not re.fullmatch(r"[^@\s]+@[^@\s]+\.[^@\s]+", email):
+            flash("Ingresa un correo v\u00e1lido", "danger")
+            return render_template("onboarding/register.html"), 400
         password = request.form["password"]
         if (
             len(password) < 6

--- a/tests/test_email_format.py
+++ b/tests/test_email_format.py
@@ -1,0 +1,10 @@
+from crunevo.models import User
+
+
+def test_register_invalid_email(client):
+    resp = client.post(
+        "/onboarding/register",
+        data={"email": "bademail", "password": "StrongPassw0rd!"},
+    )
+    assert resp.status_code == 400
+    assert User.query.filter_by(email="bademail").first() is None


### PR DESCRIPTION
## Summary
- validate email format in register view
- test invalid emails on registration
- document changes in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6864cc3d2f608325932564c73744bd96