### PR TITLE
Fix mission is_active migration default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -594,3 +594,4 @@
 - Introduced Story model with expiry, /stories routes and scheduled cleanup (PR stories-feature).
 - Onboarding confirm route refreshes user before login to fix feed redirect issue (PR confirm-login-refresh).
 - Events now include notification_times and recurring; calendar JSON endpoint and missions auto-activate before linked events (PR events-calendar-missions)
+- Fixed is_active column migration using server_default=sa.text('true') to avoid PostgreSQL type mismatch (PR mission-boolean-default-fix).

--- a/migrations/versions/9b7a1e2f4c8d_event_calendar_fields.py
+++ b/migrations/versions/9b7a1e2f4c8d_event_calendar_fields.py
@@ -41,7 +41,7 @@ def upgrade():
                     "is_active",
                     sa.Boolean(),
                     nullable=True,
-                    server_default=sa.text("1"),
+                    server_default=sa.text("true"),
                 )
             )
 


### PR DESCRIPTION
## Summary
- correct boolean default for `is_active` in mission migration
- document change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6869369c6aa0832589a8a1f73714821d