### PR TITLE
Add user activity tracking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -572,3 +572,4 @@
 - Added TwoFactorToken model with 2FA login flow and backup codes. (PR twofactor-auth)
 - Added MAINTENANCE_MODE flag with admin toggle and maintenance blueprint (PR maintenance-mode).
 - Added VerificationRequest model with admin approval workflow and profile badges. (PR verification-requests)
+- Added UserActivity model tracking posts, comments and logins with new dashboard activity page. (PR user-activity-tracking)

--- a/crunevo/models/__init__.py
+++ b/crunevo/models/__init__.py
@@ -35,3 +35,4 @@ from .achievement_popup import AchievementPopup  # noqa: F401
 from .club import Club, ClubMember  # noqa: F401
 from .two_factor_token import TwoFactorToken  # noqa: F401
 from .verification_request import VerificationRequest  # noqa: F401
+from .user_activity import UserActivity  # noqa: F401

--- a/crunevo/models/user_activity.py
+++ b/crunevo/models/user_activity.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+from crunevo.extensions import db
+
+
+class UserActivity(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    action = db.Column(db.String(30), nullable=False)
+    target_id = db.Column(db.Integer)
+    target_type = db.Column(db.String(30))
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+
+    user = db.relationship("User")

--- a/crunevo/routes/auth_routes.py
+++ b/crunevo/routes/auth_routes.py
@@ -20,7 +20,13 @@ import cloudinary.uploader
 from werkzeug.utils import secure_filename
 from crunevo.extensions import db, csrf
 from crunevo.models import User, Note, TwoFactorToken
-from crunevo.utils import spend_credit, record_login, send_notification, add_credit
+from crunevo.utils import (
+    spend_credit,
+    record_login,
+    send_notification,
+    add_credit,
+    record_activity,
+)
 from crunevo.constants import CreditReasons
 from crunevo.utils.login_streak import streak_reward
 from datetime import date, datetime, timedelta
@@ -78,6 +84,7 @@ def login():
                 return redirect(url_for("auth.verify_token"))
             login_user(user)
             record_login(user)
+            record_activity("login")
             if admin_mode:
                 return redirect(url_for("admin.dashboard"))
             next_page = request.args.get("next")
@@ -112,6 +119,7 @@ def verify_token():
         if valid:
             login_user(user)
             record_login(user)
+            record_activity("login")
             session.pop("2fa_user_id", None)
             next_page = session.pop("next", None)
             admin_mode = current_app.config.get("ADMIN_INSTANCE")

--- a/crunevo/routes/course_routes.py
+++ b/crunevo/routes/course_routes.py
@@ -3,6 +3,7 @@ from flask_login import current_user
 from crunevo.utils.helpers import activated_required
 from crunevo.extensions import db
 from crunevo.models import Course, SavedCourse
+from crunevo.utils import record_activity
 from sqlalchemy import desc
 
 course_bp = Blueprint("courses", __name__, url_prefix="/cursos")
@@ -116,6 +117,7 @@ def toggle_save_course(course_id):
         message = "Curso guardado exitosamente"
 
     db.session.commit()
+    record_activity(f"course_{action}", course.id, "course")
 
     if request.headers.get("X-Requested-With") == "XMLHttpRequest":
         return jsonify({"action": action, "message": message})

--- a/crunevo/routes/dashboard_routes.py
+++ b/crunevo/routes/dashboard_routes.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import asyncio
 import requests
 from flask import Blueprint, render_template, request, jsonify, current_app
-from flask_login import login_required
+from flask_login import login_required, current_user
 
 from crunevo.cache import weather_cache
+from crunevo.models import UserActivity
 
 
 dashboard_bp = Blueprint("dashboard", __name__, url_prefix="/dashboard")
@@ -15,6 +16,18 @@ dashboard_bp = Blueprint("dashboard", __name__, url_prefix="/dashboard")
 @login_required
 def index():
     return render_template("dashboard/dashboard.html")
+
+
+@dashboard_bp.get("/activity")
+@login_required
+def activity():
+    activities = (
+        UserActivity.query.filter_by(user_id=current_user.id)
+        .order_by(UserActivity.timestamp.desc())
+        .limit(50)
+        .all()
+    )
+    return render_template("dashboard/activity.html", activities=activities)
 
 
 async def fetch_weather(lat: float, lon: float) -> dict | None:

--- a/crunevo/routes/feed_routes.py
+++ b/crunevo/routes/feed_routes.py
@@ -36,6 +36,7 @@ from crunevo.utils import (
     create_feed_item_for_all,
     unlock_achievement,
     send_notification,
+    record_activity,
 )
 from crunevo.utils.credits import add_credit, spend_credit
 from crunevo.constants import CreditReasons, AchievementCodes
@@ -146,6 +147,7 @@ def create_post():
     for url in urls:
         db.session.add(PostImage(post_id=post.id, url=url))
     db.session.commit()
+    record_activity("post_created", post.id, "post")
     create_feed_item_for_all("post", post.id)
     flash("Publicación creada")
     return redirect(url_for("feed.view_feed"))
@@ -521,6 +523,7 @@ def comment_post(post_id):
     comment = PostComment(body=body, author=current_user, post=post)
     db.session.add(comment)
     db.session.commit()
+    record_activity("comment_post", comment.id, "post")
     if post.author_id != current_user.id:
         send_notification(
             post.author_id,

--- a/crunevo/routes/notes_routes.py
+++ b/crunevo/routes/notes_routes.py
@@ -26,7 +26,7 @@ from crunevo.models import (
     Referral,
 )
 from crunevo.utils.credits import add_credit
-from crunevo.utils import unlock_achievement, send_notification
+from crunevo.utils import unlock_achievement, send_notification, record_activity
 from crunevo.utils.scoring import update_feed_score
 from crunevo.cache.feed_cache import remove_item
 from crunevo.constants import CreditReasons, AchievementCodes
@@ -254,6 +254,7 @@ def add_comment(note_id):
     db.session.add(comment)
     note.comments_count += 1
     db.session.commit()
+    record_activity("comment_note", comment.id, "note")
     if note.user_id != current_user.id:
         send_notification(
             note.user_id,

--- a/crunevo/templates/dashboard/activity.html
+++ b/crunevo/templates/dashboard/activity.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block title %}Mi Actividad{% endblock %}
+
+{% block content %}
+<h1 class="mb-4 fw-bold">Actividad Reciente</h1>
+<ul class="list-group">
+  {% for a in activities %}
+  <li class="list-group-item d-flex justify-content-between align-items-center">
+    <span>{{ a.action }}</span>
+    <small class="text-muted">{{ a.timestamp.strftime('%Y-%m-%d %H:%M') }}</small>
+  </li>
+  {% else %}
+  <li class="list-group-item">Sin actividad registrada.</li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/crunevo/templates/dashboard/dashboard.html
+++ b/crunevo/templates/dashboard/dashboard.html
@@ -5,6 +5,7 @@
 <div class="row">
   <div class="col-lg-8">
     <h1 class="mb-4 fw-bold">Dashboard</h1>
+    <a class="btn btn-sm btn-primary" href="{{ url_for('dashboard.activity') }}">Mi actividad</a>
   </div>
   <div class="col-lg-4">
     {% include 'dashboard/_weather.html' %}

--- a/crunevo/utils/__init__.py
+++ b/crunevo/utils/__init__.py
@@ -5,3 +5,4 @@ from .login_history import record_login  # noqa: F401
 from .login_streak import handle_login_streak  # noqa: F401
 from .feed import create_feed_item_for_all  # noqa: F401
 from .notify import send_notification  # noqa: F401
+from .user_activity import record_activity  # noqa: F401

--- a/crunevo/utils/user_activity.py
+++ b/crunevo/utils/user_activity.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+from flask_login import current_user
+from crunevo.extensions import db
+from crunevo.models import UserActivity
+
+
+def record_activity(
+    action: str, target_id: int | None = None, target_type: str | None = None
+):
+    if not current_user.is_authenticated:
+        return
+    act = UserActivity(
+        user_id=current_user.id,
+        action=action,
+        target_id=target_id,
+        target_type=target_type,
+        timestamp=datetime.utcnow(),
+    )
+    db.session.add(act)
+    db.session.commit()

--- a/migrations/versions/add_user_activity.py
+++ b/migrations/versions/add_user_activity.py
@@ -1,0 +1,41 @@
+"""add user activity table
+
+Revision ID: add_user_activity
+Revises: 20c9b1f4eabc
+Create Date: 2025-10-01 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def has_table(name: str, conn) -> bool:
+    inspector = sa.inspect(conn)
+    return name in inspector.get_table_names()
+
+
+revision = "add_user_activity"
+down_revision = "9e8b7a4cd123"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    if not has_table("user_activity", conn):
+        op.create_table(
+            "user_activity",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "user_id", sa.Integer(), sa.ForeignKey("user.id"), nullable=False
+            ),
+            sa.Column("action", sa.String(length=30), nullable=False),
+            sa.Column("target_id", sa.Integer(), nullable=True),
+            sa.Column("target_type", sa.String(length=30), nullable=True),
+            sa.Column("timestamp", sa.DateTime(), nullable=True),
+            if_not_exists=True,
+        )
+
+
+def downgrade():
+    op.drop_table("user_activity", if_exists=True)

--- a/tests/test_user_activity.py
+++ b/tests/test_user_activity.py
@@ -1,0 +1,29 @@
+def login(client, username, password="secret"):
+    return client.post("/login", data={"username": username, "password": password})
+
+
+def test_activity_on_login(client, test_user):
+    login(client, test_user.username)
+    from crunevo.models import UserActivity
+
+    act = UserActivity.query.filter_by(user_id=test_user.id, action="login").first()
+    assert act is not None
+
+
+def test_activity_on_post(client, test_user):
+    login(client, test_user.username)
+    client.post("/feed/post", data={"content": "hello"})
+    from crunevo.models import UserActivity
+
+    act = UserActivity.query.filter_by(
+        action="post_created", user_id=test_user.id
+    ).first()
+    assert act is not None
+
+
+def test_activity_page(client, test_user):
+    login(client, test_user.username)
+    client.post("/feed/post", data={"content": "hello"})
+    resp = client.get("/dashboard/activity")
+    assert resp.status_code == 200
+    assert b"post_created" in resp.data


### PR DESCRIPTION
## Summary
- track user actions with new `UserActivity` model
- record posts, comments and logins
- expose dashboard activity page
- test storing and retrieving activities
- document feature in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68686a966f18832593712733696c4236