### PR TITLE
Add fullscreen toggle and annotation hook for notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -597,3 +597,4 @@
 - Fixed is_active column migration using server_default=sa.text('true') to avoid PostgreSQL type mismatch (PR mission-boolean-default-fix).
 - Added migration ensuring two_factor_token table is created if missing (PR twofactor-migration-fix).
 - Migration fix for comment_permission column using op.add_column with if_not_exists (PR comment-permission-migration-fix)
+- Added fullscreen toggle and annotation hook in viewer.js with button in note detail (PR note-viewer-fullscreen)

--- a/crunevo/static/js/viewer.js
+++ b/crunevo/static/js/viewer.js
@@ -1,6 +1,19 @@
+let annotationHandler = null;
+function setAnnotationHook(fn) {
+  annotationHandler = typeof fn === 'function' ? fn : null;
+}
+
 function initNoteViewer() {
   const container = document.getElementById('noteViewer');
   if (!container) return;
+  const fullBtn = document.getElementById('fullscreenBtn');
+  fullBtn?.addEventListener('click', () => {
+    if (!document.fullscreenElement) {
+      container.requestFullscreen?.();
+    } else {
+      document.exitFullscreen?.();
+    }
+  });
   const type = container.dataset.type;
   const url = container.dataset.url;
   if (type === 'pdf' && typeof pdfjsLib !== 'undefined') {
@@ -51,6 +64,11 @@ function initNoteViewer() {
         renderPage(pageNum);
       }
     });
+    canvas.addEventListener('dblclick', (ev) => {
+      if (annotationHandler) {
+        annotationHandler({ page: pageNum, x: ev.offsetX, y: ev.offsetY });
+      }
+    });
   } else if (type === 'image') {
     const img = document.createElement('img');
     img.src = url;
@@ -63,3 +81,5 @@ function initNoteViewer() {
     container.appendChild(p);
   }
 }
+
+window.setAnnotationHook = setAnnotationHook;

--- a/crunevo/templates/notes/detalle.html
+++ b/crunevo/templates/notes/detalle.html
@@ -5,6 +5,7 @@
   <div class="row g-4">
     <div class="col-md-9 order-md-2">
       <div id="noteViewer" data-url="{{ note.filename }}" data-type="{{ file_type }}"></div>
+      <button type="button" class="btn btn-outline-secondary btn-sm mt-2" id="fullscreenBtn">Pantalla completa</button>
       <p class="text-muted small mt-2"><a href="{{ url_for('notes.download_note', note_id=note.id) }}">Descargar archivo</a></p>
     </div>
     <div class="col-md-3 order-md-1">


### PR DESCRIPTION
## Summary
- add fullscreen and annotation support in `viewer.js`
- include fullscreen button in note detail template
- record changes in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68693ec301a88325af92db913d5a9a48