### PR TITLE
Add internship posting and application routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -612,3 +612,4 @@
 - Exposed read-only API endpoints with rate limiting and added developer API key generation (PR developer-api-endpoints).
 - Added `career` and `interests` fields to users with notifications filtered by these attributes (PR user-career-interests).
 - Added LinkedIn sharing and posting for certificates with OAuth integration (PR linkedin-share)
+- Added Internship model with application routes and filters by field/location (PR internship-system).

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -283,6 +283,7 @@ def create_app():
     from .routes.club_routes import club_bp
     from .routes.forum_routes import forum_bp
     from .routes.event_routes import event_bp, list_events
+    from .routes.internship_routes import internship_bp
     from .routes.about_routes import about_bp
     from .routes.static_routes import static_bp
     from .routes.saved_routes import saved_bp
@@ -388,6 +389,7 @@ def create_app():
         app.register_blueprint(club_bp)
         app.register_blueprint(forum_bp)
         app.register_blueprint(event_bp)
+        app.register_blueprint(internship_bp)
         app.add_url_rule(
             "/events",
             endpoint="event.list_events_alias",

--- a/crunevo/models/__init__.py
+++ b/crunevo/models/__init__.py
@@ -45,3 +45,5 @@ from .group_mission import GroupMission, GroupMissionParticipant  # noqa: F401
 from .user_block import UserBlock  # noqa: F401
 from .print_request import PrintRequest  # noqa: F401
 from .api_key import APIKey  # noqa: F401
+
+from .internship import Internship, InternshipApplication  # noqa: F401

--- a/crunevo/models/internship.py
+++ b/crunevo/models/internship.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+from crunevo.extensions import db
+
+
+class Internship(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(200), nullable=False)
+    description = db.Column(db.Text)
+    field = db.Column(db.String(100))
+    location = db.Column(db.String(100))
+    company = db.Column(db.String(100))
+    posted_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+class InternshipApplication(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    internship_id = db.Column(
+        db.Integer, db.ForeignKey("internship.id"), nullable=False
+    )
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    cover_letter = db.Column(db.Text)
+    applied_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    internship = db.relationship("Internship", backref="applications")
+    user = db.relationship("User", backref="internship_applications")

--- a/crunevo/routes/internship_routes.py
+++ b/crunevo/routes/internship_routes.py
@@ -1,0 +1,84 @@
+from flask import Blueprint, render_template, request, redirect, url_for, flash, jsonify
+from flask_login import login_required, current_user
+from crunevo.extensions import db
+from crunevo.models.internship import Internship, InternshipApplication
+
+internship_bp = Blueprint("internship", __name__)
+
+
+@internship_bp.route("/internships")
+def list_internships():
+    field = request.args.get("field", "")
+    location = request.args.get("location", "")
+    query = Internship.query
+    if field:
+        query = query.filter(Internship.field.ilike(f"%{field}%"))
+    if location:
+        query = query.filter(Internship.location.ilike(f"%{location}%"))
+    internships = query.order_by(Internship.posted_at.desc()).all()
+    return render_template(
+        "internship/list.html",
+        internships=internships,
+        field=field,
+        location=location,
+    )
+
+
+@internship_bp.route("/internships/<int:internship_id>")
+def view_internship(internship_id):
+    internship = Internship.query.get_or_404(internship_id)
+    has_applied = False
+    if current_user.is_authenticated:
+        has_applied = (
+            InternshipApplication.query.filter_by(
+                internship_id=internship.id, user_id=current_user.id
+            ).first()
+            is not None
+        )
+    return render_template(
+        "internship/detail.html", internship=internship, has_applied=has_applied
+    )
+
+
+@internship_bp.route("/internships/post", methods=["GET", "POST"])
+@login_required
+def post_internship():
+    if request.method == "POST":
+        title = request.form.get("title")
+        description = request.form.get("description")
+        field = request.form.get("field")
+        location = request.form.get("location")
+        company = request.form.get("company")
+        internship = Internship(
+            title=title,
+            description=description,
+            field=field,
+            location=location,
+            company=company,
+        )
+        db.session.add(internship)
+        db.session.commit()
+        flash("Práctica publicada correctamente")
+        return redirect(url_for("internship.list_internships"))
+    return render_template("internship/post.html")
+
+
+@internship_bp.route("/internships/<int:internship_id>/apply", methods=["POST"])
+@login_required
+def apply_internship(internship_id):
+    Internship.query.get_or_404(internship_id)
+    cover_letter = request.form.get("cover_letter")
+    existing = InternshipApplication.query.filter_by(
+        internship_id=internship_id, user_id=current_user.id
+    ).first()
+    if existing:
+        return jsonify({"error": "Ya aplicaste"}), 400
+    application = InternshipApplication(
+        internship_id=internship_id,
+        user_id=current_user.id,
+        cover_letter=cover_letter,
+    )
+    db.session.add(application)
+    db.session.commit()
+    flash("Aplicación enviada")
+    return jsonify({"success": True})

--- a/crunevo/templates/internship/detail.html
+++ b/crunevo/templates/internship/detail.html
@@ -1,0 +1,28 @@
+{% extends 'base.html' %}
+{% import 'components/csrf.html' as csrf %}
+
+{% block title %}{{ internship.title }}{% endblock %}
+
+{% block content %}
+<div class="container my-4">
+  <h1 class="mb-3">{{ internship.title }}</h1>
+  <p class="text-muted">{{ internship.company }} - {{ internship.location }}</p>
+  <p>{{ internship.description }}</p>
+  {% if current_user.is_authenticated %}
+    {% if has_applied %}
+      <div class="alert alert-success">Ya aplicaste a esta práctica.</div>
+    {% else %}
+      <form method="post" action="{{ url_for('internship.apply_internship', internship_id=internship.id) }}" class="card p-3">
+        {{ csrf.csrf_field() }}
+        <div class="mb-3">
+          <label class="form-label">Carta de Presentación</label>
+          <textarea name="cover_letter" class="form-control" rows="4"></textarea>
+        </div>
+        <button type="submit" class="btn btn-primary">Aplicar</button>
+      </form>
+    {% endif %}
+  {% else %}
+    <p>Inicia sesión para aplicar.</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/crunevo/templates/internship/list.html
+++ b/crunevo/templates/internship/list.html
@@ -1,0 +1,30 @@
+{% extends 'base.html' %}
+
+{% block title %}Prácticas{% endblock %}
+
+{% block content %}
+<div class="container my-4">
+  <h1 class="mb-3">Prácticas</h1>
+  <form method="get" class="row g-2 mb-4">
+    <div class="col-md-4">
+      <input type="text" name="field" class="form-control" placeholder="Área" value="{{ field }}">
+    </div>
+    <div class="col-md-4">
+      <input type="text" name="location" class="form-control" placeholder="Ubicación" value="{{ location }}">
+    </div>
+    <div class="col-md-4">
+      <button class="btn btn-primary w-100" type="submit">Filtrar</button>
+    </div>
+  </form>
+  <div class="list-group">
+    {% for internship in internships %}
+    <a href="{{ url_for('internship.view_internship', internship_id=internship.id) }}" class="list-group-item list-group-item-action">
+      <h5 class="mb-1">{{ internship.title }}</h5>
+      <small class="text-muted">{{ internship.company }} - {{ internship.location }}</small>
+    </a>
+    {% else %}
+    <p>No hay resultados.</p>
+    {% endfor %}
+  </div>
+</div>
+{% endblock %}

--- a/crunevo/templates/internship/post.html
+++ b/crunevo/templates/internship/post.html
@@ -1,0 +1,36 @@
+{% extends 'base.html' %}
+{% import 'components/csrf.html' as csrf %}
+
+{% block title %}Publicar Práctica{% endblock %}
+
+{% block content %}
+<div class="container my-4">
+  <h1 class="mb-3">Publicar Práctica</h1>
+  <form method="post" class="card p-4">
+    {{ csrf.csrf_field() }}
+    <div class="mb-3">
+      <label class="form-label">Título</label>
+      <input type="text" name="title" class="form-control" required>
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Descripción</label>
+      <textarea name="description" class="form-control" rows="4"></textarea>
+    </div>
+    <div class="row">
+      <div class="col-md-4 mb-3">
+        <label class="form-label">Área</label>
+        <input type="text" name="field" class="form-control">
+      </div>
+      <div class="col-md-4 mb-3">
+        <label class="form-label">Ubicación</label>
+        <input type="text" name="location" class="form-control">
+      </div>
+      <div class="col-md-4 mb-3">
+        <label class="form-label">Empresa</label>
+        <input type="text" name="company" class="form-control">
+      </div>
+    </div>
+    <button type="submit" class="btn btn-primary">Publicar</button>
+  </form>
+</div>
+{% endblock %}

--- a/migrations/versions/add_internship_models.py
+++ b/migrations/versions/add_internship_models.py
@@ -1,0 +1,58 @@
+"""add internship models
+
+Revision ID: add_internship_models
+Revises: 4c29ad8b8c1a
+Create Date: 2025-12-31 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def has_table(name: str, conn) -> bool:
+    inspector = sa.inspect(conn)
+    return name in inspector.get_table_names()
+
+
+revision = "add_internship_models"
+down_revision = "4c29ad8b8c1a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    if not has_table("internship", conn):
+        op.create_table(
+            "internship",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("title", sa.String(length=200), nullable=False),
+            sa.Column("description", sa.Text(), nullable=True),
+            sa.Column("field", sa.String(length=100), nullable=True),
+            sa.Column("location", sa.String(length=100), nullable=True),
+            sa.Column("company", sa.String(length=100), nullable=True),
+            sa.Column("posted_at", sa.DateTime(), nullable=True),
+            if_not_exists=True,
+        )
+    if not has_table("internship_application", conn):
+        op.create_table(
+            "internship_application",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "internship_id",
+                sa.Integer(),
+                sa.ForeignKey("internship.id"),
+                nullable=False,
+            ),
+            sa.Column(
+                "user_id", sa.Integer(), sa.ForeignKey("user.id"), nullable=False
+            ),
+            sa.Column("cover_letter", sa.Text(), nullable=True),
+            sa.Column("applied_at", sa.DateTime(), nullable=True),
+            if_not_exists=True,
+        )
+
+
+def downgrade():
+    op.drop_table("internship_application", if_exists=True)
+    op.drop_table("internship", if_exists=True)


### PR DESCRIPTION
## Summary
- introduce `Internship` and `InternshipApplication` models
- add blueprint to list, post and apply for internships with filters
- register internship blueprint in the app
- document the change in AGENTS log

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6869683b2584832583833d41159313be