### PR TITLE
Optimize PageView logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -581,3 +581,4 @@
 - Chat ahora admite mensajes de audio cortos en formatos MP3/OGG con validación de duración y subida a Cloudinary o carpeta local (PR chat-audio-support).
 - Widget de apuntes embebible con ruta /notes/<id>/embed y botón de copiado en detalle (PR notes-embed-widget).
 - Consolidated DOMContentLoaded handlers from courses, events and private chat into main.js (PR domcontent-consolidation).
+- PageView logging commits after each request and skips health endpoints (PR pageview-commit-after-request).


### PR DESCRIPTION
## Summary
- log PageViews but defer DB commit until after each request
- skip logging for health endpoints
- document the logging change in AGENTS guidelines

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68691457505083258af3de2b72b0967b