### PR TITLE
Fix long migration ID

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -614,3 +614,4 @@
 - Added LinkedIn sharing and posting for certificates with OAuth integration (PR linkedin-share)
 - Added Internship model with application routes and filters by field/location (PR internship-system).
 - Generated PDF invoices after each purchase and added profile tab to download them (PR invoice-download).
+- Shortened Alembic revision ID to `user_block_attachment` and updated dependencies to fit varchar(32) limit (PR revision-length-fix).

--- a/migrations/versions/add_purchase_shipping_fields.py
+++ b/migrations/versions/add_purchase_shipping_fields.py
@@ -10,7 +10,7 @@ def has_col(table: str, column: str, conn) -> bool:
 
 
 revision = "add_purchase_shipping_fields"
-down_revision = ("add_group_mission", "add_user_block_and_message_attachment")
+down_revision = ("add_group_mission", "user_block_attachment")
 branch_labels = None
 depends_on = None
 

--- a/migrations/versions/add_user_block_and_message_attachment.py
+++ b/migrations/versions/add_user_block_and_message_attachment.py
@@ -1,6 +1,6 @@
 """add user_block table and message attachment_url column
 
-Revision ID: add_user_block_and_message_attachment
+Revision ID: user_block_attachment
 Revises: add_story_model
 Create Date: 2025-07-15 00:00:00.000000
 """
@@ -19,7 +19,7 @@ def has_col(table: str, column: str, conn) -> bool:
     return any(c["name"] == column for c in inspector.get_columns(table))
 
 
-revision = "add_user_block_and_message_attachment"
+revision = "user_block_attachment"
 down_revision = "2ae2987611ab"
 branch_labels = None
 depends_on = None


### PR DESCRIPTION
## Summary
- shorten revision ID in user block/attachment migration
- update purchase shipping migration dependency
- document change in AGENTS guidelines

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68696d3d72a48325a441780fa928f8cd