### PR TITLE
Fix errors blueprint registration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -565,3 +565,4 @@
 - Added quick-notes modal with Shift+Q shortcut storing notes in localStorage. (PR quick-notes-modal)
 - Fixed OnlineNamespace.on_disconnect to accept optional sid and avoid TypeError causing worker restarts (PR socketio-disconnect-fix).
 - Gunicorn now uses the eventlet worker and SocketIO async_mode is set to eventlet to prevent timeouts. (PR socketio-eventlet-worker)
+- errors blueprint registered once in create_app for admin and public modes (PR errors-blueprint-once).

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -215,7 +215,6 @@ def create_app():
         app.register_blueprint(auth_bp)
         app.register_blueprint(admin_bp)
         app.register_blueprint(admin_email_bp)
-        app.register_blueprint(errors_bp)
     else:
         app.register_blueprint(onboarding_bp)
         app.register_blueprint(auth_bp)
@@ -308,11 +307,12 @@ def create_app():
         app.register_blueprint(saved_bp)
         app.register_blueprint(dashboard_bp)
         app.register_blueprint(settings_bp)
-        app.register_blueprint(errors_bp)
         if testing_env:
             app.register_blueprint(admin_bp)
             app.register_blueprint(admin_email_bp)
         app.register_blueprint(admin_blocker_bp)
+
+    app.register_blueprint(errors_bp)
 
     # Initialize socket namespaces
     import crunevo.routes.socket_routes  # noqa: F401

--- a/tests/test_errors_blueprint.py
+++ b/tests/test_errors_blueprint.py
@@ -1,0 +1,16 @@
+import os
+from crunevo.app import create_app
+
+
+def test_errors_blueprint_registered_once_public(monkeypatch):
+    monkeypatch.delenv("ADMIN_INSTANCE", raising=False)
+    os.environ["ENABLE_TALISMAN"] = "0"
+    app = create_app()
+    assert list(app.blueprints.keys()).count("errors") == 1
+
+
+def test_errors_blueprint_registered_once_admin(monkeypatch):
+    monkeypatch.setenv("ADMIN_INSTANCE", "1")
+    os.environ["ENABLE_TALISMAN"] = "0"
+    app = create_app()
+    assert list(app.blueprints.keys()).count("errors") == 1


### PR DESCRIPTION
## Summary
- register `errors_bp` after admin/public branch so it's always loaded once
- test blueprint registration in both admin and public modes
- document blueprint registration in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6868618570fc8325b9cd7bb7dbd6e60c