### PR TITLE
Fix store link for admin instance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -640,3 +640,4 @@
 - Finish route activates user and refreshes session to prevent stuck pending state (PR onboarding-finish-activate-login).
 - Finish route refreshes user and clears flashes; added test ensuring feed access after completing profile (PR finish-refresh-test).
 - Fixed UnboundLocalError in onboarding register GET by only sending email after POST and returning template on GET (PR register-user-fix).
+- Mobile bottom nav store link uses fallback to "/" when store blueprint missing to prevent BuildError (PR store-link-fallback).

--- a/crunevo/templates/components/mobile_bottom_nav.html
+++ b/crunevo/templates/components/mobile_bottom_nav.html
@@ -52,7 +52,8 @@
           </div>
           <span class="nav-label">Alertas</span>
         </a>
-      <a href="{{ url_for('store.store_index') }}" class="nav-item {% if request.endpoint and 'store' in request.endpoint %}active{% endif %}">
+      <a href="{{ url_for('store.store_index') if 'store.store_index' in url_for.__globals__.get('current_app', {}).view_functions else '/' }}"
+         class="nav-item {% if request.endpoint and 'store' in request.endpoint %}active{% endif %}">
         <i class="bi bi-shop"></i>
         <span>Tienda</span>
       </a>


### PR DESCRIPTION
## Summary
- avoid BuildError in admin instance by checking store blueprint before linking
- document change in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686add73813883259a8d2946c78cf3dd