### PR TITLE
Onboarding finish redirect if profile incomplete

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -635,3 +635,5 @@
 - Added missing templates for Ghost Mentor challenge and League team creation; fixed backpack template when table missing (PR log-fixes-templates).
 
 - Fixed optional alias update to avoid NULL username and added /onboarding/confirm page with redirect after register. Updated test expectations (PR register-confirm-redirect).
+
+- Onboarding confirm ahora redirige a /onboarding/finish si el perfil usa datos por defecto y se actualizan las pruebas (PR onboarding-finish-redirect).

--- a/crunevo/routes/onboarding_routes.py
+++ b/crunevo/routes/onboarding_routes.py
@@ -19,6 +19,7 @@ from werkzeug.utils import secure_filename
 from crunevo.extensions import db, limiter, csrf
 from flask_limiter.util import get_remote_address
 from crunevo.models import User, EmailToken
+from crunevo.models.user import DEFAULT_AVATAR_URL
 from crunevo.utils.mailer import send_email
 from crunevo.utils.audit import record_auth_event
 import re
@@ -160,6 +161,9 @@ def confirm(token):
     # Remove stale flash messages from previous requests
     session.pop("_flashes", None)
     flash("¡Correo verificado! Bienvenido a CRUNEVO", "success")
+    user = record.user
+    if user.username == user.email or user.avatar_url == DEFAULT_AVATAR_URL:
+        return redirect(url_for("onboarding.finish"))
     return redirect(url_for("feed.feed_home"))
 
 


### PR DESCRIPTION
## Summary
- check avatar and username after login in onboarding confirm
- redirect to finish page if profile is incomplete
- adjust confirm tests and add new case
- document the change in **AGENTS.md**

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686a3f3c07408325878a370eed1e1c7c