### PR TITLE
Add admin dashboard metrics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -576,3 +576,4 @@
 - Added weekly database backup job uploading to S3 via apscheduler (PR db-backup).
 - SiteConfig table stores MAINTENANCE_MODE loaded on startup (PR maintenance-db-flag).
 
+- Dashboard charts now use real registration and content metrics; docs added (PR admin-dashboard-metrics).

--- a/crunevo/templates/admin/dashboard.html
+++ b/crunevo/templates/admin/dashboard.html
@@ -305,10 +305,10 @@ document.addEventListener('DOMContentLoaded', function() {
   new Chart(growthCtx, {
     type: 'line',
     data: {
-      labels: ['Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb', 'Dom'],
+      labels: {{ reg_labels|tojson }},
       datasets: [{
         label: 'Nuevos usuarios',
-        data: [12, 19, 15, 25, 22, 18, 28],
+        data: {{ reg_counts|tojson }},
         borderColor: '#667eea',
         backgroundColor: 'rgba(102, 126, 234, 0.1)',
         tension: 0.4,
@@ -341,15 +341,16 @@ document.addEventListener('DOMContentLoaded', function() {
 
   // Activity Chart
   const activityCtx = document.getElementById('activityChart').getContext('2d');
+  const activityData = {{ content_counts|tojson }};
   new Chart(activityCtx, {
     type: 'doughnut',
     data: {
-      labels: ['Posts', 'Apuntes', 'Comentarios', 'Compras'],
+      labels: Object.keys(activityData),
       datasets: [{
-        data: [40, 30, 20, 10],
+        data: Object.values(activityData),
         backgroundColor: [
           '#667eea',
-          '#764ba2', 
+          '#764ba2',
           '#f093fb',
           '#f5576c'
         ],

--- a/docs/dashboard_metrics.md
+++ b/docs/dashboard_metrics.md
@@ -1,0 +1,8 @@
+# Dashboard Metrics
+
+The admin dashboard now displays two charts powered by Chart.js.
+
+- **User Registrations** – shows daily sign ups for the last 7 days. Registration dates are derived from the first email confirmation token created for each user.
+- **Content Distribution** – total number of posts, notes, comments and purchases stored in the database.
+
+These metrics are queried in `admin_routes.dashboard` and passed as JSON variables to the template so the charts update automatically.


### PR DESCRIPTION
## Summary
- compute registration stats and content counts for admin dashboard
- inject metrics into Chart.js charts
- document metrics in `dashboard_metrics.md`
- record update in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68687bbee244832595b93241858d81c0