### PR TITLE
Add page view analytics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -577,3 +577,4 @@
 - SiteConfig table stores MAINTENANCE_MODE loaded on startup (PR maintenance-db-flag).
 
 - Dashboard charts now use real registration and content metrics; docs added (PR admin-dashboard-metrics).
+- Added PageView model to log requests and admin heatmap analytics (PR pageview-analytics).

--- a/crunevo/models/__init__.py
+++ b/crunevo/models/__init__.py
@@ -37,3 +37,4 @@ from .two_factor_token import TwoFactorToken  # noqa: F401
 from .verification_request import VerificationRequest  # noqa: F401
 from .user_activity import UserActivity  # noqa: F401
 from .site_config import SiteConfig  # noqa: F401
+from .page_view import PageView  # noqa: F401

--- a/crunevo/models/page_view.py
+++ b/crunevo/models/page_view.py
@@ -1,0 +1,8 @@
+from datetime import datetime
+from crunevo.extensions import db
+
+
+class PageView(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    path = db.Column(db.String(300), nullable=False)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)

--- a/crunevo/templates/admin/pageviews.html
+++ b/crunevo/templates/admin/pageviews.html
@@ -1,0 +1,47 @@
+{% extends 'admin/base_admin.html' %}
+{% block admin_content %}
+<h2 class="page-title mb-4">Analíticas de Visitas</h2>
+<div class="card shadow-sm">
+  <div class="card-body">
+    <canvas id="pageHeatmap" height="400"
+      data-matrix='{{ matrix_data|tojson }}'
+      data-labels-x='{{ labels_x|tojson }}'
+      data-labels-y='{{ labels_y|tojson }}'></canvas>
+  </div>
+</div>
+{% endblock %}
+{% block body_end %}
+  {{ super() }}
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-matrix@2.1.1/dist/chartjs-chart-matrix.min.js"></script>
+  <script>
+  function initPageviewHeatmap() {
+    const canvas = document.getElementById('pageHeatmap');
+    if (!canvas) return;
+    const data = JSON.parse(canvas.dataset.matrix || '[]');
+    const labelsX = JSON.parse(canvas.dataset.labelsX || '[]');
+    const labelsY = JSON.parse(canvas.dataset.labelsY || '[]');
+    const max = Math.max(...data.map(d => d.v)) || 1;
+    new Chart(canvas.getContext('2d'), {
+      type: 'matrix',
+      data: { datasets: [{
+        data: data,
+        backgroundColor: ctx => {
+          const v = ctx.dataset.data[ctx.dataIndex].v;
+          return `rgba(102,126,234,${v / max})`;
+        },
+        width: ({chart}) => chart.chartArea.width / labelsX.length - 1,
+        height: ({chart}) => chart.chartArea.height / labelsY.length - 1,
+      }]},
+      options: {
+        maintainAspectRatio: false,
+        plugins: { legend: { display: false } },
+        scales: {
+          x: { position: 'top', ticks: { callback: v => labelsX[v] }, offset: true },
+          y: { ticks: { callback: v => labelsY[v] }, offset: true }
+        }
+      }
+    });
+  }
+  document.addEventListener('DOMContentLoaded', initPageviewHeatmap);
+  </script>
+{% endblock %}

--- a/crunevo/templates/admin/partials/sidebar.html
+++ b/crunevo/templates/admin/partials/sidebar.html
@@ -25,6 +25,9 @@
   <a class="nav-link {% if request.endpoint == 'admin.stats_page' %}active{% endif %}" href="{{ url_for('admin.stats_page') }}">
     <i class="ti ti-chart-bar me-2"></i> Estadísticas
   </a>
+  <a class="nav-link {% if request.endpoint == 'admin.pageviews' %}active{% endif %}" href="{{ url_for('admin.pageviews') }}">
+    <i class="ti ti-chart-heatmap me-2"></i> Pageviews
+  </a>
   {% endif %}
   <a class="nav-link {% if request.endpoint == 'admin.manage_credits' %}active{% endif %}" href="{{ url_for('admin.manage_credits') }}">
     <i class="ti ti-coin me-2"></i> Crolars

--- a/migrations/versions/add_page_view.py
+++ b/migrations/versions/add_page_view.py
@@ -1,0 +1,36 @@
+"""add page view table
+
+Revision ID: add_page_view
+Revises: 018c30955e14
+Create Date: 2025-07-05 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def has_table(name: str, conn) -> bool:
+    inspector = sa.inspect(conn)
+    return name in inspector.get_table_names()
+
+
+revision = "add_page_view"
+down_revision = "add_site_config"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    if not has_table("page_view", conn):
+        op.create_table(
+            "page_view",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("path", sa.String(length=300), nullable=False),
+            sa.Column("timestamp", sa.DateTime(), nullable=True),
+            if_not_exists=True,
+        )
+
+
+def downgrade():
+    op.drop_table("page_view", if_exists=True)


### PR DESCRIPTION
## Summary
- create `PageView` model and migration
- log non-static requests in `before_request`
- add admin pageview heatmap analytics
- document new feature in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68689fd0e1588325884c53d823e7c90b