### PR TITLE
Fix flash after email confirmation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -585,3 +585,4 @@
 - Patched eventlet websocket close to ignore EBADF and prevent noisy 'Bad file descriptor' logs (PR websocket-ebadf-fix).
 
 - Added tests for PageView logging, admin pageviews analytics and maintenance mode persistence (PR pageviews-maintenance-tests).
+- Cleared stale flash messages on email confirmation (PR confirm-flash-clear).

--- a/crunevo/routes/onboarding_routes.py
+++ b/crunevo/routes/onboarding_routes.py
@@ -8,6 +8,7 @@ from flask import (
     url_for,
     flash,
     current_app,
+    session,
 )
 from flask_login import login_user, current_user, login_required
 import secrets
@@ -148,7 +149,8 @@ def confirm(token):
     db.session.commit()
     record_auth_event(record.user, "confirm_email")
     login_user(record.user)
-
+    # Remove stale flash messages from previous requests
+    session.pop("_flashes", None)
     flash("¡Correo verificado! Bienvenido a CRUNEVO", "success")
     return redirect(url_for("feed.feed_home"))
 


### PR DESCRIPTION
## Summary
- clear stale flash messages before success message on email confirmation

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68692059d3a083259f534c5d8854a8f2