### PR TITLE
Add persistent maintenance mode flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -574,3 +574,5 @@
 - Added VerificationRequest model with admin approval workflow and profile badges. (PR verification-requests)
 - Added UserActivity model tracking posts, comments and logins with new dashboard activity page. (PR user-activity-tracking)
 - Added weekly database backup job uploading to S3 via apscheduler (PR db-backup).
+- SiteConfig table stores MAINTENANCE_MODE loaded on startup (PR maintenance-db-flag).
+

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -161,6 +161,15 @@ def create_app():
             except Exception as e:
                 app.logger.error(f"Database initialization error: {e}")
 
+        try:
+            from .models import SiteConfig
+
+            cfg = SiteConfig.query.filter_by(key="maintenance_mode").first()
+            if cfg:
+                app.config["MAINTENANCE_MODE"] = cfg.value == "1"
+        except Exception as e:  # pragma: no cover - safeguard on startup
+            app.logger.error(f"Error loading maintenance flag: {e}")
+
     from .routes.onboarding_routes import bp as onboarding_bp
     from .routes.auth_routes import auth_bp
     from .routes.notes_routes import notes_bp

--- a/crunevo/models/__init__.py
+++ b/crunevo/models/__init__.py
@@ -36,3 +36,4 @@ from .club import Club, ClubMember  # noqa: F401
 from .two_factor_token import TwoFactorToken  # noqa: F401
 from .verification_request import VerificationRequest  # noqa: F401
 from .user_activity import UserActivity  # noqa: F401
+from .site_config import SiteConfig  # noqa: F401

--- a/crunevo/models/site_config.py
+++ b/crunevo/models/site_config.py
@@ -1,0 +1,11 @@
+from crunevo.extensions import db
+
+
+class SiteConfig(db.Model):
+    """Simple key/value site configuration storage."""
+
+    __tablename__ = "site_config"
+
+    id = db.Column(db.Integer, primary_key=True)
+    key = db.Column(db.String(50), unique=True, nullable=False)
+    value = db.Column(db.String(255))

--- a/migrations/versions/add_site_config.py
+++ b/migrations/versions/add_site_config.py
@@ -1,0 +1,32 @@
+"""add site_config table"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def has_table(name: str, conn) -> bool:
+    inspector = sa.inspect(conn)
+    return name in inspector.get_table_names()
+
+
+# revision identifiers, used by Alembic.
+revision = "add_site_config"
+down_revision = "add_user_activity"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    if not has_table("site_config", conn):
+        op.create_table(
+            "site_config",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("key", sa.String(length=50), nullable=False, unique=True),
+            sa.Column("value", sa.String(length=255), nullable=True),
+            if_not_exists=True,
+        )
+
+
+def downgrade():
+    op.drop_table("site_config", if_exists=True)


### PR DESCRIPTION
## Summary
- add `SiteConfig` model for key/value site settings
- store maintenance mode in the `SiteConfig` table
- load maintenance flag during `create_app`
- record new table in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6868780949088325a3d157e08104679e