### PR TITLE
Twitter-style photo modal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -543,3 +543,4 @@
 - Se extrajo el CSS del visor de imágenes a `photo-modal.css`, se incluyó en `base.html` y se añadieron mejoras de accesibilidad: role="dialog", botones type="button" y enlace para abrir la imagen en nueva pestaña. (PR photo-modal-css)
 - Galería macro ahora siempre define data-images para todas las publicaciones y trending incluye botón "Volver al Feed" (PR feed-gallery-data-images).
 - Mejorado visor de imágenes con fondo oscuro, controles de zoom y flechas centradas. Tarjeta lateral ocupa 100% hasta 400px y botón para abrir imagen en nueva pestaña. (PR photo-modal-pro-style)
+- Visor de imágenes estilo X/Twitter con flechas internas, controles de zoom flotantes y tarjeta lateral de 380px (PR photo-modal-twitter-style)

--- a/crunevo/static/css/photo-modal.css
+++ b/crunevo/static/css/photo-modal.css
@@ -8,7 +8,7 @@
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: rgba(0, 0, 0, 0.92);
+  background-color: #0d0d0d;
   backdrop-filter: blur(4px);
   z-index: 1050;
 }
@@ -51,14 +51,13 @@
   overflow-y: auto;
   max-height: 30vh;
   width: 100%;
-  max-width: 400px;
+  max-width: 380px;
 }
 
 .zoom-controls {
   position: absolute;
-  bottom: 10px;
-  left: 50%;
-  transform: translateX(-50%);
+  top: 10px;
+  right: 10px;
   display: flex;
   gap: 0.5rem;
 }
@@ -85,7 +84,7 @@
 }
 
 .image-modal .close,
-.image-modal .modal-nav {
+.modal-image-container .modal-nav {
   position: absolute;
   color: #fff;
   font-size: 2rem;
@@ -104,27 +103,25 @@
 .image-modal .close {
   top: 10px;
   right: 20px;
-}
-
 .image-modal .modal-counter {
   position: absolute;
   top: 10px;
-  right: 70px;
+  left: 50%;
+  transform: translateX(-50%);
   color: #fff;
 }
 
-
-.image-modal .modal-nav.prev {
-  left: 40px;
+.modal-image-container .modal-nav {
   top: 50%;
   transform: translateY(-50%);
 }
 
+.modal-image-container .modal-nav.prev {
+  left: 16px;
+}
 
-.image-modal .modal-nav.next {
-  right: 40px;
-  top: 50%;
-  transform: translateY(-50%);
+.modal-image-container .modal-nav.next {
+  right: 16px;
 }
 
 body.photo-modal-open {
@@ -142,7 +139,7 @@ body.photo-modal-open {
   }
 
   .modal-details {
-    flex: 0 0 400px;
+    flex: 0 0 380px;
     max-height: 100%;
   }
 }

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -916,11 +916,11 @@ window.reportPost = reportPost;
 window.copyPostLink = copyPostLink;
 
 const editPostForm = document.getElementById('editPostForm');
-if (editPostForm) {
-  editPostForm.addEventListener('submit', async (e) => {
-    e.preventDefault();
-    const form = e.currentTarget;
-    const postId = form.dataset.postId;
+  if (editPostForm) {
+    editPostForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const form = e.currentTarget;
+      const postId = form.dataset.postId;
     const content = form.querySelector('textarea[name="content"]').value.trim();
 
     const formData = new FormData();
@@ -946,5 +946,31 @@ if (editPostForm) {
     } catch (error) {
       feedManager.showToast('Error de conexión', 'error');
     }
-  });
+    });
+  }
+
+// Keyboard navigation and wheel zoom for photo modal
+document.addEventListener('keydown', (e) => {
+  if (!document.body.classList.contains('photo-modal-open')) return;
+  if (e.key === 'Escape') {
+    closeImageModal();
+  } else if (e.key === 'ArrowRight') {
+    nextImage();
+  } else if (e.key === 'ArrowLeft') {
+    prevImage();
+  }
+});
+
+const modalImageContainer = document.querySelector('#imageModal .modal-image-container');
+if (modalImageContainer) {
+  modalImageContainer.addEventListener('wheel', (e) => {
+    if (!document.body.classList.contains('photo-modal-open')) return;
+    e.preventDefault();
+    if (e.deltaY < 0) {
+      currentScale += 0.1;
+    } else {
+      currentScale = Math.max(0.2, currentScale - 0.1);
+    }
+    applyZoom();
+  }, { passive: false });
 }

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -178,14 +178,17 @@
       <button type="button" class="close" aria-label="Cerrar" onclick="closeImageModal()">✖</button>
       <div class="modal-body-wrapper">
         <div class="modal-image-container position-relative">
+          <button type="button" class="modal-nav prev" aria-label="Imagen anterior" onclick="prevImage()"><i class="bi bi-chevron-left"></i></button>
           <a id="modalImageLink" target="_blank" rel="noopener">
             <img class="modal-content" id="modalImage" alt="Imagen">
           </a>
+          <button type="button" class="modal-nav next" aria-label="Siguiente imagen" onclick="nextImage()"><i class="bi bi-chevron-right"></i></button>
           <div class="zoom-controls">
             <button type="button" aria-label="Acercar" onclick="zoomIn()"><i class="bi bi-plus-lg"></i></button>
             <button type="button" aria-label="Alejar" onclick="zoomOut()"><i class="bi bi-dash-lg"></i></button>
             <button type="button" aria-label="Ajustar" onclick="resetZoom()"><i class="bi bi-arrows-fullscreen"></i></button>
           </div>
+          <div class="modal-counter" id="modalCounter"></div>
         </div>
         <div class="text-center mt-2">
           <a id="openImageNewTab" target="_blank" class="text-decoration-none link-light" rel="noopener">
@@ -194,9 +197,6 @@
         </div>
         <div id="imageModalInfo" class="modal-details"></div>
       </div>
-      <div class="modal-counter" id="modalCounter"></div>
-      <button type="button" class="modal-nav prev" aria-label="Imagen anterior" onclick="prevImage()"><i class="bi bi-chevron-left"></i></button>
-      <button type="button" class="modal-nav next" aria-label="Siguiente imagen" onclick="nextImage()"><i class="bi bi-chevron-right"></i></button>
     </div>
 
     <!-- Bootstrap JS -->


### PR DESCRIPTION
## Summary
- move modal nav buttons inside image container
- dark background and smaller info card
- floating zoom controls and keyboard/wheel interactions
- document photo modal Twitter redesign in AGENTS log

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68664009f0bc83258ecb99b613a36c18