### PR TITLE
Fix verification redirect with new user API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -552,3 +552,4 @@
 - Updated onboarding confirm page with modern card, email change and AJAX resend endpoint; added `/auth/resend-confirmation` route (PR confirm-resend-change).
 - Onboarding now redirects to feed after email verification, profile completion is optional with default bio text when empty (PR optional-onboarding-fix).
 - Onboarding finish page updated with modern card, dynamic avatar preview and bio counter (PR onboarding-finish-refresh)
+- Added /api/user endpoint returning activation status and JS redirect in pending.html to avoid being stuck after verification (PR pending-verify-redirect).

--- a/crunevo/routes/auth_routes.py
+++ b/crunevo/routes/auth_routes.py
@@ -448,3 +448,16 @@ def delete_account():
 @auth_bp.route("/cuenta-eliminada")
 def account_deleted():
     return render_template("auth/account_deleted.html")
+
+
+@auth_bp.route("/api/user")
+@login_required
+def api_user():
+    """Return basic data for the currently logged in user."""
+    return jsonify(
+        {
+            "activated": current_user.activated,
+            "username": current_user.username,
+            "verification_level": current_user.verification_level,
+        }
+    )

--- a/crunevo/templates/onboarding/pending.html
+++ b/crunevo/templates/onboarding/pending.html
@@ -20,4 +20,9 @@
     </div>
   </div>
 </div>
+{% if current_user.activated %}
+  <script>
+    window.location.href = "{{ url_for('feed.feed_home') }}";
+  </script>
+{% endif %}
 {% endblock %}

--- a/tests/test_api_user.py
+++ b/tests/test_api_user.py
@@ -1,0 +1,11 @@
+def login(client, username, password="secret"):
+    return client.post("/login", data={"username": username, "password": password})
+
+
+def test_api_user_returns_status(client, test_user):
+    login(client, test_user.username)
+    resp = client.get("/api/user")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["activated"] is True
+    assert data["username"] == test_user.username


### PR DESCRIPTION
## Summary
- expose `/api/user` endpoint for login status
- auto redirect verified users from `onboarding/pending`
- add regression test for new endpoint
- document changes in AGENTS history

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68676c8412b883259aa9a219fb68c656