### PR TITLE
Implement anonymous comment moderation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -602,3 +602,4 @@
 - Added UserBlock model with chat blocking and attachment uploads for images and files (PR user-blocks-attachments).
 - Purchase model now stores optional shipping address and message; checkout form collects them (PR purchase-shipping)
 - Added PrintRequest model with /notes/<id>/print queue and admin tools to mark prints as cumplidos (PR notes-print-queue)
+- Comments admit anonymous posting stored as pending; admin queue allows approving or rejecting them (PR anonymous-comment-review)

--- a/crunevo/models/comment.py
+++ b/crunevo/models/comment.py
@@ -8,3 +8,4 @@ class Comment(db.Model):
     created_at = db.Column("timestamp", db.DateTime, default=datetime.utcnow)
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"))
     note_id = db.Column(db.Integer, db.ForeignKey("note.id"))
+    pending = db.Column(db.Boolean, default=False, index=True)

--- a/crunevo/models/post_comment.py
+++ b/crunevo/models/post_comment.py
@@ -8,3 +8,4 @@ class PostComment(db.Model):
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
     author_id = db.Column(db.Integer, db.ForeignKey("user.id"))
     post_id = db.Column(db.Integer, db.ForeignKey("post.id"))
+    pending = db.Column(db.Boolean, default=False, index=True)

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -367,7 +367,10 @@ class FeedManager {
         body: formData
       });
 
