### PR TITLE
Fix onboarding confirm login

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -622,3 +622,5 @@
 - Added Tailwind utility classes to personal space templates and ensured formatting/tests pass (PR personal-space-tailwind-fix).
 - Dropped leftover sequence before creating `personal_block` table to avoid UniqueViolation errors (PR personal-block-sequence-fix).
 - Patched RFC6455WebSocket.close to ignore EBADF errors and remove remaining "Bad file descriptor" logs (PR websocket-rfc6455-fix).
+- Forzamos login con force=True en la ruta de confirmación para evitar sesiones desactualizadas y redirecciones al pending. (PR confirm-force-login)
+- Added test to ensure only success flash after email confirmation and no pending redirect (PR confirm-feed-flash-test).

--- a/crunevo/routes/onboarding_routes.py
+++ b/crunevo/routes/onboarding_routes.py
@@ -149,7 +149,9 @@ def confirm(token):
     db.session.commit()
     db.session.refresh(record.user)
     record_auth_event(record.user, "confirm_email")
-    login_user(record.user, fresh=True)
+    # Force login to ensure session updates even if a different user
+    # was previously authenticated
+    login_user(record.user, fresh=True, force=True)
     # Remove stale flash messages from previous requests
     session.pop("_flashes", None)
     flash("¡Correo verificado! Bienvenido a CRUNEVO", "success")

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -125,3 +125,19 @@ def test_confirm_logs_in_and_allows_feed_access(client, db_session):
     assert resp.headers["Location"].endswith("/feed/")
     resp2 = client.get("/feed/", follow_redirects=False)
     assert resp2.status_code == 200
+
+
+# new test for flash message
+
+
+def test_confirm_shows_success_no_pending(client, db_session):
+    user = User(username="msgcheck", email="msgcheck@example.com")
+    user.set_password("StrongPassw0rd!")
+    db_session.add(user)
+    db_session.commit()
+    token = EmailToken(user_id=user.id, email=user.email)
+    db_session.add(token)
+    db_session.commit()
+    resp = client.get(f"/onboarding/confirm/{token.token}", follow_redirects=True)
+    assert b"Correo verificado" in resp.data
+    assert b"Primero debes confirmar tu correo" not in resp.data


### PR DESCRIPTION
## Summary
- force login after confirming email token so the session refreshes
- added regression test verifying only success flash after confirmation
- document fix in AGENTS log

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6869ff482ab083258be6efdc7625e629