### PR TITLE
Fix onboarding confirm login

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -622,3 +622,4 @@
 - Added Tailwind utility classes to personal space templates and ensured formatting/tests pass (PR personal-space-tailwind-fix).
 - Dropped leftover sequence before creating `personal_block` table to avoid UniqueViolation errors (PR personal-block-sequence-fix).
 - Patched RFC6455WebSocket.close to ignore EBADF errors and remove remaining "Bad file descriptor" logs (PR websocket-rfc6455-fix).
+- Forzamos login con force=True en la ruta de confirmación para evitar sesiones desactualizadas y redirecciones al pending. (PR confirm-force-login)

--- a/crunevo/routes/onboarding_routes.py
+++ b/crunevo/routes/onboarding_routes.py
@@ -149,7 +149,9 @@ def confirm(token):
     db.session.commit()
     db.session.refresh(record.user)
     record_auth_event(record.user, "confirm_email")
-    login_user(record.user, fresh=True)
+    # Force login to ensure session updates even if a different user
+    # was previously authenticated
+    login_user(record.user, fresh=True, force=True)
     # Remove stale flash messages from previous requests
     session.pop("_flashes", None)
     flash("¡Correo verificado! Bienvenido a CRUNEVO", "success")


### PR DESCRIPTION
## Summary
- force login after confirming email token so the session refreshes
- document fix in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6869ff482ab083258be6efdc7625e629