### PR TITLE
Implement two factor auth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -569,3 +569,4 @@
 
 - Config class now logs DB URI with logging.getLogger when DEBUG is enabled (PR config-debug-log)
  
+- Added TwoFactorToken model with 2FA login flow and backup codes. (PR twofactor-auth)

--- a/crunevo/models/__init__.py
+++ b/crunevo/models/__init__.py
@@ -33,3 +33,4 @@ from .referido import Referral  # noqa: F401
 from .device_claim import DeviceClaim  # noqa: F401
 from .achievement_popup import AchievementPopup  # noqa: F401
 from .club import Club, ClubMember  # noqa: F401
+from .two_factor_token import TwoFactorToken  # noqa: F401

--- a/crunevo/models/two_factor_token.py
+++ b/crunevo/models/two_factor_token.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+import secrets
+from crunevo.extensions import db
+
+
+class TwoFactorToken(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    secret = db.Column(
+        db.String(32), nullable=False, default=lambda: secrets.token_hex(10)
+    )
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    confirmed_at = db.Column(db.DateTime)
+    backup_codes = db.Column(db.Text)  # comma-separated codes
+
+    user = db.relationship("User", backref=db.backref("two_factor", uselist=False))

--- a/crunevo/templates/auth/enable_2fa.html
+++ b/crunevo/templates/auth/enable_2fa.html
@@ -1,0 +1,31 @@
+{% extends 'base.html' %}
+{% import 'components/csrf.html' as csrf %}
+{% block content %}
+<div class="container py-4">
+  <h2 class="mb-3">Autenticación de dos factores</h2>
+  {% if confirmed %}
+  <div class="alert alert-success">2FA activado</div>
+  <h5>Códigos de respaldo</h5>
+  <ul class="list-unstyled mb-3">
+    {% for c in codes %}
+    <li class="mb-1"><code>{{ c }}</code></li>
+    {% endfor %}
+  </ul>
+  <form method="post" action="{{ url_for('auth.regen_backup_codes') }}">
+    {{ csrf.csrf_field() }}
+    <button type="submit" class="btn btn-secondary">Generar nuevos códigos</button>
+  </form>
+  {% else %}
+  <p>Agrega esta clave en tu aplicación de autenticación:</p>
+  <pre class="bg-light p-2 rounded">{{ secret }}</pre>
+  <form method="post" class="mt-3">
+    {{ csrf.csrf_field() }}
+    <div class="mb-3">
+      <label for="code" class="form-label">Código de verificación</label>
+      <input id="code" name="code" class="form-control" required>
+    </div>
+    <button type="submit" class="btn btn-primary">Confirmar</button>
+  </form>
+  {% endif %}
+</div>
+{% endblock %}

--- a/crunevo/templates/auth/two_factor_verify.html
+++ b/crunevo/templates/auth/two_factor_verify.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% import 'components/csrf.html' as csrf %}
+{% block content %}
+<div class="container py-5 max-w-md mx-auto">
+  <h2 class="mb-3">Ingresa tu código de autenticación</h2>
+  <form method="post" class="mt-3">
+    {{ csrf.csrf_field() }}
+    <div class="mb-3">
+      <label for="code" class="form-label">Código</label>
+      <input id="code" name="code" class="form-control" required autofocus>
+    </div>
+    <button type="submit" class="btn btn-primary">Verificar</button>
+  </form>
+</div>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,4 @@ reportlab==4.4.2
 qrcode[pil]
 openai>=1.0.0
 eventlet==0.35.2
+pyotp==2.9.0

--- a/tests/test_twofactor.py
+++ b/tests/test_twofactor.py
@@ -1,0 +1,37 @@
+from crunevo.models import TwoFactorToken
+import pyotp
+
+
+def login(client, username, password="secret"):
+    return client.post("/login", data={"username": username, "password": password})
+
+
+def test_twofactor_setup_and_verify(client, db_session, test_user):
+    login(client, test_user.username)
+    client.get("/2fa/setup")
+    token = TwoFactorToken.query.filter_by(user_id=test_user.id).first()
+    assert token is not None
+    code = pyotp.TOTP(token.secret).now()
+    client.post("/2fa/setup", data={"code": code})
+    db_session.refresh(token)
+    assert token.confirmed_at is not None
+    assert token.backup_codes
+
+
+def test_login_twofactor_flow(client, db_session, test_user):
+    login(client, test_user.username)
+    client.get("/2fa/setup")
+    token = TwoFactorToken.query.filter_by(user_id=test_user.id).first()
+    code = pyotp.TOTP(token.secret).now()
+    client.post("/2fa/setup", data={"code": code})
+    client.get("/logout")
+
+    resp = login(client, test_user.username)
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/login/verify")
+
+    backup = token.backup_codes.split(",")[0]
+    resp = client.post("/login/verify", data={"code": backup})
+    assert resp.status_code == 302
+    db_session.refresh(token)
+    assert backup not in token.backup_codes


### PR DESCRIPTION
## Summary
- add `TwoFactorToken` model
- support verifying a second factor during login
- allow enabling 2FA and regenerating backup codes
- cover 2FA setup and login flow with tests
- record implementation details in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68686360f90c83259979ebeee4727c62