### PR TITLE
Fix feed modal image scaling and responsive card width

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -528,3 +528,4 @@
 - Eliminado Redis por completo; caches ahora usan memoria y se actualizó README y pruebas (PR redis-removal).
 - Galería del feed ajustada con límite de altura 300px, cuadrícula de hasta cuatro miniaturas y overlay de más imágenes; modal lee URLs desde data attribute (PR feed-image-grid-fix).
 - Incluido feed.css globalmente en base.html para activar la cuadrícula de la galería en todas las vistas (PR feed-gallery-css-fix).
+- Ajustados estilos del feed: imágenes del modal preservan proporciones, tarjetas ocupan todo el ancho y márgenes móviles eliminados (PR feed-responsive-fixes).

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -591,9 +591,16 @@ body[data-bs-theme="dark"] .comment-box {
 .image-modal.hidden {
   display: none;
 }
-.image-modal img {
-  max-width: 90%;
-  max-height: 80%;
+.modal-image-container {
+  max-height: 90vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.modal-image-container img {
+  max-width: 100%;
+  height: auto;
+  object-fit: contain;
   border-radius: 8px;
 }
 .image-modal .close,
@@ -626,6 +633,12 @@ body[data-bs-theme="dark"] .comment-box {
   transform: translateY(-50%);
 }
 
+/* Feed container full width */
+#feedContainer {
+  width: 100%;
+  max-width: none !important;
+}
+
 /* Modern feed post card */
 .feed-post-card {
   background: #fff;
@@ -634,9 +647,9 @@ body[data-bs-theme="dark"] .comment-box {
   padding: 16px;
   margin-bottom: 20px;
   transition: all 0.3s ease;
-  max-width: 600px;
-  margin-left: auto;
-  margin-right: auto;
+  width: 100%;
+  max-width: none;
+  margin: 0 auto;
 }
 [data-bs-theme="dark"] .feed-post-card {
   background: #1f2937;
@@ -671,6 +684,16 @@ body[data-bs-theme="dark"] .comment-box {
   .feed-post-card {
     padding: 12px;
     margin-bottom: 16px;
+    border-radius: 0;
+    margin-left: 0;
+    margin-right: 0;
+  }
+  #feedContainer {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
+  body {
+    background-color: #fff !important;
   }
 }
 

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -175,7 +175,9 @@
     <!-- Image Modal -->
     <div id="imageModal" class="image-modal hidden">
       <span class="close" onclick="closeImageModal()">&times;</span>
-      <img class="modal-content" id="modalImage" alt="Imagen">
+      <div class="modal-image-container">
+        <img class="modal-content" id="modalImage" alt="Imagen">
+      </div>
       <div class="modal-counter" id="modalCounter"></div>
       <div class="modal-nav prev" onclick="prevImage()">&larr;</div>
       <div class="modal-nav next" onclick="nextImage()">&rarr;</div>


### PR DESCRIPTION
## Summary
- wrap modal image with container for better scaling
- ensure images in modal keep aspect ratio
- make feed cards full-width and adjust container
- remove mobile side margins and set white background
- document changes in AGENTS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865a8fd71248325a3195fe9cbf92699