### PR TITLE
Implement stories feature with cleanup job

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -591,3 +591,4 @@
 - Added test ensuring users can access the feed after confirming their email (PR confirm-feed-access-test).
 - Added automatic note categorization suggestions when uploading notes (PR note-categorizer).
 - Posts now support a `comment_permission` setting (`all`, `friends`, `none`) with forms and comment endpoint enforcing it (PR comment-permission).
+- Introduced Story model with expiry, /stories routes and scheduled cleanup (PR stories-feature).

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -242,6 +242,7 @@ def create_app():
     from .routes.dashboard_routes import dashboard_bp
     from .routes.settings_routes import settings_bp
     from .routes.main_routes import main_bp
+    from .routes.story_routes import stories_bp
 
     is_admin = os.environ.get("ADMIN_INSTANCE") == "1"
     app.config["ADMIN_INSTANCE"] = is_admin
@@ -260,6 +261,7 @@ def create_app():
         app.register_blueprint(auth_bp)
         app.register_blueprint(notes_bp)
         app.register_blueprint(feed_bp)
+        app.register_blueprint(stories_bp)
         app.add_url_rule(
             "/api/feed",
             endpoint="feed.api_feed_alias",
@@ -368,11 +370,13 @@ def create_app():
         from .jobs.decay import decay_scores
         from .jobs.cleanup_auth_events import cleanup_auth_events
         from .jobs.backup_db import backup_database
+        from .jobs.cleanup_stories import cleanup_stories
 
         scheduler = BackgroundScheduler()
         scheduler.add_job(decay_scores, IntervalTrigger(hours=1))
         scheduler.add_job(cleanup_auth_events, IntervalTrigger(hours=24))
         scheduler.add_job(backup_database, IntervalTrigger(weeks=1))
+        scheduler.add_job(cleanup_stories, IntervalTrigger(hours=1))
         scheduler.start()
         app.scheduler = scheduler
 

--- a/crunevo/jobs/cleanup_stories.py
+++ b/crunevo/jobs/cleanup_stories.py
@@ -1,0 +1,8 @@
+from datetime import datetime
+from crunevo.extensions import db
+from crunevo.models import Story
+
+
+def cleanup_stories() -> None:
+    Story.query.filter(Story.expires_at <= datetime.utcnow()).delete()
+    db.session.commit()

--- a/crunevo/models/__init__.py
+++ b/crunevo/models/__init__.py
@@ -38,3 +38,4 @@ from .verification_request import VerificationRequest  # noqa: F401
 from .user_activity import UserActivity  # noqa: F401
 from .site_config import SiteConfig  # noqa: F401
 from .page_view import PageView  # noqa: F401
+from .story import Story  # noqa: F401

--- a/crunevo/models/story.py
+++ b/crunevo/models/story.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+from crunevo.extensions import db
+
+
+class Story(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    image_url = db.Column(db.String(255), nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    expires_at = db.Column(db.DateTime, nullable=False)
+
+    user = db.relationship("User", backref="stories", lazy=True)

--- a/crunevo/routes/story_routes.py
+++ b/crunevo/routes/story_routes.py
@@ -1,0 +1,62 @@
+import os
+from datetime import datetime, timedelta
+import cloudinary.uploader
+from werkzeug.utils import secure_filename
+from flask import (
+    Blueprint,
+    render_template,
+    request,
+    redirect,
+    url_for,
+    flash,
+    current_app,
+)
+from flask_login import current_user
+from crunevo.utils.helpers import activated_required
+from crunevo.extensions import db
+from crunevo.models import Story
+
+
+stories_bp = Blueprint("stories", __name__, url_prefix="/stories")
+
+
+@stories_bp.route("/", methods=["GET"], endpoint="list_stories")
+@activated_required
+def list_stories():
+    active = Story.query.filter(Story.expires_at > datetime.utcnow()).all()
+    return render_template("stories/list.html", stories=active)
+
+
+@stories_bp.route("/upload", methods=["GET", "POST"], endpoint="upload_story")
+@activated_required
+def upload_story():
+    if request.method == "POST":
+        image = request.files.get("image")
+        if not image or not image.filename:
+            flash("Selecciona una imagen", "danger")
+            return redirect(url_for("stories.upload_story"))
+        cloud_url = current_app.config.get("CLOUDINARY_URL")
+        try:
+            if cloud_url:
+                res = cloudinary.uploader.upload(image, resource_type="auto")
+                url = res["secure_url"]
+            else:
+                filename = secure_filename(image.filename)
+                upload_folder = current_app.config["UPLOAD_FOLDER"]
+                os.makedirs(upload_folder, exist_ok=True)
+                path = os.path.join(upload_folder, filename)
+                image.save(path)
+                url = path
+        except Exception:
+            current_app.logger.exception("Error uploading story")
+            flash("No se pudo subir la historia", "danger")
+            return redirect(url_for("stories.upload_story"))
+
+        expires = datetime.utcnow() + timedelta(hours=24)
+        story = Story(user_id=current_user.id, image_url=url, expires_at=expires)
+        db.session.add(story)
+        db.session.commit()
+        flash("Historia publicada", "success")
+        return redirect(url_for("stories.list_stories"))
+
+    return render_template("stories/upload.html")

--- a/crunevo/templates/stories/list.html
+++ b/crunevo/templates/stories/list.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container py-4">
+  <div class="d-flex flex-wrap gap-3">
+    {% for story in stories %}
+    <div>
+      <img src="{{ story.image_url }}" alt="story" class="img-fluid rounded" style="max-height:200px">
+      <small class="text-muted d-block">{{ story.user.username }}</small>
+    </div>
+    {% else %}
+    <p>No hay historias disponibles.</p>
+    {% endfor %}
+  </div>
+</div>
+{% endblock %}

--- a/crunevo/templates/stories/upload.html
+++ b/crunevo/templates/stories/upload.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% import 'components/csrf.html' as csrf %}
+{% block content %}
+<div class="container py-5">
+  <div class="row justify-content-center">
+    <div class="col-md-6">
+      <div class="card shadow-sm border-0">
+        <div class="card-body p-4">
+          <h3 class="card-title mb-3 text-center">Subir historia</h3>
+          <form method="post" enctype="multipart/form-data">
+            {{ csrf.csrf_field() }}
+            <div class="mb-3">
+              <input type="file" name="image" class="form-control" required>
+            </div>
+            <button type="submit" class="btn btn-primary w-100">Publicar</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/migrations/versions/add_story_model.py
+++ b/migrations/versions/add_story_model.py
@@ -1,0 +1,35 @@
+"""add story table"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def has_table(name: str, conn) -> bool:
+    inspector = sa.inspect(conn)
+    return name in inspector.get_table_names()
+
+
+revision = "add_story_model"
+down_revision = "99588ab3c722"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    if not has_table("story", conn):
+        op.create_table(
+            "story",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "user_id", sa.Integer(), sa.ForeignKey("user.id"), nullable=False
+            ),
+            sa.Column("image_url", sa.String(length=255), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("expires_at", sa.DateTime(), nullable=False),
+            if_not_exists=True,
+        )
+
+
+def downgrade():
+    op.drop_table("story", if_exists=True)


### PR DESCRIPTION
## Summary
- create `Story` model with expiration
- add upload and list routes under `/stories`
- schedule cleanup of expired stories via APScheduler
- document in `AGENTS.md`

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68692e3e8838832582f6a52d813da2f0