### PR TITLE
Fix PWA caching for feed scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -545,3 +545,4 @@
 - Mejorado visor de imágenes con fondo oscuro, controles de zoom y flechas centradas. Tarjeta lateral ocupa 100% hasta 400px y botón para abrir imagen en nueva pestaña. (PR photo-modal-pro-style)
 - Separación de plantillas escritorio/móvil para el feed con detección de user-agent y script de recarga. (PR mobile-desktop-separation)
 - Added PWA manifest and service worker with offline caching; registered in base.html (PR pwa-support).
+- Updated service worker caching: removed '/feed', excluded JS from dynamic cache and bumped version to crunevo-v2 (PR pwa-cache-update).

--- a/crunevo/static/js/sw-cache.js
+++ b/crunevo/static/js/sw-cache.js
@@ -1,6 +1,5 @@
 const STATIC_ASSETS = [
   '/',
-  '/feed',
   '/static/css/feed.css',
   '/static/img/icon-192.png',
   '/static/img/icon-512.png',
@@ -14,7 +13,24 @@ self.addEventListener('install', event => {
 
 self.addEventListener('fetch', event => {
   const req = event.request;
+  if (req.method !== 'GET') {
+    return;
+  }
   event.respondWith(
-    caches.match(req).then(res => res || fetch(req))
+    caches.match(req).then(cachedResponse => {
+      return (
+        cachedResponse ||
+        fetch(req)
+          .then(networkResponse => {
+            if (req.url.includes('.js')) {
+              return networkResponse;
+            }
+            return caches.open(version).then(cache => {
+              cache.put(req, networkResponse.clone());
+              return networkResponse;
+            });
+          })
+      );
+    })
   );
 });

--- a/crunevo/static/js/sw-utils.js
+++ b/crunevo/static/js/sw-utils.js
@@ -1,2 +1,2 @@
-const version = 'crunevo-v1';
+const version = 'crunevo-v2';
 const log = (...args) => console.log('[CRUNEVO-SW]', ...args);


### PR DESCRIPTION
## Summary
- prevent JS caching and remove `/feed` from static assets in `sw-cache.js`
- bump service worker version to force update
- document PWA cache fix in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686719961b2883259d16edc073112432