### PR TITLE
Add keyboard shortcuts with help dialog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -560,3 +560,4 @@
 - Added weather widget on user dashboard fetching data from OpenWeather API with caching via requests. (PR weather-dashboard-widget)
 =======
 - Añadido sonido opcional para nuevas notificaciones con control en configuración (PR sound-notifications).
+- Added keyboard shortcuts Shift+H (home) and Shift+N (new post) with a help dialog accessible from a question icon. (PR keyboard-shortcuts-help)

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -940,6 +940,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   initMissionClaimButtons();
   highlightNewAchievements();
+  initKeyboardShortcuts();
 
   // Bootstrap collapse handles the mobile menu
 
@@ -1194,4 +1195,28 @@ function highlightNewAchievements() {
         const el = document.getElementById(`achievement-${a.code}`);
         if (el) el.classList.add('bounce-once', 'fade-in');
     });
+}
+
+function initKeyboardShortcuts() {
+  document.addEventListener('keydown', (e) => {
+    if (!e.shiftKey) return;
+    const target = e.target;
+    if (
+      target.tagName === 'INPUT' ||
+      target.tagName === 'TEXTAREA' ||
+      target.isContentEditable
+    ) {
+      return;
+    }
+    const key = e.key.toUpperCase();
+    if (key === 'H' && window.SHORTCUTS?.home) {
+      window.location.href = window.SHORTCUTS.home;
+    } else if (key === 'N') {
+      const modal = document.getElementById('crearPublicacionModal');
+      if (modal) {
+        e.preventDefault();
+        bootstrap.Modal.getOrCreateInstance(modal).show();
+      }
+    }
+  });
 }

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -175,6 +175,10 @@
       </div>
       {% endif %}
 
+    {% if request.endpoint not in ['auth.login', 'onboarding.register'] %}
+    {% include 'components/shortcut_help.html' %}
+    {% endif %}
+
     <!-- Image Modal -->
     <div id="imageModal" class="image-modal hidden" role="dialog" aria-modal="true" onclick="outsideImageClick(event)" tabindex="-1">
       <button type="button" class="close" aria-label="Cerrar" onclick="closeImageModal()">✖</button>
@@ -238,6 +242,15 @@
         .floating-crunebot {
             display: none !important;
         }
+        .shortcut-help {
+            display: none !important;
+        }
+    }
+    .shortcut-help {
+        position: fixed;
+        bottom: 30px;
+        right: 100px;
+        z-index: 1000;
     }
     </style>
 
@@ -254,6 +267,9 @@
         hasStore: {{ 'true' if 'store.cart_count_api' in url_for.__globals__.get('current_app', {}).view_functions else 'false' }},
         version: '2.0.0',
         soundEnabled: localStorage.getItem('notifSound') !== 'off'
+      };
+      window.SHORTCUTS = {
+        home: {{ url_for('feed.view_feed')|tojson if 'feed.view_feed' in url_for.__globals__.get('current_app', {}).view_functions else '/'|tojson }}
       };
     </script>
 

--- a/crunevo/templates/components/shortcut_help.html
+++ b/crunevo/templates/components/shortcut_help.html
@@ -1,0 +1,23 @@
+<div class="shortcut-help d-none d-lg-block">
+  <button class="btn btn-secondary rounded-circle shadow-lg floating-btn" data-bs-toggle="modal" data-bs-target="#shortcutHelpModal" title="Atajos de teclado">
+    <i class="bi bi-question-lg fs-5"></i>
+  </button>
+</div>
+
+<div class="modal fade" id="shortcutHelpModal" tabindex="-1" aria-labelledby="shortcutHelpLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="shortcutHelpLabel">Atajos de teclado</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+      </div>
+      <div class="modal-body">
+        <ul class="list-unstyled">
+          <li><kbd>Shift</kbd> + <kbd>H</kbd> - Inicio</li>
+          <li><kbd>Shift</kbd> + <kbd>N</kbd> - Nueva publicación</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+


### PR DESCRIPTION
## Summary
- add Shift+H and Shift+N shortcuts with `initKeyboardShortcuts`
- expose `SHORTCUTS.home` URL in base template and include help dialog
- add floating help button with modal
- document shortcuts in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686857a273c88325862b11cd17888ca1