### PR TITLE
Add weekly DB backup job

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -573,3 +573,4 @@
 - Added MAINTENANCE_MODE flag with admin toggle and maintenance blueprint (PR maintenance-mode).
 - Added VerificationRequest model with admin approval workflow and profile badges. (PR verification-requests)
 - Added UserActivity model tracking posts, comments and logins with new dashboard activity page. (PR user-activity-tracking)
+- Added weekly database backup job uploading to S3 via apscheduler (PR db-backup).

--- a/README.md
+++ b/README.md
@@ -88,7 +88,25 @@ DNS notes:
 
 ### Background tasks
 
-Feed items are inserted synchronously using an in-memory queue, so no external worker is required.
+Feed items are inserted synchronously using an in-memory queue, so no external
+worker is required. Additional maintenance jobs run with
+[`apscheduler`](https://apscheduler.readthedocs.io/) when the environment
+variable `SCHEDULER=1`.
+
+### Respaldo de base de datos
+
+Al activar el scheduler se ejecuta semanalmente un respaldo de la base de
+datos mediante `pg_dump`. El archivo resultante se sube a S3 si defines:
+
+```bash
+AWS_ACCESS_KEY_ID=...
+AWS_SECRET_ACCESS_KEY=...
+BACKUP_BUCKET=nombre-del-bucket
+```
+
+Opcionalmente puedes establecer `BACKUP_PREFIX` para el directorio dentro del
+bucket. Si `BACKUP_BUCKET` no está definido, las copias se guardan localmente en
+`BACKUP_DIR` (por defecto `backups/`).
 
 ### Migrations
 

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -329,10 +329,12 @@ def create_app():
         from apscheduler.triggers.interval import IntervalTrigger
         from .jobs.decay import decay_scores
         from .jobs.cleanup_auth_events import cleanup_auth_events
+        from .jobs.backup_db import backup_database
 
         scheduler = BackgroundScheduler()
         scheduler.add_job(decay_scores, IntervalTrigger(hours=1))
         scheduler.add_job(cleanup_auth_events, IntervalTrigger(hours=24))
+        scheduler.add_job(backup_database, IntervalTrigger(weeks=1))
         scheduler.start()
         app.scheduler = scheduler
 

--- a/crunevo/config.py
+++ b/crunevo/config.py
@@ -106,6 +106,10 @@ class Config:
         "Matemática,Historia,Biología,Comunicación",
     ).split(",")
 
+    BACKUP_BUCKET = os.getenv("BACKUP_BUCKET")
+    BACKUP_PREFIX = os.getenv("BACKUP_PREFIX", "backups")
+    BACKUP_DIR = os.getenv("BACKUP_DIR", "backups")
+
     MAINTENANCE_MODE = os.getenv("MAINTENANCE_MODE", "0").lower() in (
         "1",
         "true",

--- a/crunevo/jobs/backup_db.py
+++ b/crunevo/jobs/backup_db.py
@@ -1,0 +1,31 @@
+import logging
+import os
+import subprocess
+import tempfile
+from datetime import datetime
+
+import boto3
+from flask import current_app
+
+log = logging.getLogger(__name__)
+
+
+def backup_database() -> None:
+    """Dump the database and upload it to S3 or store locally."""
+    db_url = current_app.config["SQLALCHEMY_DATABASE_URI"]
+    bucket = os.getenv("BACKUP_BUCKET")
+    prefix = os.getenv("BACKUP_PREFIX", "backups")
+    with tempfile.NamedTemporaryFile(suffix=".sql") as tmp:
+        subprocess.run(["pg_dump", db_url, "-f", tmp.name], check=True)
+        name = f"{datetime.utcnow():%Y-%m-%d_%H-%M-%S}.sql"
+        if bucket:
+            s3 = boto3.client("s3")
+            key = f"{prefix}/{name}"
+            s3.upload_file(tmp.name, bucket, key)
+            log.info("Database backup uploaded to s3://%s/%s", bucket, key)
+        else:
+            dest_dir = os.getenv("BACKUP_DIR", "backups")
+            os.makedirs(dest_dir, exist_ok=True)
+            dest = os.path.join(dest_dir, name)
+            subprocess.run(["cp", tmp.name, dest], check=True)
+            log.info("Database backup stored at %s", dest)

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,4 @@ qrcode[pil]
 openai>=1.0.0
 eventlet==0.35.2
 pyotp==2.9.0
+boto3==1.34.14

--- a/tests/test_backup_db.py
+++ b/tests/test_backup_db.py
@@ -1,0 +1,44 @@
+import subprocess
+
+import boto3
+
+from crunevo.jobs.backup_db import backup_database
+
+
+def test_backup_database_s3(monkeypatch, app, tmp_path):
+    def fake_run(cmd, check=True):
+        with open(cmd[2], "w") as f:
+            f.write("db")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    uploaded = {}
+
+    class FakeClient:
+        def upload_file(self, src, bucket, key):
+            uploaded["src"] = src
+            uploaded["bucket"] = bucket
+            uploaded["key"] = key
+
+    monkeypatch.setattr(boto3, "client", lambda *_: FakeClient())
+    monkeypatch.setenv("BACKUP_BUCKET", "mybucket")
+    monkeypatch.setenv("BACKUP_PREFIX", "pfx")
+    with app.app_context():
+        backup_database()
+    assert uploaded["bucket"] == "mybucket"
+    assert uploaded["key"].startswith("pfx/")
+
+
+def test_backup_database_local(monkeypatch, app, tmp_path):
+    def fake_run(cmd, check=True):
+        with open(cmd[2], "w") as f:
+            f.write("db")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    dest = tmp_path / "backups"
+    monkeypatch.delenv("BACKUP_BUCKET", raising=False)
+    monkeypatch.setenv("BACKUP_DIR", str(dest))
+    with app.app_context():
+        backup_database()
+    files = list(dest.iterdir())
+    assert len(files) == 1


### PR DESCRIPTION
## Summary
- backup database weekly with APScheduler
- store DB dumps on S3 via `BACKUP_BUCKET`
- configure backup variables in Config and document in README
- include tests for backup job
- record new feature in AGENTS.md

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68686d3dc0548325befd5f318fa6c429