### PR TITLE
Fix store price display conditions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -658,3 +658,4 @@
 - Implemented store.search_products API with AJAX search and infinite scroll; removed 'Cargar más' button (PR ajax-store-search).
 - Implementado sistema de solicitudes de productos con modelo ProductRequest, formulario para estudiantes y panel admin de aprobación. Botón flotante en tienda para solicitar. (PR store-product-requests)
 - Added dark-mode variables in store.css and updated components to use them, ensuring theme toggle works (PR store-dark-mode).
+- Precios en soles estandarizados y visibles solo si product.price > 0 en plantillas de tienda (PR store-price-standard)

--- a/crunevo/templates/store/favorites.html
+++ b/crunevo/templates/store/favorites.html
@@ -53,7 +53,7 @@
                   <div class="card-body d-flex flex-column">
                     <h5 class="card-title product-name">{{ product.name }}</h5>
                     <p class="card-text small text-muted mb-1 product-desc">{{ product.description }}</p>
-                      {% if product.price %}
+                      {% if product.price > 0 %}
                         <p class="mb-1 text-primary fw-bold">S/ {{ '%.2f' | format(product.price) }}</p>
                       {% endif %}
                     {% if product.price_credits %}

--- a/crunevo/templates/store/producto.html
+++ b/crunevo/templates/store/producto.html
@@ -21,7 +21,7 @@
         </form>
       </h1>
       <p class="text-muted">{{ product.description or 'Sin descripción detallada.' }}</p>
-      {% if product.price %}
+      {% if product.price > 0 %}
         <p class="h5"><strong class="text-primary">S/ {{ '%.2f' | format(product.price) }}</strong></p>
       {% endif %}
       {% if product.price_credits %}


### PR DESCRIPTION
## Summary
- show product price in soles only when price > 0 in product page and favorites
- note price display standardization in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686b30536b548325b1f8cd55cd16a5ee