### PR TITLE
Add dashboard weather widget

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -556,3 +556,4 @@
 - Ensured email confirmation logs the user in after activation to refresh session (PR confirm-login-user).
 - Pending page now polls `/api/user` every few seconds and redirects once the account is activated to avoid getting stuck (PR pending-refresh-status).
 - Mejorado visor de imágenes del feed con fondo oscuro, zoom accesible y flechas internas al estilo de redes sociales (PR photo-modal-advanced).
+- Added weather widget on user dashboard fetching data from OpenWeather API with caching via requests. (PR weather-dashboard-widget)

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -190,6 +190,7 @@ def create_app():
     from .routes.about_routes import about_bp
     from .routes.static_routes import static_bp
     from .routes.saved_routes import saved_bp
+    from .routes.dashboard_routes import dashboard_bp
     from .routes.settings_routes import settings_bp
     from .routes.main_routes import main_bp
 
@@ -295,6 +296,7 @@ def create_app():
         app.register_blueprint(about_bp)
         app.register_blueprint(static_bp)
         app.register_blueprint(saved_bp)
+        app.register_blueprint(dashboard_bp)
         app.register_blueprint(settings_bp)
         app.register_blueprint(errors_bp)
         if testing_env:

--- a/crunevo/cache/weather_cache.py
+++ b/crunevo/cache/weather_cache.py
@@ -1,0 +1,17 @@
+import time
+from typing import Any
+
+TTL = 600  # 10 minutes
+
+_cache: dict[str, tuple[Any, float]] = {}
+
+
+def get(key: str) -> Any | None:
+    entry = _cache.get(key)
+    if entry and entry[1] > time.time():
+        return entry[0]
+    return None
+
+
+def set(key: str, data: Any) -> None:
+    _cache[key] = (data, time.time() + TTL)

--- a/crunevo/config.py
+++ b/crunevo/config.py
@@ -37,6 +37,7 @@ class Config:
 
     RESEND_API_KEY = os.getenv("RESEND_API_KEY")
     OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+    OPENWEATHER_API_KEY = os.getenv("OPENWEATHER_API_KEY")
     MAIL_PROVIDER = os.getenv("MAIL_PROVIDER", "smtp")
     USE_RESEND = MAIL_PROVIDER == "resend" or RESEND_API_KEY is not None
     MAIL_SUPPRESS_SEND = (

--- a/crunevo/routes/dashboard_routes.py
+++ b/crunevo/routes/dashboard_routes.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import asyncio
+import requests
+from flask import Blueprint, render_template, request, jsonify, current_app
+from flask_login import login_required
+
+from crunevo.cache import weather_cache
+
+
+dashboard_bp = Blueprint("dashboard", __name__, url_prefix="/dashboard")
+
+
+@dashboard_bp.get("/")
+@login_required
+def index():
+    return render_template("dashboard/dashboard.html")
+
+
+async def fetch_weather(lat: float, lon: float) -> dict | None:
+    key = f"{lat:.2f},{lon:.2f}"
+    cached = weather_cache.get(key)
+    if cached:
+        return cached
+
+    api_key = current_app.config.get("OPENWEATHER_API_KEY")
+    if not api_key:
+        return None
+
+    url = "https://api.openweathermap.org/data/2.5/weather"
+    params = {"lat": lat, "lon": lon, "appid": api_key, "units": "metric", "lang": "es"}
+
+    loop = asyncio.get_running_loop()
+
+    def _do_request():
+        resp = requests.get(url, params=params, timeout=5)
+        resp.raise_for_status()
+        return resp.json()
+
+    data = await loop.run_in_executor(None, _do_request)
+    weather_cache.set(key, data)
+    return data
+
+
+@dashboard_bp.get("/weather")
+@login_required
+def weather():
+    lat = request.args.get("lat", type=float)
+    lon = request.args.get("lon", type=float)
+    if lat is None or lon is None:
+        return jsonify(error="missing coordinates"), 400
+
+    data = asyncio.run(fetch_weather(lat, lon))
+    if not data:
+        return jsonify(error="unavailable"), 502
+
+    weather = data.get("weather", [{}])[0]
+    icon = weather.get("icon", "01d")
+    return jsonify(
+        city=data.get("name"),
+        temp=data.get("main", {}).get("temp"),
+        desc=weather.get("description"),
+        icon=f"https://openweathermap.org/img/wn/{icon}@2x.png",
+    )

--- a/crunevo/templates/dashboard/_weather.html
+++ b/crunevo/templates/dashboard/_weather.html
@@ -1,0 +1,24 @@
+<div id="weatherWidget" class="tw-bg-white dark:tw-bg-gray-800 tw-rounded-lg tw-shadow p-4">
+  <div class="tw-flex tw-items-center">
+    <img id="weatherIcon" class="tw-w-10 tw-h-10 tw-me-2" alt="icon" />
+    <div>
+      <p id="weatherCity" class="tw-font-semibold"></p>
+      <p id="weatherTemp" class="tw-text-sm tw-text-gray-600 dark:tw-text-gray-300"></p>
+    </div>
+  </div>
+</div>
+<script>
+function loadWeather() {
+  if (!navigator.geolocation) return;
+  navigator.geolocation.getCurrentPosition(async (pos) => {
+    const { latitude, longitude } = pos.coords;
+    const resp = await fetch(`/dashboard/weather?lat=${latitude}&lon=${longitude}`);
+    if (!resp.ok) return;
+    const data = await resp.json();
+    document.getElementById('weatherCity').textContent = data.city;
+    document.getElementById('weatherTemp').textContent = `${data.temp}°C - ${data.desc}`;
+    document.getElementById('weatherIcon').src = data.icon;
+  });
+}
+document.addEventListener('DOMContentLoaded', loadWeather);
+</script>

--- a/crunevo/templates/dashboard/dashboard.html
+++ b/crunevo/templates/dashboard/dashboard.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block title %}Dashboard{% endblock %}
+
+{% block content %}
+<div class="row">
+  <div class="col-lg-8">
+    <h1 class="mb-4 fw-bold">Dashboard</h1>
+  </div>
+  <div class="col-lg-4">
+    {% include 'dashboard/_weather.html' %}
+  </div>
+</div>
+{% endblock %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,9 @@ def another_user(db_session):
 @pytest.fixture(autouse=True)
 def reset_caches():
     feed_cache._cache.clear()
+    from crunevo.cache import weather_cache
+
+    weather_cache._cache.clear()
     from crunevo import tasks
 
     tasks.task_queue = tasks._LocalQueue()

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -1,0 +1,20 @@
+def login(client, username):
+    return client.post("/login", data={"username": username, "password": "secret"})
+
+
+def test_weather_endpoint(client, test_user, monkeypatch):
+    login(client, test_user.username)
+
+    async def fake_fetch(lat, lon):
+        return {
+            "name": "Lima",
+            "main": {"temp": 21},
+            "weather": [{"description": "clear", "icon": "01d"}],
+        }
+
+    monkeypatch.setattr("crunevo.routes.dashboard_routes.fetch_weather", fake_fetch)
+    resp = client.get("/dashboard/weather?lat=0&lon=0")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["city"] == "Lima"
+    assert data["temp"] == 21


### PR DESCRIPTION
## Summary
- show weather widget on dashboard
- fetch data from OpenWeather with async helper and in-memory cache
- expose weather endpoint for geolocation requests
- test dashboard weather route
- document widget in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686850c8a98c832588fc8bd09b446a7d