### PR TITLE
Redesigned photo modal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -538,3 +538,4 @@
 - /health endpoint now returns JSON {"status": "ok"}; updated test accordingly (PR health-json-endpoint).
 - Fixed deleting posts with saved records; removal now deletes SavedPost entries to prevent IntegrityError (PR delete-savedpost-fix).
 - Implementado visor de imágenes con URL dinámica tipo Facebook y navegación en feed.js y base.html (PR photo-modal-dynamic).
+- Rediseñado modal de imágenes estilo Facebook con botones accesibles, tarjeta informativa y ruta compartible "/feed/post/<id>/photo/<n>" que establece OG:image (PR photo-modal-redesign).

--- a/crunevo/routes/feed_routes.py
+++ b/crunevo/routes/feed_routes.py
@@ -360,6 +360,31 @@ def view_post(post_id: int):
     )
 
 
+@feed_bp.route("/post/<int:post_id>/photo/<int:index>", endpoint="view_post_photo")
+@activated_required
+def view_post_photo(post_id: int, index: int):
+    """Display a single image from a post."""
+    post = Post.query.get_or_404(post_id)
+    counts = PostReaction.count_for_post(post.id)
+    my_reaction = (
+        PostReaction.query.with_entities(PostReaction.reaction_type)
+        .filter_by(user_id=current_user.id, post_id=post.id)
+        .scalar()
+    )
+    image_url = None
+    if post.images and 1 <= index <= len(post.images):
+        image_url = post.images[index - 1].url
+    elif post.file_url:
+        image_url = post.file_url
+    return render_template(
+        "feed/post_detail.html",
+        post=post,
+        reaction_counts=counts,
+        user_reaction=my_reaction,
+        og_image=image_url,
+    )
+
+
 @feed_bp.route("/user/<int:user_id>/posts")
 @activated_required
 def user_posts(user_id: int):

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -614,6 +614,14 @@ body[data-bs-theme="dark"] .comment-box {
 .modal-details {
   overflow-y: auto;
   max-height: 20vh;
+  background: #fff;
+  color: #000;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+}
+[data-bs-theme="dark"] .modal-details {
+  background: #1e1e1e;
   color: #fff;
 }
 .image-modal .close,
@@ -623,6 +631,8 @@ body[data-bs-theme="dark"] .comment-box {
   font-size: 2rem;
   cursor: pointer;
   user-select: none;
+  background: none;
+  border: none;
 }
 .image-modal .close {
   top: 10px;
@@ -644,6 +654,10 @@ body[data-bs-theme="dark"] .comment-box {
   right: 20px;
   top: 50%;
   transform: translateY(-50%);
+}
+
+body.photo-modal-open main {
+  display: none;
 }
 
 /* Feed container full width */

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -806,9 +806,21 @@ function openImageModal(src, index, postId) {
   }
   currentImageIndex = index;
   currentPostId = postId;
-  document.getElementById('modalImage').src = src;
+  const modalImage = document.getElementById('modalImage');
+  modalImage.src = src;
+  modalImage.alt = `Imagen ${index + 1} de la publicación`;
   const modal = document.getElementById('imageModal');
   modal.classList.remove('hidden');
+  document.body.classList.add('photo-modal-open');
+  const prevBtn = modal.querySelector('.modal-nav.prev');
+  const nextBtn = modal.querySelector('.modal-nav.next');
+  if (imageList.length > 1) {
+    prevBtn.style.display = '';
+    nextBtn.style.display = '';
+  } else {
+    prevBtn.style.display = 'none';
+    nextBtn.style.display = 'none';
+  }
   updateModalCounter();
   fetch(`/feed/api/post/${postId}`)
     .then((r) => r.json())
@@ -824,6 +836,7 @@ function openImageModal(src, index, postId) {
 function closeImageModal() {
   document.getElementById('imageModal').classList.add('hidden');
   document.getElementById('imageModalInfo').innerHTML = '';
+  document.body.classList.remove('photo-modal-open');
   currentPostId = null;
   window.history.back();
 }

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -174,7 +174,7 @@
 
     <!-- Image Modal -->
     <div id="imageModal" class="image-modal hidden" onclick="outsideImageClick(event)">
-      <span class="close" onclick="closeImageModal()">&times;</span>
+      <button class="close" aria-label="Cerrar" onclick="closeImageModal()">✖</button>
       <div class="modal-body-wrapper">
         <div class="modal-image-container">
           <img class="modal-content" id="modalImage" alt="Imagen">
@@ -182,8 +182,8 @@
         <div id="imageModalInfo" class="modal-details"></div>
       </div>
       <div class="modal-counter" id="modalCounter"></div>
-      <div class="modal-nav prev" onclick="prevImage()">&larr;</div>
-      <div class="modal-nav next" onclick="nextImage()">&rarr;</div>
+      <button class="modal-nav prev" aria-label="Imagen anterior" onclick="prevImage()">←</button>
+      <button class="modal-nav next" aria-label="Siguiente imagen" onclick="nextImage()">→</button>
     </div>
 
     <!-- Bootstrap JS -->

--- a/crunevo/templates/components/image_gallery.html
+++ b/crunevo/templates/components/image_gallery.html
@@ -3,7 +3,7 @@
 {% if count == 1 %}
 <div class="post-gallery single" data-post-id="{{ post_id }}">
   {% set url = images[0].url if images[0].url is defined else images[0] %}
-  <img src="{{ url }}" alt="Imagen" loading="lazy" onclick="openImageModal('{{ url }}', 0, '{{ post_id }}')" />
+  <img src="{{ url }}" alt="Imagen 1 de la publicación" loading="lazy" onclick="openImageModal('{{ url }}', 0, '{{ post_id }}')" />
 </div>
 {% else %}
 {% set urls = (images | map(attribute='url') | list) if images[0] is mapping or images[0].url is defined else images %}
@@ -13,7 +13,7 @@
   {% for image in visible %}
     {% set url = image.url if image.url is defined else image %}
     <div class="image-thumb{% if loop.last %} more{% endif %}" onclick="openImageModal('{{ url }}', {{ loop.index0 }}, '{{ post_id }}')"{% if loop.last %} data-more="+{{ count - 4 }}"{% endif %}>
-      <img src="{{ url }}" alt="Imagen" loading="lazy" />
+      <img src="{{ url }}" alt="Imagen {{ loop.index }} de la publicación" loading="lazy" />
     </div>
   {% endfor %}
   </div>
@@ -22,7 +22,7 @@
   {% for image in images %}
     {% set url = image.url if image.url is defined else image %}
     <div class="image-thumb" onclick="openImageModal('{{ url }}', {{ loop.index0 }}, '{{ post_id }}')">
-      <img src="{{ url }}" alt="Imagen" loading="lazy" />
+      <img src="{{ url }}" alt="Imagen {{ loop.index }} de la publicación" loading="lazy" />
     </div>
   {% endfor %}
   </div>

--- a/crunevo/templates/feed/post_detail.html
+++ b/crunevo/templates/feed/post_detail.html
@@ -2,6 +2,9 @@
 {% import 'components/csrf.html' as csrf %}
 {% import 'components/reactions.html' as react %}
 {% import 'components/image_gallery.html' as gallery %}
+{% if og_image %}
+{% block og_image %}{{ og_image }}{% endblock %}
+{% endif %}
 {% block content %}
 <div class="card mb-4 shadow-sm border-0 rounded-4">
   <div class="card-body p-4">


### PR DESCRIPTION
## Summary
- add accessible buttons for photo modal
- style modal details card for dark/light themes
- hide main content when photo modal open
- support dynamic OG image via new `/feed/post/<id>/photo/<n>` route
- document redesign in AGENTS notes

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68662deaa0648325baaa971549ac7a31