### PR TITLE
Implement change_email flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -548,3 +548,4 @@
 - Updated service worker caching: removed '/feed', excluded JS from dynamic cache and bumped version to crunevo-v2 (PR pwa-cache-update).
 - Pending email confirmation page redesigned with gradient background, modern card and bouncing envelope icon (PR pending-ui-refresh).
 - Fixed duplicate isMobile constant in main.js that prevented feed buttons from working (PR feed-buttons-bugfix).
+- Implemented route `onboarding.change_email` with new template and updated pending page with disabled resend button (PR pending-change-email-route).

--- a/crunevo/routes/onboarding_routes.py
+++ b/crunevo/routes/onboarding_routes.py
@@ -208,3 +208,26 @@ def resend():
 
 
 csrf.exempt(resend)
+
+
+@bp.route("/change_email", methods=["GET", "POST"])
+@login_required
+def change_email():
+    if request.method == "POST":
+        new_email = request.form.get("email")
+        if not new_email or not re.fullmatch(r"[^@\s]+@[^@\s]+\.[^@\s]+", new_email):
+            flash("Ingresa un correo válido", "danger")
+            return render_template("onboarding/change_email.html"), 400
+        if User.query.filter_by(email=new_email).first():
+            flash("Ese correo ya está registrado", "danger")
+            return render_template("onboarding/change_email.html"), 400
+        current_user.email = new_email
+        current_user.activated = False
+        db.session.commit()
+        send_confirmation_email(current_user)
+        flash(
+            "Tu dirección de correo ha sido actualizada y se ha reenviado la verificación.",
+            "success",
+        )
+        return redirect(url_for("onboarding.pending"))
+    return render_template("onboarding/change_email.html")

--- a/crunevo/templates/onboarding/change_email.html
+++ b/crunevo/templates/onboarding/change_email.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% import 'components/csrf.html' as csrf %}
+
+{% block content %}
+<div class="tw-min-h-screen tw-flex tw-items-center tw-justify-center tw-bg-gradient-to-b tw-from-indigo-50 tw-to-purple-100 dark:tw-from-gray-900 dark:tw-to-gray-800 tw-px-4">
+  <div class="tw-bg-white dark:tw-bg-gray-900 tw-rounded-2xl tw-shadow-lg tw-p-8 tw-max-w-md tw-w-full tw-text-center">
+    <div class="tw-text-4xl tw-mb-4 tw-text-indigo-600">✉️</div>
+    <h1 class="tw-text-2xl tw-font-semibold tw-mb-4">Cambiar dirección de correo</h1>
+    <form method="POST" class="tw-space-y-4">
+      {{ csrf.csrf_field() }}
+      <input type="email" name="email" placeholder="Nuevo correo" class="tw-w-full tw-p-3 tw-border tw-rounded-lg" required>
+      <button type="submit" class="tw-w-full tw-bg-indigo-600 tw-text-white tw-py-2 tw-rounded-lg hover:tw-bg-indigo-700">📤 Actualizar y reenviar</button>
+    </form>
+    <div class="tw-mt-4">
+      <a href="{{ url_for('onboarding.pending') }}" class="tw-text-sm tw-text-gray-500 hover:tw-underline">← Volver</a>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/crunevo/templates/onboarding/pending.html
+++ b/crunevo/templates/onboarding/pending.html
@@ -2,18 +2,18 @@
 {% import 'components/csrf.html' as csrf %}
 {% block content %}
 <div class="tw-min-h-screen tw-flex tw-items-center tw-justify-center tw-bg-gradient-to-b tw-from-indigo-50 tw-to-purple-100 dark:tw-from-gray-900 dark:tw-to-gray-800 tw-px-4">
-  <div class="tw-bg-white dark:tw-bg-gray-900 tw-rounded-2xl tw-shadow-lg tw-p-8 tw-max-w-md tw-w-full tw-text-center">
-    <div class="tw-text-4xl tw-mb-4 tw-text-indigo-600 animate-bounce">📩</div>
-    <h1 class="tw-text-2xl tw-font-semibold tw-mb-2">¡Estás a un paso de entrar a CRUNEVO!</h1>
-    <p class="tw-text-gray-600 dark:tw-text-gray-300 tw-mb-6">Hemos enviado un correo de verificación a <strong>tu dirección registrada</strong>. Haz clic en el enlace para activar tu cuenta.</p>
+  <div class="tw-bg-white dark:tw-bg-gray-900 tw-rounded-2xl tw-shadow-2xl tw-p-8 tw-max-w-md tw-w-full tw-text-center tw-space-y-4">
+    <div class="tw-text-5xl tw-mb-2 tw-text-indigo-600 animate-bounce">📩</div>
+    <h1 class="tw-text-2xl tw-font-semibold">¡Estás a un paso de entrar a CRUNEVO!</h1>
+    <p class="tw-text-gray-600 dark:tw-text-gray-300">Hemos enviado un correo de verificación a <strong>tu dirección registrada</strong>. Haz clic en el enlace para activar tu cuenta.</p>
 
-    <form method="post" action="{{ url_for('onboarding.resend') }}" class="tw-mb-4">
+    <form method="post" action="{{ url_for('onboarding.resend') }}" class="tw-mb-2" onsubmit="this.querySelector('button').disabled=true;">
       {{ csrf.csrf_field() }}
       <button type="submit" class="tw-w-full tw-bg-indigo-600 tw-text-white tw-py-2 tw-rounded-lg hover:tw-bg-indigo-700 tw-transition">📧 Reenviar correo</button>
     </form>
 
-    <div class="tw-mt-4">
-      <a href="{{ url_for('onboarding.register') }}" class="tw-text-sm tw-text-blue-600 hover:tw-underline">✍️ Cambiar dirección de correo</a>
+    <div>
+      <a href="{{ url_for('onboarding.change_email') }}" class="tw-text-sm tw-text-blue-600 hover:tw-underline">✍️ Cambiar dirección de correo</a>
     </div>
     <div class="tw-mt-2">
       <a href="{{ url_for('feed.feed_home') }}" class="tw-text-sm tw-text-gray-500 hover:tw-underline">← Volver al inicio</a>


### PR DESCRIPTION
## Summary
- add `/onboarding/change_email` route
- create new `change_email.html` template
- redesign pending email confirmation page
- disable resend button on submit
- test change-email functionality
- document the update in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6867371932388325b6d9ff001db26a9d