### PR TITLE
Fix onboarding confirm login

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -592,3 +592,4 @@
 - Added automatic note categorization suggestions when uploading notes (PR note-categorizer).
 - Posts now support a `comment_permission` setting (`all`, `friends`, `none`) with forms and comment endpoint enforcing it (PR comment-permission).
 - Introduced Story model with expiry, /stories routes and scheduled cleanup (PR stories-feature).
+- Onboarding confirm route refreshes user before login to fix feed redirect issue (PR confirm-login-refresh).

--- a/crunevo/routes/onboarding_routes.py
+++ b/crunevo/routes/onboarding_routes.py
@@ -147,8 +147,9 @@ def confirm(token):
         if total_done >= 10:
             unlock_achievement(ref.invitador, AchievementCodes.EMBAJADOR_CRUNEVO)
     db.session.commit()
+    db.session.refresh(record.user)
     record_auth_event(record.user, "confirm_email")
-    login_user(record.user)
+    login_user(record.user, fresh=True)
     # Remove stale flash messages from previous requests
     session.pop("_flashes", None)
     flash("¡Correo verificado! Bienvenido a CRUNEVO", "success")


### PR DESCRIPTION
## Summary
- refresh user before re-login in onboarding confirmation
- document fix in AGENTS guidelines

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6869330610e88325b7c859f3946532bb