### PR TITLE
Fix gallery urls list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -529,3 +529,4 @@
 - Galería del feed ajustada con límite de altura 300px, cuadrícula de hasta cuatro miniaturas y overlay de más imágenes; modal lee URLs desde data attribute (PR feed-image-grid-fix).
 - Incluido feed.css globalmente en base.html para activar la cuadrícula de la galería en todas las vistas (PR feed-gallery-css-fix).
 - Ajustados estilos del feed: imágenes del modal preservan proporciones, tarjetas ocupan todo el ancho y márgenes móviles eliminados (PR feed-responsive-fixes).
+- Convertido generador a lista en image_gallery.html para mantener JSON del modal. (PR gallery-list-fix)

--- a/crunevo/templates/components/image_gallery.html
+++ b/crunevo/templates/components/image_gallery.html
@@ -6,7 +6,7 @@
   <img src="{{ url }}" alt="Imagen" loading="lazy" onclick="openImageModal('{{ url }}', 0, '{{ post_id }}')" />
 </div>
 {% else %}
-{% set urls = images | map(attribute='url') if images[0] is mapping or images[0].url is defined else images %}
+{% set urls = (images | map(attribute='url') | list) if images[0] is mapping or images[0].url is defined else images %}
 {% if count > 4 %}
   {% set visible = images[:4] %}
   <div class="post-gallery images-{{ visible|length }}" data-post-id="{{ post_id }}" data-images='{{ urls | tojson }}'>


### PR DESCRIPTION
## Summary
- cast URL generator to a list when preparing gallery JSON
- document the fix in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6865adf367708325b0fbcf5f74347e46