### PR TITLE
Fix user_block migration conflict

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -615,3 +615,4 @@
 - Added Internship model with application routes and filters by field/location (PR internship-system).
 - Generated PDF invoices after each purchase and added profile tab to download them (PR invoice-download).
 - Shortened Alembic revision ID to `user_block_attachment` and updated dependencies to fit varchar(32) limit (PR revision-length-fix).
+- Dropped leftover sequence before creating `user_block` table to avoid UniqueViolation on repeated migrations (PR user-block-sequence-fix).

--- a/migrations/versions/add_user_block_and_message_attachment.py
+++ b/migrations/versions/add_user_block_and_message_attachment.py
@@ -28,6 +28,9 @@ depends_on = None
 def upgrade():
     conn = op.get_bind()
     if not has_table("user_block", conn):
+        # drop leftover sequence from aborted attempts to avoid duplicate
+        # sequence errors when creating the table
+        op.execute(sa.text("DROP SEQUENCE IF EXISTS user_block_id_seq CASCADE"))
         op.create_table(
             "user_block",
             sa.Column("id", sa.Integer(), primary_key=True),


### PR DESCRIPTION
## Summary
- fix `add_user_block_and_message_attachment` migration by dropping leftover sequence first
- document fix in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68696f7c6cb08325b12412c33fa92b6f