### PR TITLE
Relax rate limits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -630,3 +630,4 @@
 - Fixed Replit gamification feature errors, restored sidebar template, removed empty migration and ensured tests pass (PR replit-gamification-fixes).
 - Handled missing crolars_hall_member table with get_hall_membership helper and template update (PR hall-membership-safe).
 - Added table_exists helper and login requirement to activated_required; routes skip queries if tables are missing (PR log-error-fix).
+- Relaxed default Flask-Limiter to 1000/day and removed limits from store and developer routes, keeping limits only on login and onboarding (PR rate-limit-tweak).

--- a/crunevo/extensions.py
+++ b/crunevo/extensions.py
@@ -20,7 +20,8 @@ migrate = Migrate()
 login_manager = LoginManager()
 mail = Mail()
 csrf = CSRFProtect()
-limiter = Limiter(key_func=get_remote_address, default_limits=["200 per day"])
+# Relax default rate limits to avoid blocking normal usage
+limiter = Limiter(key_func=get_remote_address, default_limits=["1000 per day"])
 talisman = Talisman()
 # Use eventlet for async WebSocket support
 

--- a/crunevo/routes/developer_routes.py
+++ b/crunevo/routes/developer_routes.py
@@ -2,7 +2,7 @@ from flask import Blueprint, jsonify, request, g
 from flask_login import login_required, current_user
 from flask_limiter.util import get_remote_address
 
-from crunevo.extensions import db, limiter
+from crunevo.extensions import db
 from crunevo.models import Post, Note, APIKey
 
 
@@ -37,7 +37,6 @@ def api_key_required(f):
 
 
 @developer_bp.route("/recent-posts")
-@limiter.limit("30 per minute", key_func=api_key_func)
 @api_key_required
 def recent_posts():
     posts = Post.query.order_by(Post.created_at.desc()).limit(10).all()
@@ -50,7 +49,6 @@ def recent_posts():
 
 
 @developer_bp.route("/popular-notes")
-@limiter.limit("30 per minute", key_func=api_key_func)
 @api_key_required
 def popular_notes():
     notes = Note.query.order_by(Note.likes.desc()).limit(10).all()

--- a/crunevo/routes/store_routes.py
+++ b/crunevo/routes/store_routes.py
@@ -14,7 +14,7 @@ from datetime import datetime, timedelta
 from flask_login import current_user
 from flask import current_app
 from crunevo.utils.helpers import activated_required
-from crunevo.extensions import db, limiter
+from crunevo.extensions import db
 from crunevo.models import (
     Product,
     ProductLog,
@@ -158,7 +158,6 @@ def view_product(product_id):
 
 @store_bp.route("/product/<int:product_id>/review", methods=["POST"])
 @activated_required
-@limiter.limit("5 per minute")
 def add_review(product_id: int):
     """Allow a user to leave a review for a purchased product."""
     if not has_purchased(current_user.id, product_id):


### PR DESCRIPTION
## Summary
- set default limit to 1000/day
- drop limiter from store reviews and developer API routes
- log the change in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686a24845f3083259357792586d3c926