### PR TITLE
Redesign feed gallery layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -521,3 +521,4 @@
 - Añadido flujo de eliminación de cuenta con botón en configuración, ruta protegida y test (PR delete-account).
 - Corregido enlace en pending.html para usar 'onboarding.register' y evitar BuildError (hotfix pending-register-link).
 - Reestructurado sistema de imágenes en feed con componente unificado y galería navegable (PR feed-gallery-rework).
+- Galería del feed rediseñada con cuadrícula dinámica, modal con contador y unificación de file_url como imágenes (PR feed-gallery-facebook-style).

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -460,15 +460,18 @@ body[data-bs-theme="dark"] .comment-box {
   grid-template-columns: 1fr;
 }
 
+.post-images.images-count-1 .gallery-img {
+  height: 360px;
+}
+
 .post-images.images-count-2 {
   grid-template-columns: repeat(2, 1fr);
 }
 
 .post-images.images-count-3 {
   grid-template-columns: repeat(2, 1fr);
-  grid-template-rows: repeat(2, 1fr);
 }
-.post-images.images-count-3 .img-wrapper:nth-child(3) {
+.post-images.images-count-3 .img-wrapper:first-child {
   grid-column: 1 / -1;
 }
 
@@ -483,8 +486,8 @@ body[data-bs-theme="dark"] .comment-box {
 
 .gallery-img {
   width: 100%;
-  height: 100%;
-  border-radius: 8px;
+  height: 180px;
+  border-radius: 10px;
   object-fit: cover;
   cursor: pointer;
   transition: transform 0.2s ease;
@@ -505,5 +508,17 @@ body[data-bs-theme="dark"] .comment-box {
   font-weight: bold;
   font-size: 1.5rem;
   border-radius: 8px;
+}
+
+.gallery-modal .modal-content {
+  background: rgba(0, 0, 0, 0.9);
+}
+
+.gallery-modal .btn {
+  z-index: 10;
+}
+
+#galleryCounter {
+  z-index: 10;
 }
 

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -782,6 +782,8 @@ function openGallery(postId, startIndex = 0) {
   if (!modalEl) return;
 
   modalEl.querySelector('#modalImage').src = currentImages[currentIndex];
+  const counter = modalEl.querySelector('#galleryCounter');
+  if (counter) counter.textContent = `${currentIndex + 1}/${currentImages.length}`;
   const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
   modal.show();
   document.addEventListener('keydown', handleGalleryKey);
@@ -796,6 +798,8 @@ function closeGallery() {
 
 function updateGallery(modalEl) {
   modalEl.querySelector('#modalImage').src = currentImages[currentIndex];
+  const counter = modalEl.querySelector('#galleryCounter');
+  if (counter) counter.textContent = `${currentIndex + 1}/${currentImages.length}`;
 }
 
 function nextImage() {

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -172,7 +172,7 @@
       {% endif %}
 
     <!-- Gallery Modal -->
-    <div class="modal fade" id="galleryModal" tabindex="-1" aria-hidden="true">
+    <div class="modal fade gallery-modal" id="galleryModal" tabindex="-1" aria-hidden="true">
       <div class="modal-dialog modal-dialog-centered modal-lg">
         <div class="modal-content bg-transparent border-0 position-relative">
           <button type="button" class="btn btn-secondary position-absolute top-0 end-0 m-3" data-bs-dismiss="modal" aria-label="Cerrar" onclick="closeGallery()">
@@ -185,6 +185,7 @@
             <i class="bi bi-chevron-right"></i>
           </button>
           <img id="modalImage" class="img-fluid rounded-3" alt="Imagen" style="max-height:80vh;">
+          <div id="galleryCounter" class="position-absolute bottom-0 start-50 translate-middle-x mb-3 text-white fw-semibold"></div>
         </div>
       </div>
     </div>

--- a/crunevo/templates/feed/post_detail.html
+++ b/crunevo/templates/feed/post_detail.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% import 'components/csrf.html' as csrf %}
 {% import 'components/reactions.html' as react %}
+{% import 'components/image_gallery.html' as gallery %}
 {% block content %}
 <div class="card mb-4 shadow-sm border-0 rounded-4">
   <div class="card-body p-4">
@@ -35,11 +36,13 @@
       </a>
     </div>
     {% endif %}
-      {% if post.file_url %}
+      {% if post.images %}
+      {{ gallery.image_gallery(post.images, post.id) }}
+      {% elif post.file_url %}
         {% if post.file_url.endswith('.pdf') %}
         <a href="{{ post.file_url }}" target="_blank" class="btn btn-outline-primary mb-2">Ver PDF</a>
         {% else %}
-        <img loading="lazy" src="{{ post.file_url }}" class="feed-image img-fluid rounded mb-2">
+        {{ gallery.image_gallery([{'url': post.file_url}], post.id) }}
         {% endif %}
       {% endif %}
       {% set counts = reaction_counts %}


### PR DESCRIPTION
## Summary
- update feed gallery CSS for dynamic grid and uniform sizes
- add counter overlay to gallery modal
- display posts with file_url using the gallery macro
- show image counter on gallery navigation
- note this task in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68656421f3308325ab649a93d4e59a9e