### PR TITLE
Fix feed image grid

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -526,3 +526,4 @@
 - Rediseñado el feed principal con tarjetas centradas "feed-post-card" y oculto el sidebar derecho en móviles (PR feed-facebook-style).
 - Galería de publicaciones adaptada con clase `.post-gallery`, navegación por publicación y padding reducido en móviles (PR feed-gallery-grid).
 - Eliminado Redis por completo; caches ahora usan memoria y se actualizó README y pruebas (PR redis-removal).
+- Galería del feed ajustada con límite de altura 300px, cuadrícula de hasta cuatro miniaturas y overlay de más imágenes; modal lee URLs desde data attribute (PR feed-image-grid-fix).

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -532,9 +532,17 @@ body[data-bs-theme="dark"] .comment-box {
 .post-gallery.images-2 {
   grid-template-columns: repeat(2, 1fr);
 }
+.post-gallery.images-3 {
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: repeat(2, 120px);
+}
+.post-gallery.images-4 {
+  grid-template-columns: repeat(2, 1fr);
+}
 .post-gallery.single img {
   height: auto;
-  max-height: 400px;
+  max-height: 300px;
+  object-fit: cover;
 }
 .post-gallery img {
   width: 100%;
@@ -546,6 +554,26 @@ body[data-bs-theme="dark"] .comment-box {
 }
 .post-gallery img:hover {
   transform: scale(1.03);
+}
+
+.image-thumb {
+  position: relative;
+}
+
+.image-thumb.more::after {
+  content: attr(data-more);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  border-radius: 8px;
 }
 
 .image-modal {
@@ -621,7 +649,7 @@ body[data-bs-theme="dark"] .comment-box {
   border-radius: 8px;
   max-width: 100%;
   object-fit: cover;
-  max-height: 400px;
+  max-height: 300px;
 }
 .feed-post-card .post-actions {
   display: flex;

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -777,8 +777,17 @@ let currentImageIndex = 0;
 let imageList = [];
 
 function openImageModal(src, index, postId) {
-  const selector = `[data-post-id='${postId}'] .image-thumb img, [data-post-id='${postId}'] > img`;
-  imageList = Array.from(document.querySelectorAll(selector)).map((img) => img.src);
+  const container = document.querySelector(`[data-post-id='${postId}']`);
+  if (container && container.dataset.images) {
+    try {
+      imageList = JSON.parse(container.dataset.images);
+    } catch (e) {
+      imageList = [];
+    }
+  } else {
+    const selector = `[data-post-id='${postId}'] .image-thumb img, [data-post-id='${postId}'] > img`;
+    imageList = Array.from(document.querySelectorAll(selector)).map((img) => img.src);
+  }
   currentImageIndex = index;
   document.getElementById('modalImage').src = src;
   document.getElementById('imageModal').classList.remove('hidden');

--- a/crunevo/templates/components/image_gallery.html
+++ b/crunevo/templates/components/image_gallery.html
@@ -6,13 +6,26 @@
   <img src="{{ url }}" alt="Imagen" loading="lazy" onclick="openImageModal('{{ url }}', 0, '{{ post_id }}')" />
 </div>
 {% else %}
-<div class="post-gallery images-{{ count }}" data-post-id="{{ post_id }}">
-  {% for image in images %}
-  {% set url = image.url if image.url is defined else image %}
-  <div class="image-thumb" onclick="openImageModal('{{ url }}', {{ loop.index0 }}, '{{ post_id }}')">
-    <img src="{{ url }}" alt="Imagen" loading="lazy" />
-  </div>
+{% set urls = images | map(attribute='url') if images[0] is mapping or images[0].url is defined else images %}
+{% if count > 4 %}
+  {% set visible = images[:4] %}
+  <div class="post-gallery images-{{ visible|length }}" data-post-id="{{ post_id }}" data-images='{{ urls | tojson }}'>
+  {% for image in visible %}
+    {% set url = image.url if image.url is defined else image %}
+    <div class="image-thumb{% if loop.last %} more{% endif %}" onclick="openImageModal('{{ url }}', {{ loop.index0 }}, '{{ post_id }}')"{% if loop.last %} data-more="+{{ count - 4 }}"{% endif %}>
+      <img src="{{ url }}" alt="Imagen" loading="lazy" />
+    </div>
   {% endfor %}
-</div>
+  </div>
+{% else %}
+  <div class="post-gallery images-{{ count }}" data-post-id="{{ post_id }}">
+  {% for image in images %}
+    {% set url = image.url if image.url is defined else image %}
+    <div class="image-thumb" onclick="openImageModal('{{ url }}', {{ loop.index0 }}, '{{ post_id }}')">
+      <img src="{{ url }}" alt="Imagen" loading="lazy" />
+    </div>
+  {% endfor %}
+  </div>
+{% endif %}
 {% endif %}
 {% endmacro %}


### PR DESCRIPTION
## Summary
- keep feed images compact with 300px max-height
- add grid layout overlay for extra images
- enable modal to load images from a data attribute
- document changes in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6865a13ef1808325b944e46031453b7c