### PR TITLE
Add focus mode hide and exit button

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -644,3 +644,4 @@
 - Mobile bottom nav and navbar career links use fallback to '/micarrera' when the career blueprint is missing (PR career-link-fallback).
 - Enhanced personal space with Notion-style notes, Trello-style tasks and dashboard metrics (PR personal-space-workspace).
 - Activated and fixed personal space: suggestions create blocks, initial template via "Comenzar" button, dark mode syncs with global theme and API routes require activated login (PR personal-space-activation).
+- Focus mode hides navbars and sidebars, includes floating exit button (PR focus-mode-ui).

--- a/crunevo/static/css/personal-space.css
+++ b/crunevo/static/css/personal-space.css
@@ -614,6 +614,20 @@
     box-shadow: 0 16px 48px rgba(99, 102, 241, 0.2);
 }
 
+.focus-mode .navbar,
+.focus-mode .sidebar-left,
+.focus-mode .sidebar-right,
+.focus-mode .mobile-bottom-nav {
+    display: none !important;
+}
+
+.exit-focus-btn {
+    position: fixed;
+    bottom: 90px;
+    right: 20px;
+    z-index: 1100;
+}
+
 /* Responsive Design */
 @media (max-width: 768px) {
     .ps-title {

--- a/crunevo/static/js/personal-space.js
+++ b/crunevo/static/js/personal-space.js
@@ -57,6 +57,9 @@ function initializeEventListeners() {
     // Control buttons
     document.getElementById('darkModeToggle')?.addEventListener('click', toggleDarkMode);
     document.getElementById('focusModeBtn')?.addEventListener('click', toggleFocusMode);
+    document.getElementById('exitFocusBtn')?.addEventListener('click', () => {
+        if (isFocusMode) toggleFocusMode();
+    });
 
     // Modal events
     document.addEventListener('click', handleModalEvents);
@@ -898,6 +901,16 @@ function updateDarkModeButton() {
 function toggleFocusMode() {
     isFocusMode = !isFocusMode;
     document.querySelector('.personal-space-container').classList.toggle('focus-mode', isFocusMode);
+
+    document.querySelectorAll('.navbar, .sidebar-left, .sidebar-right, .mobile-bottom-nav').forEach(el => {
+        if (!el) return;
+        el.classList.toggle('tw-hidden', isFocusMode);
+    });
+
+    const exitBtn = document.getElementById('exitFocusBtn');
+    if (exitBtn) {
+        exitBtn.classList.toggle('d-none', !isFocusMode);
+    }
 
     const button = document.getElementById('focusModeBtn');
     if (button) {

--- a/crunevo/templates/personal_space/index.html
+++ b/crunevo/templates/personal_space/index.html
@@ -153,6 +153,9 @@
     <button class="floating-add-btn d-md-none" id="floatingAddBtn">
         <i class="bi bi-plus-lg"></i>
     </button>
+    <button class="btn btn-warning exit-focus-btn d-none" id="exitFocusBtn">
+        Salir del modo enfoque
+    </button>
 </div>
 
 <!-- Add Block Modal -->


### PR DESCRIPTION
## Summary
- hide navbar, sidebar and mobile nav in focus mode
- add button to exit focus mode
- style components for focus mode overlay
- document feature in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686af93ef5e48325b9a0ae9baea8a917