-      if (response.ok) {
+      if (response.status === 202) {
+        this.showToast('Comentario pendiente de aprobación', 'info');
+        input.value = '';
+      } else if (response.ok) {
         const comment = await response.json();
         this.addCommentToUI(comment);
         input.value = '';

--- a/crunevo/templates/admin/partials/sidebar.html
+++ b/crunevo/templates/admin/partials/sidebar.html
@@ -43,6 +43,9 @@
   <a class="nav-link {% if request.endpoint == 'admin.verification_requests' %}active{% endif %}" href="{{ url_for('admin.verification_requests') }}">
     <i class="ti ti-check me-2"></i> Verificaciones
   </a>
+  <a class="nav-link {% if request.endpoint == 'admin.pending_comments' %}active{% endif %}" href="{{ url_for('admin.pending_comments') }}">
+    <i class="ti ti-message me-2"></i> Comentarios pendientes
+  </a>
   {% if 'admin.manage_achievements' in url_for.__globals__.get('current_app', {}).view_functions %}
   <a class="nav-link {% if request.endpoint == 'admin.manage_achievements' %}active{% endif %}" href="{{ url_for('admin.manage_achievements') }}">
     <i class="ti ti-award me-2"></i> Logros

--- a/crunevo/templates/admin/pending_comments.html
+++ b/crunevo/templates/admin/pending_comments.html
@@ -1,0 +1,72 @@
+{% extends 'admin/base_admin.html' %}
+{% import 'components/csrf.html' as csrf %}
+{% block admin_content %}
+<h2 class="page-title mb-4">Comentarios pendientes</h2>
+<div class="row row-cards">
+  <div class="col-12">
+    <div class="card shadow-sm">
+      <div class="card-header"><h3 class="card-title">Publicaciones</h3></div>
+      <div class="card-body p-0">
+        <div class="table-responsive">
+          <table class="table table-vcenter card-table" data-datatable>
+            <thead><tr><th>Autor</th><th>Comentario</th><th>Post</th><th>Acciones</th></tr></thead>
+            <tbody>
+            {% for c, post, user in post_comments %}
+            <tr>
+              <td>{{ user.username if user else 'Anónimo' }}</td>
+              <td>{{ c.body[:40] }}{% if c.body|length > 40 %}...{% endif %}</td>
+              <td><a href="{{ url_for('feed.view_post', post_id=post.id) }}" target="_blank">Post {{ post.id }}</a></td>
+              <td>
+                <form method="post" action="{{ url_for('admin.approve_comment', ctype='post', cid=c.id) }}" class="d-inline">
+                  {{ csrf.csrf_field() }}
+                  <button class="btn btn-success btn-sm">Aprobar</button>
+                </form>
+                <form method="post" action="{{ url_for('admin.reject_comment', ctype='post', cid=c.id) }}" class="d-inline ms-1">
+                  {{ csrf.csrf_field() }}
+                  <button class="btn btn-danger btn-sm">Eliminar</button>
+                </form>
+              </td>
+            </tr>
+            {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="col-12 mt-4">
+    <div class="card shadow-sm">
+      <div class="card-header"><h3 class="card-title">Apuntes</h3></div>
+      <div class="card-body p-0">
+        <div class="table-responsive">
+          <table class="table table-vcenter card-table" data-datatable>
+            <thead><tr><th>Autor</th><th>Comentario</th><th>Apunte</th><th>Acciones</th></tr></thead>
+            <tbody>
+            {% for c, note, user in note_comments %}
+            <tr>
+              <td>{{ user.username if user else 'Anónimo' }}</td>
+              <td>{{ c.body[:40] }}{% if c.body|length > 40 %}...{% endif %}</td>
+              <td><a href="{{ url_for('notes.view_note', id=note.id) }}" target="_blank">Apunte {{ note.id }}</a></td>
+              <td>
+                <form method="post" action="{{ url_for('admin.approve_comment', ctype='note', cid=c.id) }}" class="d-inline">
+                  {{ csrf.csrf_field() }}
+                  <button class="btn btn-success btn-sm">Aprobar</button>
+                </form>
+                <form method="post" action="{{ url_for('admin.reject_comment', ctype='note', cid=c.id) }}" class="d-inline ms-1">
+                  {{ csrf.csrf_field() }}
+                  <button class="btn btn-danger btn-sm">Eliminar</button>
+                </form>
+              </td>
+            </tr>
+            {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<script>
+document.addEventListener('DOMContentLoaded', initDataTables);
+</script>
+{% endblock %}

--- a/crunevo/templates/notes/detalle.html
+++ b/crunevo/templates/notes/detalle.html
@@ -57,7 +57,7 @@
   <hr>
   <h5 class="mb-3">Comentarios</h5>
   <div id="comments" class="comment-container" data-post-id="{{ note.id }}">
-    {% for c in note.comments|sort(attribute='created_at', reverse=True) %}
+    {% for c in note.comments|selectattr('pending', 'equalto', False)|sort(attribute='created_at', reverse=True) %}
     <div class="d-flex mb-3 comment comment-item comment-box">
       <img loading="lazy" src="{{ c.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
       <div>
@@ -69,7 +69,6 @@
     </div>
     {% endfor %}
   </div>
-  {% if current_user.is_authenticated %}
   <form id="commentForm" class="mt-3">
     {{ csrf.csrf_field() }}
     <div class="input-group">
@@ -77,7 +76,6 @@
       <button class="btn btn-primary" type="submit">Enviar</button>
     </div>
   </form>
-  {% endif %}
 </div>
 {% if current_user.is_authenticated and current_user.id != note.author.id %}
 <div class="modal fade" id="reportNoteModal" tabindex="-1" aria-hidden="true">
@@ -132,7 +130,14 @@
     csrfFetch("{{ url_for('notes.add_comment', note_id=note.id) }}", {
       method: 'POST',
       body: data
-    }).then(r => r.json()).then(c => {
+    }).then(r => {
+      if (r.status === 202) {
+        showToast('Comentario pendiente de aprobación');
+        return null;
+      }
+      return r.json();
+    }).then(c => {
+      if (!c) return;
       const container = document.getElementById('comments');
       if (container) {
         const div = renderComment({

--- a/migrations/versions/add_comment_pending.py
+++ b/migrations/versions/add_comment_pending.py
@@ -1,0 +1,52 @@
+"""add pending flag to comments"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def has_col(table: str, column: str, conn) -> bool:
+    inspector = sa.inspect(conn)
+    return any(c["name"] == column for c in inspector.get_columns(table))
+
+
+revision = "add_comment_pending"
+down_revision = "add_print_request_model"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    if not has_col("post_comment", "pending", conn):
+        op.add_column(
+            "post_comment",
+            sa.Column(
+                "pending",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text("false"),
+            ),
+            schema=None,
+            if_not_exists=True,
+        )
+        op.alter_column("post_comment", "pending", server_default=None)
+    if not has_col("comment", "pending", conn):
+        op.add_column(
+            "comment",
+            sa.Column(
+                "pending",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text("false"),
+            ),
+            schema=None,
+            if_not_exists=True,
+        )
+        op.alter_column("comment", "pending", server_default=None)
+
+
+def downgrade():
+    with op.batch_alter_table("post_comment", schema=None) as batch_op:
+        batch_op.drop_column("pending", if_exists=True)
+    with op.batch_alter_table("comment", schema=None) as batch_op:
+        batch_op.drop_column("pending", if_exists=True)

--- a/tests/test_pending_comments.py
+++ b/tests/test_pending_comments.py
@@ -1,0 +1,40 @@
+from crunevo.models import Post, PostComment, User
+from crunevo.utils.feed import create_feed_item_for_all
+
+
+def login(client, username, password="secret"):
+    return client.post("/login", data={"username": username, "password": password})
+
+
+def test_anonymous_comment_pending(client, db_session, test_user):
+    post = Post(content="x", author=test_user)
+    db_session.add(post)
+    db_session.commit()
+    create_feed_item_for_all("post", post.id)
+
+    resp = client.post(f"/feed/comment/{post.id}", data={"body": "hi"})
+    assert resp.status_code == 202
+
+    c = PostComment.query.first()
+    assert c.pending is True
+    assert c.author_id is None
+
+
+def test_admin_approves_comment(client, db_session, test_user):
+    admin = User(
+        username="adm",
+        email="adm@example.com",
+        role="admin",
+        activated=True,
+        avatar_url="a",
+    )
+    admin.set_password("pass")
+    post = Post(content="x", author=test_user)
+    comment = PostComment(body="hello", post=post, pending=True)
+    db_session.add_all([admin, post, comment])
+    db_session.commit()
+
+    login(client, "adm", "pass")
+    resp = client.post(f"/admin/pending-comments/post/{comment.id}/approve")
+    assert resp.status_code == 302
+    assert PostComment.query.get(comment.id).pending is False


### PR DESCRIPTION
## Summary
- allow anonymous comments for posts and notes
- mark anonymous comments as `pending`
- add admin queue to approve or reject pending comments
- include admin sidebar link and new review template
- document change in AGENTS log
- add migration and tests for anonymous comments

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6869508c59988325958d823460bffba2