### PR TITLE
Add account deletion button

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -518,3 +518,4 @@
 - Añadido enlace para cambiar email en pending.html debajo de 'Volver al inicio' (PR pending-change-email-link).
 - Validación de formato de correo en /onboarding/register y prueba unitaria correspondiente (PR email-format-validation).
 - Mejorado diseño del correo de confirmación con imagen, botón con sombra y pie responsive (PR confirmation-email-design).
+- Añadido flujo de eliminación de cuenta con botón en configuración, ruta protegida y test (PR delete-account).

--- a/crunevo/templates/auth/account_deleted.html
+++ b/crunevo/templates/auth/account_deleted.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container py-5">
+  <div class="row justify-content-center">
+    <div class="col-md-6">
+      <div class="card shadow text-center p-4">
+        <i class="bi bi-person-x-fill display-4 text-danger"></i>
+        <h4 class="mt-3">Cuenta eliminada</h4>
+        <p class="mb-0">Tu cuenta se ha eliminado correctamente. ¡Gracias por usar Crunevo!</p>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/crunevo/templates/configuracion/cuenta.html
+++ b/crunevo/templates/configuracion/cuenta.html
@@ -20,6 +20,33 @@
         </div>
         <button type="submit" class="btn btn-primary">Cambiar contraseña</button>
       </form>
+      {% if current_user.is_authenticated %}
+      <button class="btn btn-danger mt-4" data-bs-toggle="modal" data-bs-target="#deleteAccountModal">
+        <i class="bi bi-trash me-2"></i>Eliminar cuenta
+      </button>
+      <div class="modal fade" id="deleteAccountModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+          <div class="modal-content">
+            <div class="modal-header bg-danger text-white">
+              <h5 class="modal-title">
+                <i class="bi bi-exclamation-triangle-fill me-2"></i>Confirmar eliminación
+              </h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+              <p>⚠ ¿Estás seguro de que deseas eliminar tu cuenta?<br>Esta acción es irreversible y se perderán todos tus datos, apuntes, comentarios, crolars, progreso en misiones, etc.</p>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+              <form method="post" action="{{ url_for('auth.delete_account') }}">
+                {{ csrf.csrf_field() }}
+                <button type="submit" class="btn btn-danger">Sí, eliminar mi cuenta</button>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+      {% endif %}
     </div>
   </div>
 </section>

--- a/tests/test_delete_account.py
+++ b/tests/test_delete_account.py
@@ -1,0 +1,20 @@
+from crunevo.models import Post, Note
+
+
+def login(client, username, password="secret"):
+    return client.post("/login", data={"username": username, "password": password})
+
+
+def test_delete_account(client, db_session, test_user):
+    post = Post(content="bye", author=test_user)
+    note = Note(title="n", filename="n.pdf", author=test_user)
+    db_session.add_all([post, note])
+    db_session.commit()
+
+    login(client, test_user.username)
+    resp = client.post("/perfil/eliminar-cuenta")
+    assert resp.status_code == 302
+    db_session.refresh(test_user)
+    assert not test_user.activated
+    assert Post.query.get(post.id) is None
+    assert Note.query.get(note.id) is None


### PR DESCRIPTION
## Summary
- allow users to delete their account from the settings page
- implement backend route that disables the user and removes their data
- show confirmation modal before deleting
- include a confirmation page after account removal
- add regression test
- document feature in AGENTS log

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6864db3dfce8832587666a74491e15f6