### PR TITLE
Fix feed JS global actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -534,3 +534,4 @@
 - post_card.html now uses a local `author` variable and shows 'Usuario eliminado' when missing (PR post-card-orphan-fix).
 - Updated profile tabs to use query string navigation, ensuring missions and achievements load correctly (PR perfil-tabs-fix).
 - Fixed edit and delete actions on feed posts with modal form and fetch logic (PR feed-edit-delete-fix).
+- Resolved feed.js syntax error and exposed post action functions to window (hotfix feed-js-buttons).

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -833,6 +833,10 @@ window.openImageModal = openImageModal;
 window.closeImageModal = closeImageModal;
 window.nextImage = nextImage;
 window.prevImage = prevImage;
+window.editPost = editPost;
+window.deletePost = deletePost;
+window.reportPost = reportPost;
+window.copyPostLink = copyPostLink;
 
 const editPostForm = document.getElementById('editPostForm');
 if (editPostForm) {
@@ -853,7 +857,10 @@ if (editPostForm) {
       });
       if (resp.ok) {
         const card = document.querySelector(`[data-post-id='${postId}']`);
-        card?.querySelector('.post-content p')?.textContent = content;
+        const contentEl = card ? card.querySelector('.post-content p') : null;
+        if (contentEl) {
+          contentEl.textContent = content;
+        }
         feedManager.showToast('Publicación actualizada', 'success');
         bootstrap.Modal.getInstance(document.getElementById('editPostModal')).hide();
       } else {


### PR DESCRIPTION
## Summary
- fix syntax error in feed.js when updating post content
- expose post action functions globally for inline handlers
- document hotfix in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6865e8837ce083258048b581438451b1