### PR TITLE
Improve pending email redirect

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -554,3 +554,4 @@
 - Onboarding finish page updated with modern card, dynamic avatar preview and bio counter (PR onboarding-finish-refresh)
 - Added /api/user endpoint returning activation status and JS redirect in pending.html to avoid being stuck after verification (PR pending-verify-redirect).
 - Ensured email confirmation logs the user in after activation to refresh session (PR confirm-login-user).
+- Pending page now polls `/api/user` every few seconds and redirects once the account is activated to avoid getting stuck (PR pending-refresh-status).

--- a/crunevo/templates/onboarding/pending.html
+++ b/crunevo/templates/onboarding/pending.html
@@ -24,5 +24,22 @@
   <script>
     window.location.href = "{{ url_for('feed.feed_home') }}";
   </script>
+{% else %}
+  <script>
+    async function checkActivation() {
+      try {
+        const resp = await fetch("{{ url_for('auth.api_user') }}");
+        if (resp.ok) {
+          const data = await resp.json();
+          if (data.activated) {
+            window.location.href = "{{ url_for('feed.feed_home') }}";
+          }
+        }
+      } catch (e) {
+        console.error(e);
+      }
+    }
+    setInterval(checkActivation, 5000);
+  </script>
 {% endif %}
 {% endblock %}

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -100,3 +100,10 @@ def test_change_email_updates_and_resends(client, db_session):
         assert user.email == "newchg@example.com"
         assert not user.activated
         assert len(outbox) == 1
+
+
+def test_pending_redirects_when_active(client, test_user):
+    login(client, test_user.username, "secret")
+    resp = client.get("/onboarding/pending")
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/")


### PR DESCRIPTION
## Summary
- auto-check activation status on pending page via `/api/user`
- test that `/onboarding/pending` redirects for activated users
- document change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686783364aa88325b68208c7aa5ad85d