### PR TITLE
Fix onboarding finish activation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -637,3 +637,4 @@
 - Onboarding confirm ahora redirige a /onboarding/finish si el perfil usa datos por defecto y se actualizan las pruebas (PR onboarding-finish-redirect).
 
 - Actualizado correo de confirmación indicando que el enlace es válido por 1 hora (PR confirm-link-validity).
+- Finish route activates user and refreshes session to prevent stuck pending state (PR onboarding-finish-activate-login).

--- a/crunevo/routes/onboarding_routes.py
+++ b/crunevo/routes/onboarding_routes.py
@@ -193,7 +193,10 @@ def finish():
         current_user.about = request.form.get("bio")
         current_user.career = request.form.get("career")
         current_user.interests = request.form.get("interests")
+        # Ensure the user is activated and session updated
+        current_user.activated = True
         db.session.commit()
+        login_user(current_user, fresh=True, force=True)
         return redirect(url_for("feed.feed_home"))
     return render_template("onboarding/finish.html")
 


### PR DESCRIPTION
## Summary
- refresh login and ensure user is activated when completing profile
- note the change in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686ac315c89c8325a72f234699835442