### PR TITLE
Implement AJAX product search with infinite scroll

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -655,3 +655,4 @@
 - Extracted inline JS from store/store.html to static/js/store.js and loaded via extra_js block (PR store-js-extract).
 - Moved sidebar filter markup into #filterOffcanvas with a floating button on mobile; off-canvas styles and JS toggling added (PR store-filter-offcanvas).
 - Added advanced filters with price range slider, stock checkbox, tag list and AJAX refresh (PR store-advanced-filters).
+- Implemented store.search_products API with AJAX search and infinite scroll; removed 'Cargar más' button (PR ajax-store-search).

--- a/crunevo/templates/store/store.html
+++ b/crunevo/templates/store/store.html
@@ -201,16 +201,11 @@
         <div class="products-grid" id="productsGrid">
           {% include 'store/_product_cards.html' %}
         </div>
-
-        <!-- Load More / Pagination -->
-        {% if products|length >= 20 %}
-        <div class="load-more-section">
-          <button class="btn-load-more" id="loadMoreBtn">
-            <i class="bi bi-arrow-down-circle"></i>
-            Cargar más productos
-          </button>
+        <div id="productEnd" class="text-center py-4 d-none">
+          <div class="spinner-border text-primary" role="status">
+            <span class="visually-hidden">Cargando...</span>
+          </div>
         </div>
-        {% endif %}
       </main>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add `/store/api/search` returning paginated HTML via JSON
- enable asynchronous product search with infinite scroll and spinner
- remove legacy *Cargar más* button
- document AJAX search in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686b29ac466083258cd4a7382b49f026