### PR TITLE
Fix websocket timeouts with eventlet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -564,3 +564,4 @@
 - Added keyboard shortcuts Shift+H (home) and Shift+N (new post) with a help dialog accessible from a question icon. (PR keyboard-shortcuts-help)
 - Added quick-notes modal with Shift+Q shortcut storing notes in localStorage. (PR quick-notes-modal)
 - Fixed OnlineNamespace.on_disconnect to accept optional sid and avoid TypeError causing worker restarts (PR socketio-disconnect-fix).
+- Gunicorn now uses the eventlet worker and SocketIO async_mode is set to eventlet to prevent timeouts. (PR socketio-eventlet-worker)

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,5 @@ COPY migrations/versions /app/migrations/versions
 # Run gunicorn using the FLASK_APP environment variable. Default to the
 # public instance if FLASK_APP is not set (e.g. during local builds).
 # Ejecuta la app usando el valor de FLASK_APP o usa wsgi:app por defecto
-CMD ["sh", "-c", "exec gunicorn -b 0.0.0.0:8080 ${FLASK_APP:-crunevo.wsgi:app}"]
+# Use eventlet worker for WebSocket support
+CMD ["sh", "-c", "exec gunicorn -k eventlet -b 0.0.0.0:8080 ${FLASK_APP:-crunevo.wsgi:app}"]

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ It usually means Fly.io detected an outdated manifest from a previous deployment
        handlers = ["http"]
        port = 8080
    ```
-4. **Verify the Dockerfile** uses Gunicorn:
+4. **Verify the Dockerfile** uses Gunicorn with the eventlet worker for WebSocket support:
    ```Dockerfile
-   CMD ["gunicorn", "-b", "0.0.0.0:8080", "crunevo.app:app"]
+   CMD ["gunicorn", "-k", "eventlet", "-b", "0.0.0.0:8080", "crunevo.app:app"]
    ```
    or, alternatively, the Flask development server (not recommended for production).
 5. **Deploy the application**

--- a/crunevo/extensions.py
+++ b/crunevo/extensions.py
@@ -17,4 +17,5 @@ mail = Mail()
 csrf = CSRFProtect()
 limiter = Limiter(key_func=get_remote_address, default_limits=["200 per day"])
 talisman = Talisman()
-socketio = SocketIO(async_mode="threading")
+# Use eventlet for async WebSocket support
+socketio = SocketIO(async_mode="eventlet")

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,4 @@ beautifulsoup4==4.12.2
 reportlab==4.4.2
 qrcode[pil]
 openai>=1.0.0
+eventlet==0.35.2


### PR DESCRIPTION
## Summary
- enable eventlet async mode for SocketIO
- run gunicorn with eventlet worker
- document eventlet worker requirement
- add eventlet dependency
- log change in AGENTS.md

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68685e1e4edc832583e45d31fe0bdbbc