### PR TITLE
Add dynamic photo modal with history navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -537,3 +537,4 @@
 - Resolved feed.js syntax error and exposed post action functions to window (hotfix feed-js-buttons).
 - /health endpoint now returns JSON {"status": "ok"}; updated test accordingly (PR health-json-endpoint).
 - Fixed deleting posts with saved records; removal now deletes SavedPost entries to prevent IntegrityError (PR delete-savedpost-fix).
+- Implementado visor de imágenes con URL dinámica tipo Facebook y navegación en feed.js y base.html (PR photo-modal-dynamic).

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -588,11 +588,19 @@ body[data-bs-theme="dark"] .comment-box {
   background-color: rgba(0, 0, 0, 0.85);
   z-index: 9999;
 }
+.modal-body-wrapper {
+  max-width: 90vw;
+  max-height: 90vh;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
 .image-modal.hidden {
   display: none;
 }
 .modal-image-container {
-  max-height: 90vh;
+  max-height: 70vh;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -602,6 +610,11 @@ body[data-bs-theme="dark"] .comment-box {
   height: auto;
   object-fit: contain;
   border-radius: 8px;
+}
+.modal-details {
+  overflow-y: auto;
+  max-height: 20vh;
+  color: #fff;
 }
 .image-modal .close,
 .image-modal .modal-nav {

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -866,6 +866,29 @@ document.addEventListener('DOMContentLoaded', () => {
   if (window.HAS_STORE) {
     refreshCartCount();
   }
+
+  const photoMatch = window.location.pathname.match(/\/feed\/post\/(\d+)\/photo\/(\d+)/);
+  if (photoMatch && typeof openImageModal === 'function') {
+    const postId = photoMatch[1];
+    const idx = parseInt(photoMatch[2], 10) - 1;
+    const container = document.querySelector(`[data-post-id='${postId}']`);
+    if (container) {
+      const imgs = container.querySelectorAll('.image-thumb img, > img');
+      if (imgs[idx]) {
+        openImageModal(imgs[idx].src, idx, postId);
+      }
+    }
+  }
+
+  window.addEventListener('popstate', () => {
+    if (!window.location.pathname.match(/\/feed\/post\/\d+\/photo\/\d+/)) {
+      const modal = document.getElementById('imageModal');
+      if (modal && !modal.classList.contains('hidden')) {
+        modal.classList.add('hidden');
+        document.getElementById('imageModalInfo').innerHTML = '';
+      }
+    }
+  });
   document.querySelectorAll('.add-cart-btn').forEach((btn) => {
     btn.addEventListener('click', (e) => {
       e.preventDefault();

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -173,10 +173,13 @@
       {% endif %}
 
     <!-- Image Modal -->
-    <div id="imageModal" class="image-modal hidden">
+    <div id="imageModal" class="image-modal hidden" onclick="outsideImageClick(event)">
       <span class="close" onclick="closeImageModal()">&times;</span>
-      <div class="modal-image-container">
-        <img class="modal-content" id="modalImage" alt="Imagen">
+      <div class="modal-body-wrapper">
+        <div class="modal-image-container">
+          <img class="modal-content" id="modalImage" alt="Imagen">
+        </div>
+        <div id="imageModalInfo" class="modal-details"></div>
       </div>
       <div class="modal-counter" id="modalCounter"></div>
       <div class="modal-nav prev" onclick="prevImage()">&larr;</div>


### PR DESCRIPTION
## Summary
- update image modal markup in `base.html` to include post info container
- style new modal layout in `feed.css`
- load post details and push state in `feed.js` for gallery navigation
- auto-open modal from URL and handle back button in `main.js`
- document change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6865feba20b48325a3a454b5252ed4a4