### PR TITLE
Add responsive filter offcanvas to store

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -653,3 +653,4 @@
 - Fixed undefined csrf macro in store.html and added missing imports in duel, event and poll routes (PR csrf-macro-fix).
 - Imported csrf macro in view_product.html to fix template error (PR store-view-product-csrf-import).
 - Extracted inline JS from store/store.html to static/js/store.js and loaded via extra_js block (PR store-js-extract).
+- Moved sidebar filter markup into #filterOffcanvas with a floating button on mobile; off-canvas styles and JS toggling added (PR store-filter-offcanvas).

--- a/crunevo/models/duel.py
+++ b/crunevo/models/duel.py
@@ -1,4 +1,3 @@
-
 from datetime import datetime
 from crunevo.extensions import db
 
@@ -11,15 +10,21 @@ class AcademicDuel(db.Model):
     category = db.Column(db.String(50), nullable=False)
     reward_crolars = db.Column(db.Integer, default=0)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
-    status = db.Column(db.String(20), default="pending")  # pending, answered, validated, rejected
+    status = db.Column(
+        db.String(20), default="pending"
+    )  # pending, answered, validated, rejected
     answer = db.Column(db.Text)
     answered_at = db.Column(db.DateTime)
     validated_at = db.Column(db.DateTime)
     is_correct = db.Column(db.Boolean)
-    
+
     # Relationships
-    challenger = db.relationship("User", foreign_keys=[challenger_id], backref="duels_created")
-    challenged = db.relationship("User", foreign_keys=[challenged_id], backref="duels_received")
+    challenger = db.relationship(
+        "User", foreign_keys=[challenger_id], backref="duels_created"
+    )
+    challenged = db.relationship(
+        "User", foreign_keys=[challenged_id], backref="duels_received"
+    )
 
     @property
     def is_pending(self):

--- a/crunevo/models/poll.py
+++ b/crunevo/models/poll.py
@@ -1,4 +1,3 @@
-
 from datetime import datetime
 from crunevo.extensions import db
 
@@ -11,11 +10,15 @@ class Poll(db.Model):
     expires_at = db.Column(db.DateTime, nullable=False)
     is_active = db.Column(db.Boolean, default=True)
     total_votes = db.Column(db.Integer, default=0)
-    
+
     # Relationships
     author = db.relationship("User", backref="polls")
-    options = db.relationship("PollOption", backref="poll", lazy=True, cascade="all, delete-orphan")
-    votes = db.relationship("PollVote", backref="poll", lazy=True, cascade="all, delete-orphan")
+    options = db.relationship(
+        "PollOption", backref="poll", lazy=True, cascade="all, delete-orphan"
+    )
+    votes = db.relationship(
+        "PollVote", backref="poll", lazy=True, cascade="all, delete-orphan"
+    )
 
     @property
     def is_expired(self):
@@ -24,7 +27,10 @@ class Poll(db.Model):
     def get_results(self):
         if self.total_votes == 0:
             return [(option, 0) for option in self.options]
-        return [(option, (option.vote_count / self.total_votes) * 100) for option in self.options]
+        return [
+            (option, (option.vote_count / self.total_votes) * 100)
+            for option in self.options
+        ]
 
 
 class PollOption(db.Model):
@@ -32,9 +38,11 @@ class PollOption(db.Model):
     poll_id = db.Column(db.Integer, db.ForeignKey("poll.id"), nullable=False)
     text = db.Column(db.String(80), nullable=False)
     vote_count = db.Column(db.Integer, default=0)
-    
+
     # Relationships
-    votes = db.relationship("PollVote", backref="option", lazy=True, cascade="all, delete-orphan")
+    votes = db.relationship(
+        "PollVote", backref="option", lazy=True, cascade="all, delete-orphan"
+    )
 
 
 class PollVote(db.Model):
@@ -43,6 +51,6 @@ class PollVote(db.Model):
     option_id = db.Column(db.Integer, db.ForeignKey("poll_option.id"), nullable=False)
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
     voted_at = db.Column(db.DateTime, default=datetime.utcnow)
-    
+
     # Relationships
     user = db.relationship("User")

--- a/crunevo/static/css/store.css
+++ b/crunevo/static/css/store.css
@@ -813,6 +813,68 @@
   text-align: center;
 }
 
