### PR TITLE
Add pageview analytics tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -582,3 +582,4 @@
 - Widget de apuntes embebible con ruta /notes/<id>/embed y botón de copiado en detalle (PR notes-embed-widget).
 - Consolidated DOMContentLoaded handlers from courses, events and private chat into main.js (PR domcontent-consolidation).
 - PageView logging commits after each request and skips health endpoints (PR pageview-commit-after-request).
+- Added tests for PageView logging, admin pageviews analytics and maintenance mode persistence (PR pageviews-maintenance-tests).

--- a/tests/test_pageviews.py
+++ b/tests/test_pageviews.py
@@ -1,0 +1,61 @@
+from crunevo.models import PageView, User, SiteConfig
+
+
+def login(client, username, password):
+    return client.post("/login", data={"username": username, "password": password})
+
+
+def test_pageview_recorded(client, db_session):
+    resp = client.get("/terms")
+    assert resp.status_code == 200
+    view = PageView.query.one()
+    assert view.path == "/terms"
+
+
+def test_admin_pageviews_route(client, db_session, test_user):
+    admin = User(
+        username="admin",
+        email="admin@example.com",
+        role="admin",
+        activated=True,
+        avatar_url="a",
+    )
+    admin.set_password("pass")
+    db_session.add(admin)
+    db_session.commit()
+
+    # generate some page views
+    client.get("/terms")
+    client.get("/terms")
+
+    login(client, "admin", "pass")
+    resp = client.get("/admin/pageviews")
+    assert resp.status_code == 200
+    assert b"/terms" in resp.data
+
+
+def test_toggle_maintenance_persists(client, db_session):
+    admin = User(
+        username="ma",
+        email="ma@example.com",
+        role="admin",
+        activated=True,
+        avatar_url="a",
+    )
+    admin.set_password("pass")
+    db_session.add(admin)
+    db_session.commit()
+
+    login(client, "ma", "pass")
+
+    resp = client.post("/admin/toggle-maintenance")
+    assert resp.status_code == 302
+    cfg = SiteConfig.query.filter_by(key="maintenance_mode").first()
+    assert cfg.value == "1"
+    assert client.application.config["MAINTENANCE_MODE"] is True
+
+    resp = client.post("/admin/toggle-maintenance")
+    assert resp.status_code == 302
+    cfg = SiteConfig.query.filter_by(key="maintenance_mode").first()
+    assert cfg.value == "0"
+    assert client.application.config["MAINTENANCE_MODE"] is False


### PR DESCRIPTION
## Summary
- test that PageView is logged on page visit
- ensure admin pageviews report includes visited paths
- verify maintenance mode toggle persists in SiteConfig
- document new tests in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68691c4629d08325aff53876be41f667