### PR TITLE
Add Fly.io port troubleshooting tip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -665,3 +665,4 @@
 - Fixed store.css not loading by using head_extra block and removed stray </meta> tag in store.html (PR store-css-load-fix).
 - Restored product grid layout, limited card width to 320px and corrected cart count endpoint (PR store-grid-js-fix).
 - Mejorada accesibilidad del marketplace: botones con íconos tienen title, campos de dirección con placeholder y overlays usan role="button" (PR accessibility-html-fix).
+- Added note to README explaining how to resolve Fly.io warning about the app not listening on 0.0.0.0:8080 (PR fly-port-doc).

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ This command sets the `DATABASE_URL` secret automatically. Verify it with
 `fly secrets list -a crunevo2`. If the database is stopped, restart it with
 `fly pg restart -a crunevo-db` and then run `fly deploy` again.
 
+If Fly warns that the app is not listening on `0.0.0.0:8080`, double-check that
+your Dockerfile binds Gunicorn to that address and that `internal_port = 8080`
+is set in `fly.toml`. You can inspect startup errors with `fly logs`.
+
 If you want to run the application locally but use a PostgreSQL
 database hosted on Fly.io:
 ```bash


### PR DESCRIPTION
## Summary
- document fix for Fly.io "not listening" warning in README
- track the change in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686b50707c5c832596ef416e5cfcf7d5