### PR TITLE
Fix onboarding finish activation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -637,3 +637,5 @@
 - Onboarding confirm ahora redirige a /onboarding/finish si el perfil usa datos por defecto y se actualizan las pruebas (PR onboarding-finish-redirect).
 
 - Actualizado correo de confirmación indicando que el enlace es válido por 1 hora (PR confirm-link-validity).
+- Finish route activates user and refreshes session to prevent stuck pending state (PR onboarding-finish-activate-login).
+- Finish route refreshes user and clears flashes; added test ensuring feed access after completing profile (PR finish-refresh-test).


### PR DESCRIPTION
## Summary
- refresh login and ensure user is activated when completing profile
- document the change in AGENTS

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686ac315c89c8325a72f234699835442