### PR TITLE
Update confirm email validity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -635,3 +635,4 @@
 - Added missing templates for Ghost Mentor challenge and League team creation; fixed backpack template when table missing (PR log-fixes-templates).
 
 - Fixed optional alias update to avoid NULL username and added /onboarding/confirm page with redirect after register. Updated test expectations (PR register-confirm-redirect).
+- Actualizado correo de confirmación indicando que el enlace es válido por 1 hora (PR confirm-link-validity).

--- a/crunevo/templates/emails/confirm.html
+++ b/crunevo/templates/emails/confirm.html
@@ -18,7 +18,7 @@
                 <p style="color:#333;font-size:16px;line-height:1.4;margin:16px 0;">¡Hola! 👋<br>Estamos felices de que formes parte de <strong>CRUNEVO</strong>, la comunidad educativa donde compartir conocimiento es divertido y valioso.</p>
                 <p style="margin:16px 0;color:#333;font-size:16px;">Para activar tu cuenta y empezar tu aventura educativa, haz clic en el siguiente botón:</p>
                 <a href="{{ confirm_url }}" style="background-color:#7B2CBF;color:#ffffff;text-decoration:none;padding:14px 26px;border-radius:12px;display:inline-block;font-weight:bold;font-size:16px;box-shadow:0px 4px 10px rgba(0,0,0,0.2);">Activar mi cuenta ahora</a>
-                <p style="font-size:14px;color:#555;margin:20px 0 0;">El enlace es válido por 24 horas por motivos de seguridad.</p>
+                <p style="font-size:14px;color:#555;margin:20px 0 0;">El enlace es válido por 1 hora por motivos de seguridad.</p>
                 <p style="font-size:14px;color:#555;margin:0;">Si no solicitaste este registro, simplemente ignora este correo.</p>
             </td>
         </tr>


### PR DESCRIPTION
## Summary
- clarify that confirm email link only works for 1 hour
- document change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686a3919b36c8325b8f097c640216a10