### PR TITLE
Add note categorizer helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -589,3 +589,4 @@
 - Auth routes now verify the `two_factor_token` table exists before using TwoFactorToken to prevent login failures when migrations are missing (PR twofactor-table-check).
 - Consolidated DOMContentLoaded handlers from store/store.html, chat/global.html, ia/chat.html and dashboard/_weather.html into main.js (PR domcontent-store-chat).
 - Added test ensuring users can access the feed after confirming their email (PR confirm-feed-access-test).
+- Added automatic note categorization suggestions when uploading notes (PR note-categorizer).

--- a/crunevo/templates/notes/upload.html
+++ b/crunevo/templates/notes/upload.html
@@ -28,6 +28,7 @@
                 <option value="{{ cat }}">{{ cat }}</option>
                 {% endfor %}
               </select>
+              <div class="mt-2" id="categorySuggestions"></div>
             </div>
 
 
@@ -144,6 +145,10 @@
     const imgPrev = document.getElementById('imgPreview');
     const form = document.getElementById('noteUploadForm');
     const btn = document.getElementById('uploadBtn');
+    const catSelect = document.getElementById('category');
+    const catBox = document.getElementById('categorySuggestions');
+    const descInput = document.getElementById('description');
+    const titleInput = document.getElementById('title');
 
     fileInput.addEventListener('change', () => {
       const file = fileInput.files[0];
@@ -182,6 +187,30 @@
     const tagContainer = document.getElementById('tagsContainer');
     const hiddenTags = document.getElementById('tagsHidden');
     const picked = [];
+
+    function fetchCategorySuggestions() {
+      const text = `${titleInput.value} ${descInput.value}`.trim();
+      if (!text) return;
+      fetch('{{ url_for('notes.categorize_text') }}', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text })
+      })
+        .then(r => r.json())
+        .then(data => {
+          catBox.innerHTML = '';
+          data.forEach(c => {
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'btn btn-sm btn-outline-primary me-1 mb-1';
+            btn.textContent = c;
+            btn.addEventListener('click', () => {
+              catSelect.value = c;
+            });
+            catBox.appendChild(btn);
+          });
+        });
+    }
 
     function renderTags() {
       tagContainer.innerHTML = '';
@@ -232,6 +261,9 @@
     tagInput.addEventListener('input', () => {
       showSuggestions(tagInput.value.trim());
     });
+
+    titleInput.addEventListener('blur', fetchCategorySuggestions);
+    descInput.addEventListener('blur', fetchCategorySuggestions);
 
     tagInput.addEventListener('keydown', (e) => {
       if (e.key === 'Enter' && tagInput.value.trim()) {

--- a/crunevo/utils/__init__.py
+++ b/crunevo/utils/__init__.py
@@ -6,3 +6,4 @@ from .login_streak import handle_login_streak  # noqa: F401
 from .feed import create_feed_item_for_all  # noqa: F401
 from .notify import send_notification  # noqa: F401
 from .user_activity import record_activity  # noqa: F401
+from .note_categorizer import suggest_categories  # noqa: F401

--- a/crunevo/utils/note_categorizer.py
+++ b/crunevo/utils/note_categorizer.py
@@ -1,0 +1,37 @@
+import re
+from typing import Iterable, List
+
+CATEGORY_KEYWORDS = {
+    "matemática": ["algebra", "geometría", "cálculo"],
+    "historia": ["historia", "batalla", "guerra", "civilización"],
+    "biología": ["biología", "célula", "genética"],
+    "comunicación": ["comunicación", "gramática", "lenguaje"],
+}
+
+
+def suggest_categories(text: str, categories: Iterable[str]) -> List[str]:
+    """Return likely categories for the given text."""
+    if not text:
+        return []
+    text = text.lower()
+    words = set(re.findall(r"\w+", text))
+    suggestions = []
+    for cat in categories:
+        ckey = cat.lower()
+        if ckey in text:
+            suggestions.append(cat)
+            continue
+        for kw in CATEGORY_KEYWORDS.get(ckey, []):
+            if kw in words:
+                suggestions.append(cat)
+                break
+    # Preserve original order and limit to 3 suggestions
+    seen = set()
+    ordered = []
+    for s in suggestions:
+        if s not in seen:
+            seen.add(s)
+            ordered.append(s)
+        if len(ordered) >= 3:
+            break
+    return ordered


### PR DESCRIPTION
## Summary
- add `suggest_categories` helper to detect categories from text
- integrate category guess in note creation
- provide `/notes/api/categorize` endpoint
- show suggested categories in upload form
- document new feature

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686929e321ac8325b7d4adc8ba5346a0