### PR TITLE
Fix account activation redirect and add rate limit page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -631,3 +631,4 @@
 - Handled missing crolars_hall_member table with get_hall_membership helper and template update (PR hall-membership-safe).
 - Added table_exists helper and login requirement to activated_required; routes skip queries if tables are missing (PR log-error-fix).
 - Relaxed default Flask-Limiter to 1000/day and removed limits from store and developer routes, keeping limits only on login and onboarding (PR rate-limit-tweak).
+- Improved email confirmation flow: activated_required refreshes user from DB, added 429 error page, and removed 'Mi Espacio' from mobile nav (PR email-activation-fix).

--- a/crunevo/routes/errors.py
+++ b/crunevo/routes/errors.py
@@ -11,3 +11,8 @@ def internal_error(error):
 @errors_bp.app_errorhandler(404)
 def not_found_error(error):
     return render_template("errors/404.html"), 404
+
+
+@errors_bp.app_errorhandler(429)
+def too_many_requests(error):
+    return render_template("errors/429.html"), 429

--- a/crunevo/templates/components/mobile_bottom_nav.html
+++ b/crunevo/templates/components/mobile_bottom_nav.html
@@ -56,10 +56,6 @@
         <i class="bi bi-shop"></i>
         <span>Tienda</span>
       </a>
-      <a href="{{ url_for('personal_space.index') }}" class="nav-item {% if request.endpoint and 'personal_space' in request.endpoint %}active{% endif %}">
-        <i class="bi bi-house-gear"></i>
-        <span>Mi Espacio</span>
-      </a>
 
     <a href="{{ url_for('carrera.index') }}" class="nav-item">
       <i class="bi bi-mortarboard"></i>

--- a/crunevo/templates/errors/429.html
+++ b/crunevo/templates/errors/429.html
@@ -1,0 +1,47 @@
+{% extends "base.html" %}
+
+{% block title %}Demasiadas solicitudes - Crunevo{% endblock %}
+
+{% block content %}
+<div class="error-wrapper tw-flex tw-items-center tw-justify-center">
+  <div class="error-page position-relative text-center">
+    <button class="btn-close position-absolute top-0 end-0 m-3" onclick="this.closest('.error-wrapper').remove()" aria-label="Cerrar error"></button>
+    <div class="error-icon mb-4">
+      <i class="bi bi-hourglass-split display-1 text-warning"></i>
+    </div>
+    <h1 class="display-4 fw-bold text-warning mb-3">¡Demasiadas acciones!</h1>
+    <p class="lead text-muted mb-4">
+      Has realizado demasiadas acciones en poco tiempo. Intenta nuevamente en unos minutos.
+    </p>
+    <a href="{{ url_for('feed.feed_home') }}" class="btn btn-primary btn-lg">
+      <i class="bi bi-house-fill me-2"></i>Regresar al inicio
+    </a>
+  </div>
+</div>
+
+<style>
+.error-page {
+  padding: 2rem;
+  background: rgba(255, 193, 7, 0.03);
+  border-radius: 20px;
+  border: 1px solid rgba(255, 193, 7, 0.1);
+}
+[data-bs-theme="dark"] .error-page {
+  background: rgba(255, 193, 7, 0.05);
+  border-color: rgba(255, 255, 255, 0.1);
+}
+.error-icon {
+  animation: pulse 1.5s ease-in-out infinite;
+}
+@keyframes pulse {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.1); }
+  100% { transform: scale(1); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .error-icon {
+    animation: none;
+  }
+}
+</style>
+{% endblock %}

--- a/crunevo/utils/helpers.py
+++ b/crunevo/utils/helpers.py
@@ -2,6 +2,7 @@ from functools import wraps
 from datetime import datetime
 from flask import redirect, url_for, flash
 from flask_login import current_user, login_required
+from crunevo.models import User
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy import inspect
 
@@ -42,9 +43,11 @@ def activated_required(f):
     @wraps(f)
     @login_required
     def decorated_function(*args, **kwargs):
-        if not current_user.activated:
-            flash("Debes activar tu cuenta para acceder a esta función.", "warning")
-            return redirect(url_for("auth.perfil"))
+        if table_exists("user"):
+            user = User.query.get(current_user.id)
+            if not user or not user.activated:
+                flash("Debes activar tu cuenta para acceder a esta función.", "warning")
+                return redirect(url_for("onboarding.pending"))
         return f(*args, **kwargs)
 
     return decorated_function


### PR DESCRIPTION
## Summary
- update `activated_required` to refresh from DB and send unverified users to onboarding
- handle HTTP 429 errors with a friendly template
- remove deprecated personal space link from the mobile bottom nav
- log changes in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686a27f720ac8325bacd704c70da91e4