### PR TITLE
Enable maintenance mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -570,3 +570,4 @@
 - Config class now logs DB URI with logging.getLogger when DEBUG is enabled (PR config-debug-log)
  
 - Added TwoFactorToken model with 2FA login flow and backup codes. (PR twofactor-auth)
+- Added MAINTENANCE_MODE flag with admin toggle and maintenance blueprint (PR maintenance-mode).

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -194,6 +194,7 @@ def create_app():
     from .routes.errors import errors_bp
     from .routes.missions_routes import missions_bp
     from .routes.health_routes import health_bp
+    from .routes.maintenance_routes import maintenance_bp
     from .routes.club_routes import club_bp
     from .routes.forum_routes import forum_bp
     from .routes.event_routes import event_bp, list_events
@@ -208,6 +209,7 @@ def create_app():
     app.config["ADMIN_INSTANCE"] = is_admin
 
     app.register_blueprint(health_bp)
+    app.register_blueprint(maintenance_bp)
     app.register_blueprint(main_bp)
     app.logger.info("Running in ADMIN mode" if is_admin else "Running in PUBLIC mode")
 

--- a/crunevo/config.py
+++ b/crunevo/config.py
@@ -105,3 +105,9 @@ class Config:
         "NOTE_CATEGORIES",
         "Matemática,Historia,Biología,Comunicación",
     ).split(",")
+
+    MAINTENANCE_MODE = os.getenv("MAINTENANCE_MODE", "0").lower() in (
+        "1",
+        "true",
+        "yes",
+    )

--- a/crunevo/routes/admin_routes.py
+++ b/crunevo/routes/admin_routes.py
@@ -7,6 +7,7 @@ from flask import (
     url_for,
     jsonify,
     abort,
+    current_app,
 )
 from flask_login import login_required, current_user
 from crunevo.extensions import db
@@ -332,6 +333,25 @@ def run_ranking():
     calculate_weekly_ranking()
     log_admin_action("Recalcul\u00f3 ranking semanal")
     flash("Ranking recalculado", "success")
+    return redirect(url_for("admin.dashboard"))
+
+
+@admin_bp.route("/toggle-maintenance", methods=["POST"])
+def toggle_maintenance():
+    """Toggle maintenance mode."""
+    current = current_app.config.get("MAINTENANCE_MODE", False)
+    current_app.config["MAINTENANCE_MODE"] = not current
+    log_admin_action(
+        "Activ\u00f3 mantenimiento" if not current else "Desactiv\u00f3 mantenimiento"
+    )
+    flash(
+        (
+            "Modo mantenimiento activado"
+            if not current
+            else "Modo mantenimiento desactivado"
+        ),
+        "success",
+    )
     return redirect(url_for("admin.dashboard"))
 
 

--- a/crunevo/routes/maintenance_routes.py
+++ b/crunevo/routes/maintenance_routes.py
@@ -1,0 +1,14 @@
+from flask import Blueprint, render_template, current_app, request
+
+maintenance_bp = Blueprint("maintenance", __name__)
+
+
+@maintenance_bp.before_app_request
+def check_maintenance():
+    if not current_app.config.get("MAINTENANCE_MODE"):
+        return None
+    if request.blueprint and request.blueprint.startswith("admin"):
+        return None
+    if request.path.startswith("/static") or request.path.startswith("/health"):
+        return None
+    return render_template("maintenance.html"), 503

--- a/crunevo/templates/admin/partials/topbar.html
+++ b/crunevo/templates/admin/partials/topbar.html
@@ -1,6 +1,13 @@
+{% from "components/csrf.html" import csrf_field %}
 <header class="d-flex justify-content-between align-items-center py-3 mb-4 border-bottom">
   <h1 class="h4 m-0">CRUNEVO Admin</h1>
   <div>
+    <form method="post" action="{{ url_for('admin.toggle_maintenance') }}" class="d-inline">
+      {{ csrf_field() }}
+      <button class="btn btn-sm btn-warning me-2" type="submit">
+        {% if current_app.config.MAINTENANCE_MODE %}Desactivar{% else %}Activar{% endif %} mantenimiento
+      </button>
+    </form>
     <button class="btn btn-sm btn-outline-primary me-2 admin-theme-toggle" data-theme-toggle data-bs-toggle="tooltip" title="Modo claro / oscuro">
       <i class="bi"></i>
     </button>

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -58,6 +58,11 @@
     {% block head_extra %}{% endblock %}
 </head>
 <body class="d-flex flex-column min-vh-100">
+    {% if current_app.config.MAINTENANCE_MODE and not request.path.startswith('/admin') %}
+    <div class="alert alert-warning text-center m-0" role="alert">
+        El sitio se encuentra en mantenimiento. Algunas funciones pueden no estar disponibles.
+    </div>
+    {% endif %}
     <!-- Navigation -->
     {% if not request.path.startswith('/admin')
           and request.endpoint not in ['auth.login', 'onboarding.register'] %}

--- a/crunevo/templates/maintenance.html
+++ b/crunevo/templates/maintenance.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block title %}Mantenimiento - Crunevo{% endblock %}
+
+{% block content %}
+<div class="error-wrapper tw-flex tw-items-center tw-justify-center">
+  <div class="error-page position-relative text-center">
+    <div class="error-icon mb-4">
+      <i class="bi bi-tools display-1 text-warning"></i>
+    </div>
+    <h1 class="display-4 fw-bold text-warning mb-3">Estamos en mantenimiento</h1>
+    <p class="lead text-muted">Volveremos en breve. Gracias por tu paciencia.</p>
+  </div>
+</div>
+{% endblock %}

--- a/fly-admin.toml
+++ b/fly-admin.toml
@@ -11,6 +11,7 @@ primary_region = "bog"
   FLASK_APP = "crunevo.wsgi_admin:app"
   FLASK_ENV = "production"
   ADMIN_INSTANCE = "1"
+  MAINTENANCE_MODE = "0"
   PORT = "8080"
 
 [experimental]


### PR DESCRIPTION
## Summary
- add `MAINTENANCE_MODE` flag in Config
- register new maintenance blueprint and admin toggle
- display banner when maintenance mode is active
- expose toggle button in the admin topbar
- include env var in `fly-admin.toml`
- document feature in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68686546ffdc83259828ec561e4bb864