### PR TITLE
Improve feed gallery and trending navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -541,3 +541,4 @@
 - Rediseñado modal de imágenes estilo Facebook con botones accesibles, tarjeta informativa y ruta compartible "/feed/post/<id>/photo/<n>" que establece OG:image (PR photo-modal-redesign).
 - Añadidos metadatos OpenGraph dinámicos en `post_detail` con título y descripción derivados del contenido, enviados desde `feed_routes.py` (PR feed-og-tags).
 - Se extrajo el CSS del visor de imágenes a `photo-modal.css`, se incluyó en `base.html` y se añadieron mejoras de accesibilidad: role="dialog", botones type="button" y enlace para abrir la imagen en nueva pestaña. (PR photo-modal-css)
+- Galería macro ahora siempre define data-images para todas las publicaciones y trending incluye botón "Volver al Feed" (PR feed-gallery-data-images).

--- a/crunevo/templates/components/image_gallery.html
+++ b/crunevo/templates/components/image_gallery.html
@@ -1,12 +1,12 @@
 {% macro image_gallery(images, post_id) %}
 {% set count = images|length %}
+{% set urls = (images | map(attribute='url') | list) if images and (images[0] is mapping or images[0].url is defined) else images %}
 {% if count == 1 %}
-<div class="post-gallery single" data-post-id="{{ post_id }}">
-  {% set url = images[0].url if images[0].url is defined else images[0] %}
+<div class="post-gallery single" data-post-id="{{ post_id }}" data-images='{{ urls | tojson }}'>
+  {% set url = urls[0] %}
   <img src="{{ url }}" alt="Imagen 1 de la publicación" loading="lazy" onclick="openImageModal('{{ url }}', 0, '{{ post_id }}')" />
 </div>
 {% else %}
-{% set urls = (images | map(attribute='url') | list) if images[0] is mapping or images[0].url is defined else images %}
 {% if count > 4 %}
   {% set visible = images[:4] %}
   <div class="post-gallery images-{{ visible|length }}" data-post-id="{{ post_id }}" data-images='{{ urls | tojson }}'>
@@ -18,7 +18,7 @@
   {% endfor %}
   </div>
 {% else %}
-  <div class="post-gallery images-{{ count }}" data-post-id="{{ post_id }}">
+  <div class="post-gallery images-{{ count }}" data-post-id="{{ post_id }}" data-images='{{ urls | tojson }}'>
   {% for image in images %}
     {% set url = image.url if image.url is defined else image %}
     <div class="image-thumb" onclick="openImageModal('{{ url }}', {{ loop.index0 }}, '{{ post_id }}')">

--- a/crunevo/templates/feed/trending.html
+++ b/crunevo/templates/feed/trending.html
@@ -170,9 +170,15 @@
     <div class="col-lg-9 col-12">
       <div class="px-3 px-lg-4">
         <!-- Hero Section -->
-        <div class="trending-hero">
+        <div class="trending-hero mb-3">
           <h1>🔥 Trending</h1>
           <p>Lo más popular e impactante de la comunidad educativa</p>
+        </div>
+
+        <div class="mb-4 text-end">
+          <a href="{{ url_for('feed.view_feed') }}" class="btn btn-outline-primary btn-sm">
+            <i class="bi bi-arrow-left"></i> Volver al Feed
+          </a>
         </div>
 
         <!-- Filters -->


### PR DESCRIPTION
## Summary
- ensure `image_gallery` sets `data-images` for all posts
- add a back link to the feed in the trending page
- document changes in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686636a51e648325a3cd5cfdd8650c22