### PR TITLE
Fix registration link on pending page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -518,3 +518,4 @@
 - Añadido enlace para cambiar email en pending.html debajo de 'Volver al inicio' (PR pending-change-email-link).
 - Validación de formato de correo en /onboarding/register y prueba unitaria correspondiente (PR email-format-validation).
 - Mejorado diseño del correo de confirmación con imagen, botón con sombra y pie responsive (PR confirmation-email-design).
+- Corregido enlace en pending.html para usar 'onboarding.register' y evitar BuildError (hotfix pending-register-link).

--- a/crunevo/templates/onboarding/pending.html
+++ b/crunevo/templates/onboarding/pending.html
@@ -13,7 +13,7 @@
 <div class="text-center mt-4">
   <p class="text-muted small">
     ¿Te equivocaste al escribir tu correo?
-    <a href="{{ url_for('auth.register') }}" class="text-decoration-underline">Cambiar dirección de correo</a>
+    <a href="{{ url_for('onboarding.register') }}" class="text-decoration-underline">Cambiar dirección de correo</a>
   </p>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- fix registration link on pending onboarding page
- document the fix in AGENTS.md

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6864dacf98d88325bf6601b56dd13642