### PR TITLE
Fix optional onboarding flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -550,3 +550,4 @@
 - Fixed duplicate isMobile constant in main.js that prevented feed buttons from working (PR feed-buttons-bugfix).
 - Implemented route `onboarding.change_email` with new template and updated pending page with disabled resend button (PR pending-change-email-route).
 - Updated onboarding confirm page with modern card, email change and AJAX resend endpoint; added `/auth/resend-confirmation` route (PR confirm-resend-change).
+- Onboarding now redirects to feed after email verification, profile completion is optional with default bio text when empty (PR optional-onboarding-fix).

--- a/crunevo/routes/onboarding_routes.py
+++ b/crunevo/routes/onboarding_routes.py
@@ -148,7 +148,11 @@ def confirm(token):
     db.session.commit()
     record_auth_event(record.user, "confirm_email")
     login_user(record.user)
-    return redirect(url_for("onboarding.finish"))
+    flash(
+        "¡Correo verificado! Puedes personalizar tu perfil o ir directamente al feed.",
+        "success",
+    )
+    return redirect(url_for("feed.feed_home"))
 
 
 @bp.route("/finish", methods=["GET", "POST"])

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -56,6 +56,8 @@
                     <i>Añade una descripción sobre ti...</i>
                     <button class="btn btn-sm btn-outline-primary ms-2">Editar</button>
                   </p>
+                  {% else %}
+                  <p class="text-muted mb-2"><i>Este usuario aún no ha escrito su biografía.</i></p>
                   {% endif %}
                 </div>
               </div>
@@ -91,6 +93,8 @@
               {% elif is_own_profile %}
                 <i>Añade una descripción sobre ti...</i>
                 <button class="btn btn-sm btn-outline-primary ms-2">Editar</button>
+              {% else %}
+                <i>Este usuario aún no ha escrito su biografía.</i>
               {% endif %}
             </p>
           </div>

--- a/crunevo/templates/onboarding/finish.html
+++ b/crunevo/templates/onboarding/finish.html
@@ -6,13 +6,16 @@
     <div class="col-md-8 col-lg-6">
       <div class="card shadow">
         <div class="card-body p-4">
-          <h2 class="text-center mb-4">👤 Completa tu perfil</h2>
+          <h2 class="text-center mb-4">👤 Opcional: personaliza tu perfil</h2>
+          <p class="text-muted text-center">Puedes hacerlo más tarde desde tu perfil público.</p>
           <form method="post" enctype="multipart/form-data">
             {{ csrf.csrf_field() }}
+            {% if current_user.username == current_user.email %}
             <div class="mb-3">
               <label for="aliasInput" class="form-label">Nombre para mostrar</label>
               <input type="text" class="form-control" id="aliasInput" name="alias" placeholder="ej. ProfeRogger">
             </div>
+            {% endif %}
             <div class="mb-3">
               <label class="form-label">Foto de perfil</label>
               <input class="form-control mb-2" type="file" id="avatarFileInput" name="avatar_file" accept="image/*">

--- a/crunevo/templates/perfil_publico.html
+++ b/crunevo/templates/perfil_publico.html
@@ -14,6 +14,8 @@
     {% endif %}
     {% if user.about %}
     <p class="lead">{{ user.about }}</p>
+    {% else %}
+    <p class="text-muted"><i>Este usuario aún no ha escrito su biografía.</i></p>
     {% endif %}
     <div class="mb-3">
       <span class="badge bg-success"><i class="bi bi-coin me-1"></i>{{ user.credits }}</span>

--- a/crunevo/utils/helpers.py
+++ b/crunevo/utils/helpers.py
@@ -1,6 +1,6 @@
 from functools import wraps
 from datetime import datetime
-from flask import redirect, url_for
+from flask import redirect, url_for, flash
 from flask_login import current_user, login_required
 
 
@@ -31,9 +31,8 @@ def activated_required(f):
     @login_required
     def decorated_function(*args, **kwargs):
         if not current_user.activated:
+            flash("Primero debes confirmar tu correo.", "warning")
             return redirect(url_for("onboarding.pending"))
-        if current_user.username == current_user.email or not current_user.avatar_url:
-            return redirect(url_for("onboarding.finish"))
         return f(*args, **kwargs)
 
     return decorated_function


### PR DESCRIPTION
## Summary
- redirect users to the feed after verifying the email
- make `activated_required` only enforce email confirmation
- clarify that finishing the profile is optional
- show default biography text when empty
- log the change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68674cf930d08325a931ae27d935cad7