### PR TITLE
Enhance photo modal with zoom controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -542,3 +542,4 @@
 - Añadidos metadatos OpenGraph dinámicos en `post_detail` con título y descripción derivados del contenido, enviados desde `feed_routes.py` (PR feed-og-tags).
 - Se extrajo el CSS del visor de imágenes a `photo-modal.css`, se incluyó en `base.html` y se añadieron mejoras de accesibilidad: role="dialog", botones type="button" y enlace para abrir la imagen en nueva pestaña. (PR photo-modal-css)
 - Galería macro ahora siempre define data-images para todas las publicaciones y trending incluye botón "Volver al Feed" (PR feed-gallery-data-images).
+- Mejorado visor de imágenes con fondo oscuro, controles de zoom y flechas centradas. Tarjeta lateral ocupa 100% hasta 400px y botón para abrir imagen en nueva pestaña. (PR photo-modal-pro-style)

--- a/crunevo/static/css/photo-modal.css
+++ b/crunevo/static/css/photo-modal.css
@@ -8,7 +8,8 @@
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: rgba(0, 0, 0, 0.85);
+  background-color: rgba(0, 0, 0, 0.92);
+  backdrop-filter: blur(4px);
   z-index: 1050;
 }
 
@@ -29,6 +30,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  position: relative;
+  overflow: hidden;
 }
 
 .modal-image-container img {
@@ -36,6 +39,7 @@
   height: auto;
   object-fit: contain;
   border-radius: 8px;
+  transition: transform 0.3s ease;
 }
 
 .modal-details {
@@ -46,6 +50,33 @@
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
   overflow-y: auto;
   max-height: 30vh;
+  width: 100%;
+  max-width: 400px;
+}
+
+.zoom-controls {
+  position: absolute;
+  bottom: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 0.5rem;
+}
+
+.zoom-controls button {
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.7);
+}
+
+[data-bs-theme="dark"] .zoom-controls button {
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
 }
 
 [data-bs-theme="dark"] .modal-details {
@@ -60,8 +91,14 @@
   font-size: 2rem;
   cursor: pointer;
   user-select: none;
-  background: none;
   border: none;
+  background: rgba(0, 0, 0, 0.4);
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .image-modal .close {
@@ -76,14 +113,16 @@
   color: #fff;
 }
 
+
 .image-modal .modal-nav.prev {
-  left: 20px;
+  left: 40px;
   top: 50%;
   transform: translateY(-50%);
 }
 
+
 .image-modal .modal-nav.next {
-  right: 20px;
+  right: 40px;
   top: 50%;
   transform: translateY(-50%);
 }
@@ -103,7 +142,7 @@ body.photo-modal-open {
   }
 
   .modal-details {
-    flex: 0 0 320px;
+    flex: 0 0 400px;
     max-height: 100%;
   }
 }

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -791,6 +791,29 @@ window.initFeedManager = initFeedManager;
 let currentImageIndex = 0;
 let imageList = [];
 let currentPostId = null;
+let currentScale = 1;
+
+function applyZoom() {
+  const img = document.getElementById('modalImage');
+  if (img) {
+    img.style.transform = `scale(${currentScale})`;
+  }
+}
+
+function zoomIn() {
+  currentScale += 0.2;
+  applyZoom();
+}
+
+function zoomOut() {
+  currentScale = Math.max(0.2, currentScale - 0.2);
+  applyZoom();
+}
+
+function resetZoom() {
+  currentScale = 1;
+  applyZoom();
+}
 
 function openImageModal(src, index, postId) {
   const container = document.querySelector(`[data-post-id='${postId}']`);
@@ -808,8 +831,12 @@ function openImageModal(src, index, postId) {
   currentPostId = postId;
   const modalImage = document.getElementById('modalImage');
   const modalLink = document.getElementById('modalImageLink');
+  const openTab = document.getElementById('openImageNewTab');
   modalImage.src = src;
   if (modalLink) modalLink.href = src;
+  if (openTab) openTab.href = src;
+  currentScale = 1;
+  applyZoom();
   modalImage.alt = `Imagen ${index + 1} de la publicación`;
   const modal = document.getElementById('imageModal');
   modal.classList.remove('hidden');
@@ -880,6 +907,9 @@ window.closeImageModal = closeImageModal;
 window.nextImage = nextImage;
 window.prevImage = prevImage;
 window.outsideImageClick = outsideImageClick;
+window.zoomIn = zoomIn;
+window.zoomOut = zoomOut;
+window.resetZoom = resetZoom;
 window.editPost = editPost;
 window.deletePost = deletePost;
 window.reportPost = reportPost;

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -177,16 +177,26 @@
     <div id="imageModal" class="image-modal hidden" role="dialog" aria-modal="true" onclick="outsideImageClick(event)">
       <button type="button" class="close" aria-label="Cerrar" onclick="closeImageModal()">✖</button>
       <div class="modal-body-wrapper">
-        <div class="modal-image-container">
+        <div class="modal-image-container position-relative">
           <a id="modalImageLink" target="_blank" rel="noopener">
             <img class="modal-content" id="modalImage" alt="Imagen">
+          </a>
+          <div class="zoom-controls">
+            <button type="button" aria-label="Acercar" onclick="zoomIn()"><i class="bi bi-plus-lg"></i></button>
+            <button type="button" aria-label="Alejar" onclick="zoomOut()"><i class="bi bi-dash-lg"></i></button>
+            <button type="button" aria-label="Ajustar" onclick="resetZoom()"><i class="bi bi-arrows-fullscreen"></i></button>
+          </div>
+        </div>
+        <div class="text-center mt-2">
+          <a id="openImageNewTab" target="_blank" class="text-decoration-none link-light" rel="noopener">
+            Abrir imagen <i class="bi bi-box-arrow-up-right"></i>
           </a>
         </div>
         <div id="imageModalInfo" class="modal-details"></div>
       </div>
       <div class="modal-counter" id="modalCounter"></div>
-      <button type="button" class="modal-nav prev" aria-label="Imagen anterior" onclick="prevImage()">←</button>
-      <button type="button" class="modal-nav next" aria-label="Siguiente imagen" onclick="nextImage()">→</button>
+      <button type="button" class="modal-nav prev" aria-label="Imagen anterior" onclick="prevImage()"><i class="bi bi-chevron-left"></i></button>
+      <button type="button" class="modal-nav next" aria-label="Siguiente imagen" onclick="nextImage()"><i class="bi bi-chevron-right"></i></button>
     </div>
 
     <!-- Bootstrap JS -->


### PR DESCRIPTION
## Summary
- improve photo modal background and side card sizing
- add zoom controls and open link
- style navigation arrows
- document photo modal improvements in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68663ace83148325bf5eba63f2437e75