### PR TITLE
Reorder mobile nav and sidebar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -622,3 +622,4 @@
 - Added Tailwind utility classes to personal space templates and ensured formatting/tests pass (PR personal-space-tailwind-fix).
 - Dropped leftover sequence before creating `personal_block` table to avoid UniqueViolation errors (PR personal-block-sequence-fix).
 - Patched RFC6455WebSocket.close to ignore EBADF errors and remove remaining "Bad file descriptor" logs (PR websocket-rfc6455-fix).
+- Reordered sidebar item "Mi Espacio Personal" under "Mi Perfil" and centered profile icon on mobile navbar while removing "Buscar" and "Mi Espacio" links (PR mobile-nav-sidebar-reorder).

--- a/crunevo/templates/components/mobile_bottom_nav.html
+++ b/crunevo/templates/components/mobile_bottom_nav.html
@@ -11,14 +11,6 @@
           <span class="nav-label">Inicio</span>
         </a>
 
-        <!-- Search -->
-        <a href="{{ url_for('search.search_page') if 'search.search_page' in url_for.__globals__.get('current_app', {}).view_functions else '#' }}"
-           class="nav-item {{ 'active' if request.endpoint == 'search.search_page' }}">
-          <div class="nav-icon">
-            <i class="bi bi-search"></i>
-          </div>
-          <span class="nav-label">Buscar</span>
-        </a>
 
         <!-- Notes -->
         <a href="{{ url_for('notes.list_notes') if 'notes.list_notes' in url_for.__globals__.get('current_app', {}).view_functions else '#' }}"
@@ -29,30 +21,15 @@
           <span class="nav-label">Apuntes</span>
         </a>
 
-        <!-- Notifications -->
-        <a href="{{ url_for('noti.ver_notificaciones') if 'noti.ver_notificaciones' in url_for.__globals__.get('current_app', {}).view_functions else '#' }}"
-           class="nav-item position-relative {{ 'active' if request.endpoint == 'noti.ver_notificaciones' }}">
-          <div class="nav-icon">
-            <i class="bi bi-bell{{ '-fill' if request.endpoint == 'noti.ver_notificaciones' }}"></i>
-            {% if current_user.is_authenticated %}
-            <span id="mobileNotificationBadge" 
-                  class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger notification-badge">
-              {{ current_user.unread_notifications_count or '' }}
-            </span>
-            {% endif %}
-          </div>
-          <span class="nav-label">Alertas</span>
-        </a>
-
         <!-- Profile -->
         <a href="{{ url_for('auth.perfil') if 'auth.perfil' in url_for.__globals__.get('current_app', {}).view_functions else '#' }}"
            class="nav-item {{ 'active' if request.endpoint == 'auth.perfil' }}">
           <div class="nav-icon">
             {% if current_user.is_authenticated %}
-            <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" 
-                 class="rounded-circle border" 
-                 width="24" 
-                 height="24" 
+            <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}"
+                 class="rounded-circle border"
+                 width="24"
+                 height="24"
                  alt="Perfil">
             {% else %}
             <i class="bi bi-person-circle"></i>
@@ -60,13 +37,24 @@
           </div>
           <span class="nav-label">Perfil</span>
         </a>
+
+        <!-- Notifications -->
+        <a href="{{ url_for('noti.ver_notificaciones') if 'noti.ver_notificaciones' in url_for.__globals__.get('current_app', {}).view_functions else '#' }}"
+           class="nav-item position-relative {{ 'active' if request.endpoint == 'noti.ver_notificaciones' }}">
+          <div class="nav-icon">
+            <i class="bi bi-bell{{ '-fill' if request.endpoint == 'noti.ver_notificaciones' }}"></i>
+            {% if current_user.is_authenticated %}
+            <span id="mobileNotificationBadge"
+                  class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger notification-badge">
+              {{ current_user.unread_notifications_count or '' }}
+            </span>
+            {% endif %}
+          </div>
+          <span class="nav-label">Alertas</span>
+        </a>
       <a href="{{ url_for('store.store_index') }}" class="nav-item {% if request.endpoint and 'store' in request.endpoint %}active{% endif %}">
         <i class="bi bi-shop"></i>
         <span>Tienda</span>
-      </a>
-      <a href="{{ url_for('personal_space.index') }}" class="nav-item {% if request.endpoint and 'personal_space' in request.endpoint %}active{% endif %}">
-        <i class="bi bi-house-gear"></i>
-        <span>Mi Espacio</span>
       </a>
       </div>
     </div>

--- a/crunevo/templates/components/sidebar_left_feed.html
+++ b/crunevo/templates/components/sidebar_left_feed.html
@@ -55,6 +55,14 @@
         </li>
 
         <li>
+          <a href="{{ url_for('personal_space.index') if 'personal_space.index' in url_for.__globals__.get('current_app', {}).view_functions else '/personal_space' }}" class="nav-link {{ 'active' if request.endpoint == 'personal_space.index' }}">
+            <i class="bi bi-house-gear"></i>
+            <span class="fw-semibold">Mi Espacio Personal</span>
+          </a>
+        </li>
+
+
+        <li>
           <a href="{{ url_for('notes.list_notes') if 'notes.list_notes' in url_for.__globals__.get('current_app', {}).view_functions else '/notes' }}" class="nav-link {{ 'active' if request.endpoint == 'notes.list_notes' }}">
             <i class="bi bi-journal-text"></i>
             <span class="fw-semibold">Apuntes</span>
@@ -110,12 +118,6 @@
           <a href="{{ url_for('ranking.index') if 'ranking.index' in url_for.__globals__.get('current_app', {}).view_functions else '/ranking' }}" class="nav-link {{ 'active' if request.endpoint == 'ranking.index' }}">
             <i class="bi bi-award"></i>
             <span class="fw-semibold">Ranking</span>
-          </a>
-        </li>
-          <li>
-          <a href="{{ url_for('personal_space.index') if 'personal_space.index' in url_for.__globals__.get('current_app', {}).view_functions else '/personal_space' }}" class="nav-link {{ 'active' if request.endpoint == 'personal_space.index' }}">
-            <i class="bi bi-house-gear"></i>
-            <span class="fw-semibold">Mi Espacio Personal</span>
           </a>
         </li>
 


### PR DESCRIPTION
## Summary
- remove search and personal space links from mobile bottom nav
- center profile link on mobile bottom nav
- move "Mi Espacio Personal" below "Mi Perfil" in sidebar
- document changes in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6869fe9fb238832592d3aba12961df98