### PR TITLE
Add quick notes modal with shortcut

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -562,3 +562,4 @@
 - Added weather widget on user dashboard fetching data from OpenWeather API with caching via requests. (PR weather-dashboard-widget)
 - Añadido sonido opcional para nuevas notificaciones con control en configuración (PR sound-notifications).
 - Added keyboard shortcuts Shift+H (home) and Shift+N (new post) with a help dialog accessible from a question icon. (PR keyboard-shortcuts-help)
+- Added quick-notes modal with Shift+Q shortcut storing notes in localStorage. (PR quick-notes-modal)

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -941,6 +941,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   initMissionClaimButtons();
   highlightNewAchievements();
+  initQuickNotes();
   initKeyboardShortcuts();
 
   // Bootstrap collapse handles the mobile menu
@@ -1212,6 +1213,20 @@ function highlightNewAchievements() {
     });
 }
 
+function initQuickNotes() {
+  const textarea = document.getElementById('quickNotesTextarea');
+  const saveBtn = document.getElementById('quickNotesSaveBtn');
+  if (!textarea || !saveBtn) return;
+  textarea.value = localStorage.getItem('quick_notes') || '';
+  saveBtn.addEventListener('click', () => {
+    localStorage.setItem('quick_notes', textarea.value);
+    bootstrap.Modal.getOrCreateInstance(
+      document.getElementById('quickNotesModal')
+    ).hide();
+    showToast('Nota guardada');
+  });
+}
+
 function initKeyboardShortcuts() {
   document.addEventListener('keydown', (e) => {
     if (!e.shiftKey) return;
@@ -1228,6 +1243,12 @@ function initKeyboardShortcuts() {
       window.location.href = window.SHORTCUTS.home;
     } else if (key === 'N') {
       const modal = document.getElementById('crearPublicacionModal');
+      if (modal) {
+        e.preventDefault();
+        bootstrap.Modal.getOrCreateInstance(modal).show();
+      }
+    } else if (key === 'Q') {
+      const modal = document.getElementById('quickNotesModal');
       if (modal) {
         e.preventDefault();
         bootstrap.Modal.getOrCreateInstance(modal).show();

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -177,6 +177,7 @@
 
     {% if request.endpoint not in ['auth.login', 'onboarding.register'] %}
     {% include 'components/shortcut_help.html' %}
+    {% include 'components/quick_notes.html' %}
     {% endif %}
 
     <!-- Image Modal -->
@@ -250,6 +251,12 @@
         position: fixed;
         bottom: 30px;
         right: 100px;
+        z-index: 1000;
+    }
+    .quick-notes {
+        position: fixed;
+        bottom: 30px;
+        right: 170px;
         z-index: 1000;
     }
     </style>

--- a/crunevo/templates/components/quick_notes.html
+++ b/crunevo/templates/components/quick_notes.html
@@ -1,0 +1,23 @@
+<div class="quick-notes d-none d-lg-block">
+  <button class="btn btn-secondary rounded-circle shadow-lg floating-btn" data-bs-toggle="modal" data-bs-target="#quickNotesModal" title="Notas rápidas">
+    <i class="bi bi-journal-text fs-5"></i>
+  </button>
+</div>
+
+<div class="modal fade" id="quickNotesModal" tabindex="-1" aria-labelledby="quickNotesLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="quickNotesLabel">Notas rápidas</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+      </div>
+      <div class="modal-body">
+        <textarea id="quickNotesTextarea" class="form-control" rows="5"></textarea>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" id="quickNotesSaveBtn">Guardar</button>
+      </div>
+    </div>
+  </div>
+</div>
+


### PR DESCRIPTION
## Summary
- add floating Quick Notes modal to base layout
- store notes in localStorage with JS helper
- open modal with Shift+Q keyboard shortcut
- document feature in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6868596ba2c0832595ae4e5f49eae885