### PR TITLE
Add test for feed access after confirmation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -587,3 +587,4 @@
 - Added tests for PageView logging, admin pageviews analytics and maintenance mode persistence (PR pageviews-maintenance-tests).
 - Cleared stale flash messages on email confirmation (PR confirm-flash-clear).
 - Auth routes now verify the `two_factor_token` table exists before using TwoFactorToken to prevent login failures when migrations are missing (PR twofactor-table-check).
+- Added test ensuring users can access the feed after confirming their email (PR confirm-feed-access-test).

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -107,3 +107,21 @@ def test_pending_redirects_when_active(client, test_user):
     resp = client.get("/onboarding/pending")
     assert resp.status_code == 302
     assert resp.headers["Location"].endswith("/")
+
+
+# new test
+
+
+def test_confirm_logs_in_and_allows_feed_access(client, db_session):
+    user = User(username="logincheck", email="logincheck@example.com")
+    user.set_password("StrongPassw0rd!")
+    db_session.add(user)
+    db_session.commit()
+    token = EmailToken(user_id=user.id, email=user.email)
+    db_session.add(token)
+    db_session.commit()
+    resp = client.get(f"/onboarding/confirm/{token.token}")
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/feed/")
+    resp2 = client.get("/feed/", follow_redirects=False)
+    assert resp2.status_code == 200


### PR DESCRIPTION
## Summary
- ensure user session refreshes after email confirmation by testing feed access
- document new test in AGENTS guidelines

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6869277e52f88325b603e5bff35deb61