### PR TITLE
Fix onboarding flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -633,3 +633,5 @@
 - Relaxed default Flask-Limiter to 1000/day and removed limits from store and developer routes, keeping limits only on login and onboarding (PR rate-limit-tweak).
 - Improved email confirmation flow: activated_required refreshes user from DB, added 429 error page, and removed 'Mi Espacio' from mobile nav (PR email-activation-fix).
 - Added missing templates for Ghost Mentor challenge and League team creation; fixed backpack template when table missing (PR log-fixes-templates).
+
+- Fixed optional alias update to avoid NULL username and added /onboarding/confirm page with redirect after register. Updated test expectations (PR register-confirm-redirect).

--- a/crunevo/routes/onboarding_routes.py
+++ b/crunevo/routes/onboarding_routes.py
@@ -97,16 +97,21 @@ def register():
                         db.session.commit()
                 except (ProgrammingError, OperationalError):
                     db.session.rollback()
-        success, error = send_confirmation_email(user)
-        if not success:
-            flash(
-                "No se pudo enviar el correo de confirmación. Inténtalo más tarde.",
-                "danger",
-            )
-            if error:
-                flash(error, "danger")
-        return render_template("onboarding/confirm.html")
-    return render_template("onboarding/register.html")
+    success, error = send_confirmation_email(user)
+    if not success:
+        flash(
+            "No se pudo enviar el correo de confirmación. Inténtalo más tarde.",
+            "danger",
+        )
+        if error:
+            flash(error, "danger")
+    return redirect(url_for("onboarding.confirm_sent"))
+
+
+@bp.route("/confirm")
+def confirm_sent():
+    """Display page instructing the user to check their email."""
+    return render_template("onboarding/confirm.html")
 
 
 @bp.route("/confirm/<token>")
@@ -162,7 +167,9 @@ def confirm(token):
 @login_required
 def finish():
     if request.method == "POST":
-        current_user.username = request.form.get("alias")
+        alias = request.form.get("alias")
+        if alias:
+            current_user.username = alias
         avatar_url = request.form.get("avatar_url")
         avatar_file = request.files.get("avatar_file")
         if avatar_file and avatar_file.filename:

--- a/tests/test_password_policy.py
+++ b/tests/test_password_policy.py
@@ -17,6 +17,6 @@ def test_register_strong_password(client):
             "/onboarding/register",
             data={"email": "ok@example.com", "password": "StrongPassw0rd!"},
         )
-        assert resp.status_code == 200
+        assert resp.status_code == 302
         assert len(outbox) == 1
     assert User.query.filter_by(email="ok@example.com").first() is not None


### PR DESCRIPTION
## Summary
- redirect to `/onboarding/confirm` after registering
- add `confirm_sent` route and avoid setting username when alias empty
- adjust tests for new redirect
- document changes in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686a2e6def6c8325be9e39f44237b78d