### PR TITLE
Add notes embed widget

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -579,3 +579,4 @@
 - Dashboard charts now use real registration and content metrics; docs added (PR admin-dashboard-metrics).
 - Added PageView model to log requests and admin heatmap analytics (PR pageview-analytics).
 - Chat ahora admite mensajes de audio cortos en formatos MP3/OGG con validación de duración y subida a Cloudinary o carpeta local (PR chat-audio-support).
+- Widget de apuntes embebible con ruta /notes/<id>/embed y botón de copiado en detalle (PR notes-embed-widget).

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -868,6 +868,17 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
+  document.querySelectorAll('.embed-btn').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const url = btn.dataset.embedUrl;
+      if (!url) return;
+      const code = `<iframe src="${url}" style="border:none;width:100%;height:500px;"></iframe>`;
+      navigator.clipboard.writeText(code).then(() => {
+        showToast('Código copiado');
+      });
+    });
+  });
+
   // Feed interactions are handled by FeedManager in feed.js
 
   if (window.HAS_STORE) {

--- a/crunevo/templates/notes/detalle.html
+++ b/crunevo/templates/notes/detalle.html
@@ -31,6 +31,7 @@
       <a href="{{ url_for('notes.download_note', note_id=note.id) }}" class="btn btn-outline-primary w-100 mb-2">Descargar</a>
       <button type="button" class="btn btn-outline-secondary w-100 mb-2" id="saveBtn">Guardar</button>
       <button type="button" class="btn btn-outline-secondary w-100 share-btn" data-share-url="{{ url_for('notes.view_note', id=note.id, _external=True) }}">Compartir</button>
+      <button type="button" class="btn btn-outline-secondary w-100 mb-2 embed-btn" data-embed-url="{{ url_for('notes.embed_note', note_id=note.id, _external=True) }}">Copiar código para incrustar</button>
       {% if current_user.is_authenticated and note.user_id == current_user.id %}
       <a href="{{ url_for('notes.edit_note', note_id=note.id) }}" class="btn btn-outline-secondary w-100 mt-2">Editar</a>
       <form action="{{ url_for('notes.delete_note', note_id=note.id) }}" method="post" onsubmit="return confirm('¿Eliminar este apunte?');" class="mt-2">

--- a/crunevo/templates/notes/embed.html
+++ b/crunevo/templates/notes/embed.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="{{ url_for('static', filename='vendor/bootstrap.min.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+  <title>{{ note.title }}</title>
+</head>
+<body class="p-2">
+  <div id="noteViewer" data-url="{{ note.filename }}" data-type="{{ file_type }}"></div>
+  <script src="{{ url_for('static', filename='pdfjs/pdf.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/viewer.js') }}"></script>
+  <script>pdfjsLib.GlobalWorkerOptions.workerSrc = "{{ url_for('static', filename='pdfjs/pdf.worker.min.js') }}";</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- support embedding notes with `/notes/<id>/embed`
- add "Copy embed code" button
- allow copying embed iframe via JavaScript
- document new widget in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6868f560a20c83259b0da2e80afbc674