### PR TITLE
Implement developer API endpoints with keys

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -609,3 +609,4 @@
 - Integrated Sentry error monitoring with logging integration and setup docs (PR sentry-monitoring)
 - Added local SHA-256 hashing on note uploads to detect duplicates, blocking the upload and notifying moderators (PR note-plagiarism-check).
 - Added OAuth import from Google Drive and Dropbox allowing file import to notes (PR drive-dropbox-import).
+- Exposed read-only API endpoints with rate limiting and added developer API key generation (PR developer-api-endpoints).

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -281,6 +281,7 @@ def create_app():
     from .routes.settings_routes import settings_bp
     from .routes.main_routes import main_bp
     from .routes.story_routes import stories_bp
+    from .routes.developer_routes import developer_bp
 
     is_admin = os.environ.get("ADMIN_INSTANCE") == "1"
     app.config["ADMIN_INSTANCE"] = is_admin
@@ -288,6 +289,7 @@ def create_app():
     app.register_blueprint(health_bp)
     app.register_blueprint(maintenance_bp)
     app.register_blueprint(main_bp)
+    app.register_blueprint(developer_bp)
     app.logger.info("Running in ADMIN mode" if is_admin else "Running in PUBLIC mode")
 
     if is_admin:

--- a/crunevo/models/__init__.py
+++ b/crunevo/models/__init__.py
@@ -44,3 +44,4 @@ from .story import Story  # noqa: F401
 from .group_mission import GroupMission, GroupMissionParticipant  # noqa: F401
 from .user_block import UserBlock  # noqa: F401
 from .print_request import PrintRequest  # noqa: F401
+from .api_key import APIKey  # noqa: F401

--- a/crunevo/models/api_key.py
+++ b/crunevo/models/api_key.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+import secrets
+
+from crunevo.extensions import db
+
+
+class APIKey(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    key = db.Column(
+        db.String(64),
+        unique=True,
+        nullable=False,
+        default=lambda: secrets.token_urlsafe(32),
+    )
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    user = db.relationship("User", backref=db.backref("api_keys", lazy=True))

--- a/crunevo/routes/developer_routes.py
+++ b/crunevo/routes/developer_routes.py
@@ -1,0 +1,68 @@
+from flask import Blueprint, jsonify, request, g
+from flask_login import login_required, current_user
+from flask_limiter.util import get_remote_address
+
+from crunevo.extensions import db, limiter
+from crunevo.models import Post, Note, APIKey
+
+
+developer_bp = Blueprint("developer_api", __name__, url_prefix="/api")
+
+
+def api_key_func():
+    return (
+        g.get("api_key")
+        or request.headers.get("X-API-Key")
+        or request.args.get("api_key")
+        or get_remote_address()
+    )
+
+
+def api_key_required(f):
+    from functools import wraps
+
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        key = request.headers.get("X-API-Key") or request.args.get("api_key")
+        if not key:
+            return jsonify({"error": "API key required"}), 401
+        api_key = APIKey.query.filter_by(key=key).first()
+        if not api_key:
+            return jsonify({"error": "Invalid API key"}), 401
+        g.api_key = key
+        g.api_user = api_key.user
+        return f(*args, **kwargs)
+
+    return wrapper
+
+
+@developer_bp.route("/recent-posts")
+@limiter.limit("30 per minute", key_func=api_key_func)
+@api_key_required
+def recent_posts():
+    posts = Post.query.order_by(Post.created_at.desc()).limit(10).all()
+    return jsonify(
+        [
+            {"id": p.id, "content": p.content, "created_at": p.created_at.isoformat()}
+            for p in posts
+        ]
+    )
+
+
+@developer_bp.route("/popular-notes")
+@limiter.limit("30 per minute", key_func=api_key_func)
+@api_key_required
+def popular_notes():
+    notes = Note.query.order_by(Note.likes.desc()).limit(10).all()
+    return jsonify([{"id": n.id, "title": n.title, "likes": n.likes} for n in notes])
+
+
+@developer_bp.route("/generate-key", methods=["POST"])
+@login_required
+def generate_key():
+    api_key = APIKey.query.filter_by(user_id=current_user.id).first()
+    if not api_key:
+        api_key = APIKey(user_id=current_user.id)
+        db.session.add(api_key)
+        db.session.commit()
+    return jsonify({"api_key": api_key.key})

--- a/migrations/versions/add_api_key_table.py
+++ b/migrations/versions/add_api_key_table.py
@@ -1,0 +1,36 @@
+"""add api_key table"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def has_table(name: str, conn) -> bool:
+    inspector = sa.inspect(conn)
+    return name in inspector.get_table_names()
+
+
+# revision identifiers, used by Alembic.
+revision = "add_api_key"
+down_revision = "b25339c3d623"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    if not has_table("api_key", conn):
+        op.create_table(
+            "api_key",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "user_id", sa.Integer(), sa.ForeignKey("user.id"), nullable=False
+            ),
+            sa.Column("key", sa.String(length=64), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.UniqueConstraint("key"),
+            if_not_exists=True,
+        )
+
+
+def downgrade():
+    op.drop_table("api_key", if_exists=True)

--- a/tests/test_developer_api.py
+++ b/tests/test_developer_api.py
@@ -1,0 +1,16 @@
+def login(client, username, password="secret"):
+    return client.post("/login", data={"username": username, "password": password})
+
+
+def test_recent_posts_requires_api_key(client):
+    resp = client.get("/api/recent-posts")
+    assert resp.status_code == 401
+
+
+def test_generate_key_and_access(client, test_user, db_session):
+    login(client, test_user.username)
+    resp = client.post("/api/generate-key")
+    assert resp.status_code == 200
+    key = resp.get_json()["api_key"]
+    resp2 = client.get("/api/recent-posts", headers={"X-API-Key": key})
+    assert resp2.status_code == 200


### PR DESCRIPTION
## Summary
- create `APIKey` model and migration
- add developer API blueprint with recent posts & popular notes
- include API key generation endpoint
- register the new blueprint
- test API key workflow
- document new feature in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6869613195d08325abc21ee27d2c3c11