### PR TITLE
Add career & interests filters for notifications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -610,3 +610,4 @@
 - Added local SHA-256 hashing on note uploads to detect duplicates, blocking the upload and notifying moderators (PR note-plagiarism-check).
 - Added OAuth import from Google Drive and Dropbox allowing file import to notes (PR drive-dropbox-import).
 - Exposed read-only API endpoints with rate limiting and added developer API key generation (PR developer-api-endpoints).
+- Added `career` and `interests` fields to users with notifications filtered by these attributes (PR user-career-interests).

--- a/crunevo/models/user.py
+++ b/crunevo/models/user.py
@@ -21,6 +21,8 @@ class User(UserMixin, db.Model):
     verification_level = db.Column(db.SmallInteger, default=0)
     avatar_url = db.Column(db.String(255), default=DEFAULT_AVATAR_URL)
     about = db.Column(db.Text)
+    career = db.Column(db.String(120))
+    interests = db.Column(db.Text)
     credit_history = db.relationship("Credit", back_populates="user", lazy=True)
     notes = db.relationship("Note", backref="author", lazy=True)
     posts = db.relationship(

--- a/crunevo/routes/onboarding_routes.py
+++ b/crunevo/routes/onboarding_routes.py
@@ -178,6 +178,8 @@ def finish():
         elif avatar_url:
             current_user.avatar_url = avatar_url
         current_user.about = request.form.get("bio")
+        current_user.career = request.form.get("career")
+        current_user.interests = request.form.get("interests")
         db.session.commit()
         return redirect(url_for("feed.feed_home"))
     return render_template("onboarding/finish.html")

--- a/crunevo/routes/settings_routes.py
+++ b/crunevo/routes/settings_routes.py
@@ -20,6 +20,8 @@ def index():
 def update_personal():
     username = request.form.get("username")
     about = request.form.get("about")
+    career = request.form.get("career")
+    interests = request.form.get("interests")
     changed = False
     if username is not None:
         username = username.strip()
@@ -33,6 +35,10 @@ def update_personal():
             changed = True
     if about is not None:
         current_user.about = about
+    if career is not None:
+        current_user.career = career
+    if interests is not None:
+        current_user.interests = interests
     db.session.commit()
     return jsonify(success=True, changed_username=changed)
 

--- a/crunevo/templates/configuracion/personal.html
+++ b/crunevo/templates/configuracion/personal.html
@@ -34,3 +34,39 @@
     </div>
   </div>
 </section>
+
+<section id="career" class="mb-4">
+  <div class="card shadow-sm border-0">
+    <div class="card-header bg-white">
+      <h5 class="mb-0">Carrera</h5>
+    </div>
+    <div class="card-body">
+      <form id="careerForm" class="settings-form" method="post" action="{{ url_for('settings.update_personal') }}">
+        {{ csrf.csrf_field() }}
+        <div class="mb-3">
+          <label for="career" class="form-label">Carrera</label>
+          <input type="text" class="form-control" id="career" name="career" value="{{ current_user.career }}">
+        </div>
+        <button type="submit" class="btn btn-primary">Guardar</button>
+      </form>
+    </div>
+  </div>
+</section>
+
+<section id="interests" class="mb-4">
+  <div class="card shadow-sm border-0">
+    <div class="card-header bg-white">
+      <h5 class="mb-0">Intereses</h5>
+    </div>
+    <div class="card-body">
+      <form id="interestsForm" class="settings-form" method="post" action="{{ url_for('settings.update_personal') }}">
+        {{ csrf.csrf_field() }}
+        <div class="mb-3">
+          <label for="interests" class="form-label">Intereses (separados por comas)</label>
+          <input type="text" class="form-control" id="interests" name="interests" value="{{ current_user.interests }}">
+        </div>
+        <button type="submit" class="btn btn-primary">Guardar</button>
+      </form>
+    </div>
+  </div>
+</section>

--- a/crunevo/templates/onboarding/finish.html
+++ b/crunevo/templates/onboarding/finish.html
@@ -36,6 +36,16 @@
             </div>
           </div>
 
+          <div class="mb-4 text-start">
+            <label class="form-label fw-semibold" for="careerInput">Carrera</label>
+            <input type="text" class="form-control" id="careerInput" name="career" placeholder="Ing. Sistemas">
+          </div>
+
+          <div class="mb-4 text-start">
+            <label class="form-label fw-semibold" for="interestsInput">Intereses</label>
+            <input type="text" class="form-control" id="interestsInput" name="interests" placeholder="tecnología, música">
+          </div>
+
           <button class="btn btn-primary w-100 mt-3" type="submit">Guardar mi perfil</button>
         </form>
 

--- a/crunevo/utils/notify.py
+++ b/crunevo/utils/notify.py
@@ -1,8 +1,23 @@
 from crunevo.models.notification import Notification
 from crunevo.extensions import db
+from crunevo.models import User
 
 
-def send_notification(user_id, message, url=None):
-    notif = Notification(user_id=user_id, message=message, url=url)
-    db.session.add(notif)
+def send_notification(
+    user_id=None, message=None, url=None, career=None, interests=None
+):
+    """Send a notification to a single user or a filtered group."""
+    if user_id is not None:
+        users = User.query.filter_by(id=user_id).all()
+    else:
+        query = User.query
+        if career:
+            query = query.filter_by(career=career)
+        if interests:
+            query = query.filter(User.interests.ilike(f"%{interests}%"))
+        users = query.all()
+
+    for u in users:
+        db.session.add(Notification(user_id=u.id, message=message, url=url))
+
     db.session.commit()

--- a/migrations/versions/4c29ad8b8c1a_add_user_career_interests.py
+++ b/migrations/versions/4c29ad8b8c1a_add_user_career_interests.py
@@ -1,0 +1,38 @@
+"""add career and interests fields to user
+
+Revision ID: 4c29ad8b8c1a
+Revises: 018c30955e14
+Create Date: 2025-07-08 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def has_col(table: str, column: str, conn) -> bool:
+    inspector = sa.inspect(conn)
+    return any(c["name"] == column for c in inspector.get_columns(table))
+
+
+# revision identifiers, used by Alembic.
+revision = "4c29ad8b8c1a"
+down_revision = "add_api_key"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    with op.batch_alter_table("user", schema=None) as batch_op:
+        if not has_col("user", "career", conn):
+            batch_op.add_column(
+                sa.Column("career", sa.String(length=120), nullable=True)
+            )
+        if not has_col("user", "interests", conn):
+            batch_op.add_column(sa.Column("interests", sa.Text(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("user", schema=None) as batch_op:
+        batch_op.drop_column("interests", if_exists=True)
+        batch_op.drop_column("career", if_exists=True)

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,4 +1,5 @@
-from crunevo.models import Notification
+from crunevo.models import Notification, User
+from crunevo.utils import send_notification
 
 
 def login(client, username, password="secret"):
@@ -26,3 +27,29 @@ def test_mark_all_read(client, db_session, test_user):
     assert (
         Notification.query.filter_by(user_id=test_user.id, is_read=False).count() == 0
     )
+
+
+def test_send_notification_filter(db_session):
+    u1 = User(
+        username="law",
+        email="law@example.com",
+        activated=True,
+        avatar_url="a",
+        career="law",
+    )
+    u1.set_password("secret")
+    u2 = User(
+        username="eng",
+        email="eng@example.com",
+        activated=True,
+        avatar_url="a",
+        career="engineering",
+    )
+    u2.set_password("secret")
+    db_session.add_all([u1, u2])
+    db_session.commit()
+
+    send_notification(message="Hola", career="law")
+
+    assert Notification.query.filter_by(user_id=u1.id).count() == 1
+    assert Notification.query.filter_by(user_id=u2.id).count() == 0


### PR DESCRIPTION
## Summary
- extend `User` model with `career` and `interests` attributes
- save these new fields during onboarding and in personal settings
- filter notification recipients in `send_notification`
- add Alembic migration for new columns
- test filtered notifications
- document changes in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6869638295dc8325ac04a3ce33c20ff8