### PR TITLE
Fix post_card orphan author handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -529,3 +529,4 @@
 - Galería del feed ajustada con límite de altura 300px, cuadrícula de hasta cuatro miniaturas y overlay de más imágenes; modal lee URLs desde data attribute (PR feed-image-grid-fix).
 - Incluido feed.css globalmente en base.html para activar la cuadrícula de la galería en todas las vistas (PR feed-gallery-css-fix).
 - Ajustados estilos del feed: imágenes del modal preservan proporciones, tarjetas ocupan todo el ancho y márgenes móviles eliminados (PR feed-responsive-fixes).
+- post_card.html now uses a local `author` variable and shows 'Usuario eliminado' when missing (PR post-card-orphan-fix).

--- a/crunevo/templates/components/post_card.html
+++ b/crunevo/templates/components/post_card.html
@@ -1,4 +1,5 @@
 {% set post = item.data %}
+{% set author = post.author %}
 {% set reaction_counts = reaction_counts if reaction_counts is defined else {} %}
 {% set user_reactions = user_reactions if user_reactions is defined else {} %}
 {% import 'components/image_gallery.html' as gallery %}
@@ -6,20 +7,24 @@
   <div class="post-body p-4">
     <!-- Post Header -->
     <div class="d-flex align-items-center gap-3 mb-3">
-      <img src="{{ post.author.avatar_url or url_for('static', filename='img/default.png') }}" 
-           alt="{{ post.author.username }}" 
-           class="rounded-circle" 
-           width="48" 
+      <img src="{{ author.avatar_url if author else url_for('static', filename='img/default.png') }}"
+           alt="{{ author.username if author else 'Usuario eliminado' }}"
+           class="rounded-circle"
+           width="48"
            height="48">
       <div class="flex-grow-1">
         <div class="d-flex align-items-center gap-2">
           <h6 class="mb-0 fw-semibold">
-            <a href="{{ url_for('auth.profile_by_username', username=post.author.username) }}" 
+            {% if author %}
+            <a href="{{ url_for('auth.profile_by_username', username=author.username) }}"
                class="text-decoration-none text-dark">
-              {{ post.author.username }}
+              {{ author.username }}
             </a>
+            {% else %}
+            Usuario eliminado
+            {% endif %}
           </h6>
-          {% if post.author.verification_level >= 2 %}
+          {% if author and author.verification_level >= 2 %}
           <span class="badge verified-badge" data-bs-toggle="tooltip" title="Cuenta verificada">
             <i class="bi bi-check-circle-fill"></i> Verificado
           </span>


### PR DESCRIPTION
## Summary
- add local `author` variable in `post_card.html`
- show default avatar and placeholder text when post has no author
- document this fix in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6865adf33d608325b21d57b032cdb81f