+/* Floating Filter */
+.floating-filter {
+  position: fixed;
+  bottom: 6rem;
+  right: 2rem;
+  z-index: 1000;
+}
+
+.floating-filter-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 3.5rem;
+  height: 3.5rem;
+  background: var(--primary-purple);
+  color: white;
+  border: none;
+  border-radius: 50%;
+  font-size: 1.5rem;
+  box-shadow: var(--shadow-lg);
+  transition: var(--transition);
+}
+
+.floating-filter-btn:hover {
+  background: var(--secondary-purple);
+  transform: scale(1.1);
+}
+
+/* Offcanvas Filters */
+#filterOffcanvas {
+  /* start hidden offscreen */
+}
+
+.offcanvas-mobile {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 80%;
+  max-width: 320px;
+  height: 100vh;
+  overflow-y: auto;
+  background: white;
+  box-shadow: var(--shadow-xl);
+  transform: translateX(-100%);
+  transition: var(--transition);
+  z-index: 1055;
+}
+
+.offcanvas-mobile.open {
+  transform: translateX(0);
+}
+
+@media (min-width: 992px) {
+  .offcanvas-mobile {
+    position: static;
+    transform: none;
+    height: auto;
+    width: auto;
+    box-shadow: none;
+  }
+}
+
 /* ==========================================================================
    Responsive Design
    ========================================================================== */
@@ -978,6 +1040,11 @@
 [data-bs-theme="dark"] .cart-link:hover {
   background: var(--primary-purple);
   color: white;
+}
+
+[data-bs-theme="dark"] .offcanvas-mobile {
+  background: var(--surface-white);
+  border: 1px solid var(--border-light);
 }
 
 /* ==========================================================================

--- a/crunevo/static/js/store.js
+++ b/crunevo/static/js/store.js
@@ -123,4 +123,29 @@ function showToast(toastId) {
             toggleFavorite(this);
         });
     });
+
+    const openBtn = document.getElementById('openFilterBtn');
+    const closeBtn = document.getElementById('closeFilterBtn');
+    const offcanvas = document.getElementById('filterOffcanvas');
+
+    function closeFilters() {
+        if (!offcanvas) return;
+        offcanvas.classList.remove('open');
+        offcanvas.addEventListener(
+            'transitionend',
+            () => offcanvas.classList.add('d-none'),
+            { once: true }
+        );
+    }
+
+    if (openBtn && offcanvas) {
+        openBtn.addEventListener('click', () => {
+            offcanvas.classList.remove('d-none');
+            requestAnimationFrame(() => offcanvas.classList.add('open'));
+        });
+    }
+
+    if (closeBtn) {
+        closeBtn.addEventListener('click', closeFilters);
+    }
 })();

--- a/crunevo/templates/admin/create_event.html
+++ b/crunevo/templates/admin/create_event.html
@@ -1,5 +1,6 @@
 
 {% extends "admin/base_admin.html" %}
+{% import 'components/csrf.html' as csrf %}
 
 {% block title %}Crear Evento{% endblock %}
 
@@ -13,7 +14,7 @@
                 </div>
                 <div class="card-body">
                     <form method="POST">
-                        {{ csrf_token() }}
+                        {{ csrf.csrf_field() }}
                         
                         <div class="mb-3">
                             <label for="title" class="form-label">Título *</label>

--- a/crunevo/templates/duel/create.html
+++ b/crunevo/templates/duel/create.html
@@ -1,5 +1,6 @@
 
 {% extends "base.html" %}
+{% import 'components/csrf.html' as csrf %}
 
 {% block title %}Crear Reto - CRUNEVO{% endblock %}
 
@@ -49,7 +50,7 @@
         </h2>
         
         <form method="POST">
-            {{ csrf_token() }}
+            {{ csrf.csrf_field() }}
             
             <!-- Target User -->
             <div class="mb-4">

--- a/crunevo/templates/poll/create.html
+++ b/crunevo/templates/poll/create.html
@@ -1,5 +1,6 @@
 
 {% extends "base.html" %}
+{% import 'components/csrf.html' as csrf %}
 
 {% block title %}Crear Encuesta - CRUNEVO{% endblock %}
 
@@ -60,7 +61,7 @@
         </h2>
         
         <form method="POST">
-            {{ csrf_token() }}
+            {{ csrf.csrf_field() }}
             
             <!-- Question -->
             <div class="mb-4">

--- a/crunevo/templates/store/store.html
+++ b/crunevo/templates/store/store.html
@@ -74,7 +74,8 @@
     <div class="store-layout">
       <!-- Sidebar Filters -->
       <aside class="store-sidebar">
-        <div class="filters-container">
+        <div id="filterOffcanvas" class="filters-container offcanvas-mobile d-none d-lg-block">
+          <button type="button" class="btn-close d-lg-none mb-3" id="closeFilterBtn" aria-label="Cerrar"></button>
           <h3>🔍 Filtros</h3>
 
           <!-- Search -->
@@ -339,6 +340,13 @@
       <i class="bi bi-cart3"></i>
       <span class="cart-badge" id="mobileCartCount">0</span>
     </a>
+  </div>
+
+  <!-- Floating Filter Button (Mobile) -->
+  <div class="floating-filter d-lg-none">
+    <button type="button" class="floating-filter-btn" id="openFilterBtn">
+      <i class="bi bi-funnel-fill"></i>
+    </button>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- implement mobile filter sidebar with floating button
- animate filter offcanvas in store.css
- add toggle logic in store.js
- fix missing CSRF macros in multiple templates
- document filter move in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686b23e83f388325a3b8f530b6bd1929