### PR TITLE
Fix online disconnect handler

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -563,3 +563,4 @@
 - Añadido sonido opcional para nuevas notificaciones con control en configuración (PR sound-notifications).
 - Added keyboard shortcuts Shift+H (home) and Shift+N (new post) with a help dialog accessible from a question icon. (PR keyboard-shortcuts-help)
 - Added quick-notes modal with Shift+Q shortcut storing notes in localStorage. (PR quick-notes-modal)
+- Fixed OnlineNamespace.on_disconnect to accept optional sid and avoid TypeError causing worker restarts (PR socketio-disconnect-fix).

--- a/crunevo/routes/socket_routes.py
+++ b/crunevo/routes/socket_routes.py
@@ -11,8 +11,11 @@ class OnlineNamespace(Namespace):
         connected_sessions.add(request.sid)
         emit("count", {"count": len(connected_sessions)}, broadcast=True)
 
-    def on_disconnect(self):
-        connected_sessions.discard(request.sid)
+    def on_disconnect(self, sid=None, *args):
+        # Flask-SocketIO may pass the session id and a reason argument when the
+        # client disconnects. Accept optional parameters to avoid TypeError.
+        session_id = sid or request.sid
+        connected_sessions.discard(session_id)
         emit("count", {"count": len(connected_sessions)}, broadcast=True)
 
 


### PR DESCRIPTION
## Summary
- handle optional sid when disconnecting from Socket.IO
- document the fix in `AGENTS.md`

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68685afc71a08325bd11f76b58ed3c87