### PR TITLE
Fix onboarding register GET

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -639,3 +639,4 @@
 - Actualizado correo de confirmación indicando que el enlace es válido por 1 hora (PR confirm-link-validity).
 - Finish route activates user and refreshes session to prevent stuck pending state (PR onboarding-finish-activate-login).
 - Finish route refreshes user and clears flashes; added test ensuring feed access after completing profile (PR finish-refresh-test).
+- Fixed UnboundLocalError in onboarding register GET by only sending email after POST and returning template on GET (PR register-user-fix).

--- a/crunevo/routes/onboarding_routes.py
+++ b/crunevo/routes/onboarding_routes.py
@@ -53,7 +53,7 @@ def register():
     if request.method == "POST":
         email = request.form["email"]
         if not re.fullmatch(r"[^@\s]+@[^@\s]+\.[^@\s]+", email):
-            flash("Ingresa un correo v\u00e1lido", "danger")
+            flash("Ingresa un correo válido", "danger")
             return render_template("onboarding/register.html"), 400
         password = request.form["password"]
         if (
@@ -98,15 +98,18 @@ def register():
                         db.session.commit()
                 except (ProgrammingError, OperationalError):
                     db.session.rollback()
-    success, error = send_confirmation_email(user)
-    if not success:
-        flash(
-            "No se pudo enviar el correo de confirmación. Inténtalo más tarde.",
-            "danger",
-        )
-        if error:
-            flash(error, "danger")
-    return redirect(url_for("onboarding.confirm_sent"))
+
+        success, error = send_confirmation_email(user)
+        if not success:
+            flash(
+                "No se pudo enviar el correo de confirmación. Inténtalo más tarde.",
+                "danger",
+            )
+            if error:
+                flash(error, "danger")
+        return redirect(url_for("onboarding.confirm_sent"))
+
+    return render_template("onboarding/register.html")
 
 
 @bp.route("/confirm")


### PR DESCRIPTION
## Summary
- on /onboarding/register only send email after successful POST
- return template when requesting GET
- document change in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686ad5814c0c8325a85983929d548ddf