### PR TITLE
Enable personal space functionality

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -643,3 +643,4 @@
 - Mobile bottom nav store link uses fallback to "/" when store blueprint missing to prevent BuildError (PR store-link-fallback).
 - Mobile bottom nav and navbar career links use fallback to '/micarrera' when the career blueprint is missing (PR career-link-fallback).
 - Enhanced personal space with Notion-style notes, Trello-style tasks and dashboard metrics (PR personal-space-workspace).
+- Activated and fixed personal space: suggestions create blocks, initial template via "Comenzar" button, dark mode syncs with global theme and API routes require activated login (PR personal-space-activation).

--- a/crunevo/routes/personal_space_routes.py
+++ b/crunevo/routes/personal_space_routes.py
@@ -34,6 +34,7 @@ def index():
 
 @personal_space_bp.route("/api/blocks", methods=["GET"])
 @login_required
+@activated_required
 def get_blocks():
     """API endpoint to get all user blocks"""
     blocks = (
@@ -47,6 +48,7 @@ def get_blocks():
 
 @personal_space_bp.route("/api/blocks", methods=["POST"])
 @login_required
+@activated_required
 def create_block():
     """Create a new personal block"""
     data = request.get_json()
@@ -128,6 +130,7 @@ def create_block():
 
 @personal_space_bp.route("/api/blocks/<int:block_id>", methods=["PUT"])
 @login_required
+@activated_required
 def update_block(block_id):
     """Update an existing block"""
     block = PersonalBlock.query.filter_by(id=block_id, user_id=current_user.id).first()
@@ -165,6 +168,7 @@ def update_block(block_id):
 
 @personal_space_bp.route("/api/blocks/<int:block_id>", methods=["DELETE"])
 @login_required
+@activated_required
 def delete_block(block_id):
     """Delete a block"""
     block = PersonalBlock.query.filter_by(id=block_id, user_id=current_user.id).first()
@@ -180,6 +184,7 @@ def delete_block(block_id):
 
 @personal_space_bp.route("/api/blocks/reorder", methods=["POST"])
 @login_required
+@activated_required
 def reorder_blocks():
     """Update block order positions"""
     data = request.get_json()
@@ -200,6 +205,7 @@ def reorder_blocks():
 
 @personal_space_bp.route("/api/suggestions")
 @login_required
+@activated_required
 def api_suggestions():
     """Get smart suggestions for the user"""
     suggestions = get_smart_suggestions()


### PR DESCRIPTION
## Summary
- allow personal space API routes only for activated users
- sync dark mode with global theme and fix suggestion actions
- add helper for creating blocks via API and starting default template
- log changes in AGENTS history

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686af11122608325ab5a8097a0906d58