### PR TITLE
Add event conference URLs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -603,3 +603,4 @@
 - Purchase model now stores optional shipping address and message; checkout form collects them (PR purchase-shipping)
 - Added PrintRequest model with /notes/<id>/print queue and admin tools to mark prints as cumplidos (PR notes-print-queue)
 - Comments admit anonymous posting stored as pending; admin queue allows approving or rejecting them (PR anonymous-comment-review)
+- Added optional video conference URLs on events with Jitsi/Zoom embed (PR event-video-links).

--- a/crunevo/models/event.py
+++ b/crunevo/models/event.py
@@ -12,6 +12,8 @@ class Event(db.Model):
     is_featured = db.Column(db.Boolean, default=False)
     rewards = db.Column(db.Text)  # JSON string with reward details
     category = db.Column(db.String(50))
+    jitsi_url = db.Column(db.String(255))
+    zoom_url = db.Column(db.String(255))
     notification_times = db.Column(db.JSON)
     recurring = db.Column(db.String(20))
 

--- a/crunevo/templates/event/detail.html
+++ b/crunevo/templates/event/detail.html
@@ -63,7 +63,15 @@
                         </div>
                     </div>
                     {% endif %}
-                    
+
+                    {% if event.jitsi_url or event.zoom_url %}
+                    <div class="ratio ratio-16x9 mb-4">
+                        <iframe src="{{ event.jitsi_url or event.zoom_url }}"
+                                allow="camera; microphone; display-capture"
+                                allowfullscreen style="border:0;"></iframe>
+                    </div>
+                    {% endif %}
+
                     <!-- Participation Buttons -->
                     {% if current_user.is_authenticated and event.is_upcoming %}
                     <div class="participation-section">
@@ -117,6 +125,12 @@
                             <strong>Participantes:</strong><br>
                             <span class="text-muted">{{ participant_count }} personas</span>
                         </div>
+                        {% if event.jitsi_url or event.zoom_url %}
+                        <div class="mb-3">
+                            <strong>Enlace:</strong><br>
+                            <a href="{{ event.jitsi_url or event.zoom_url }}" class="link-primary" target="_blank">Unirse a la reunión</a>
+                        </div>
+                        {% endif %}
                     </div>
                 </div>
             </div>

--- a/crunevo/templates/event/list.html
+++ b/crunevo/templates/event/list.html
@@ -314,6 +314,12 @@
                 </a>
                 {% endif %}
 
+                {% if event.jitsi_url or event.zoom_url %}
+                <a href="{{ event.jitsi_url or event.zoom_url }}" target="_blank" class="btn btn-outline-primary">
+                  <i class="bi bi-camera-video me-1"></i>Unirse
+                </a>
+                {% endif %}
+
                 <div class="participant-count">
                   <i class="bi bi-people"></i>
                   <span id="participants-{{ event.id }}">

--- a/migrations/versions/b25339c3d623_add_event_conference_urls.py
+++ b/migrations/versions/b25339c3d623_add_event_conference_urls.py
@@ -1,0 +1,41 @@
+"""add event conference urls
+
+Revision ID: b25339c3d623
+Revises: add_comment_pending
+Create Date: 2025-07-05 16:40:15.428519
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "b25339c3d623"
+down_revision = "add_comment_pending"
+branch_labels = None
+depends_on = None
+
+
+def has_col(table: str, column: str, conn) -> bool:
+    inspector = sa.inspect(conn)
+    return any(c["name"] == column for c in inspector.get_columns(table))
+
+
+def upgrade():
+    conn = op.get_bind()
+    with op.batch_alter_table("event") as batch_op:
+        if not has_col("event", "jitsi_url", conn):
+            batch_op.add_column(
+                sa.Column("jitsi_url", sa.String(length=255), nullable=True)
+            )
+        if not has_col("event", "zoom_url", conn):
+            batch_op.add_column(
+                sa.Column("zoom_url", sa.String(length=255), nullable=True)
+            )
+
+
+def downgrade():
+    with op.batch_alter_table("event") as batch_op:
+        batch_op.drop_column("zoom_url", if_exists=True)
+        batch_op.drop_column("jitsi_url", if_exists=True)


### PR DESCRIPTION
## Summary
- add optional `jitsi_url` and `zoom_url` fields on events
- embed video conference iframe and links in event pages
- migration for new fields
- document change in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686954b1b3a88325932b6c4e87a1fbed