### PR TITLE
Improve post OG metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -539,3 +539,4 @@
 - Fixed deleting posts with saved records; removal now deletes SavedPost entries to prevent IntegrityError (PR delete-savedpost-fix).
 - Implementado visor de imágenes con URL dinámica tipo Facebook y navegación en feed.js y base.html (PR photo-modal-dynamic).
 - Rediseñado modal de imágenes estilo Facebook con botones accesibles, tarjeta informativa y ruta compartible "/feed/post/<id>/photo/<n>" que establece OG:image (PR photo-modal-redesign).
+- Añadidos metadatos OpenGraph dinámicos en `post_detail` con título y descripción derivados del contenido, enviados desde `feed_routes.py` (PR feed-og-tags).

--- a/crunevo/routes/feed_routes.py
+++ b/crunevo/routes/feed_routes.py
@@ -352,11 +352,19 @@ def view_post(post_id: int):
         .filter_by(user_id=current_user.id, post_id=post.id)
         .scalar()
     )
+    og_title = (
+        f"Publicación de {post.author.username}"
+        if post.author
+        else "Publicación en Crunevo"
+    )
+    og_description = (post.content or "")[:100]
     return render_template(
         "feed/post_detail.html",
         post=post,
         reaction_counts=counts,
         user_reaction=my_reaction,
+        og_title=og_title,
+        og_description=og_description,
     )
 
 
@@ -376,12 +384,16 @@ def view_post_photo(post_id: int, index: int):
         image_url = post.images[index - 1].url
     elif post.file_url:
         image_url = post.file_url
+    og_title = f"Foto de {post.author.username}" if post.author else "Foto en Crunevo"
+    og_description = (post.content or "")[:100]
     return render_template(
         "feed/post_detail.html",
         post=post,
         reaction_counts=counts,
         user_reaction=my_reaction,
         og_image=image_url,
+        og_title=og_title,
+        og_description=og_description,
     )
 
 

--- a/crunevo/templates/feed/post_detail.html
+++ b/crunevo/templates/feed/post_detail.html
@@ -2,9 +2,9 @@
 {% import 'components/csrf.html' as csrf %}
 {% import 'components/reactions.html' as react %}
 {% import 'components/image_gallery.html' as gallery %}
-{% if og_image %}
-{% block og_image %}{{ og_image }}{% endblock %}
-{% endif %}
+{% block og_title %}{{ og_title or 'Publicación de ' ~ (post.author.username if post.author else 'usuario') }}{% endblock %}
+{% block og_description %}{{ og_description or (post.content|striptags)|truncate(100) }}{% endblock %}
+{% if og_image %}{% block og_image %}{{ og_image }}{% endblock %}{% endif %}
 {% block content %}
 <div class="card mb-4 shadow-sm border-0 rounded-4">
   <div class="card-body p-4">


### PR DESCRIPTION
## Summary
- support dynamic OG title and description when viewing posts
- surface OG metadata in post_detail template

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686630f82c8c83258810d31349bf6ca3