### PR TITLE
Update store page layout with collapsible filters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -667,3 +667,4 @@
 - Mejorada accesibilidad del marketplace: botones con íconos tienen title, campos de dirección con placeholder y overlays usan role="button" (PR accessibility-html-fix).
 - Exposed openProductRequestModal and clearAllFilters on window to avoid ReferenceError when used inline (PR store-js-global-functions).
 - Added note to README explaining how to resolve Fly.io warning about the app not listening on 0.0.0.0:8080 (PR fly-port-doc).
+- Sidebar in store page can be collapsed with a new button, hero header removed and product grid shows up to 5 items per row (PR store-collapse-sidebar).

--- a/crunevo/static/css/store.css
+++ b/crunevo/static/css/store.css
@@ -116,6 +116,10 @@
   align-items: start;
 }
 
+.store-layout.sidebar-collapsed {
+  grid-template-columns: 1fr;
+}
+
 /* Sidebar */
 .store-sidebar {
   background: white;
@@ -126,6 +130,10 @@
   top: 2rem;
   max-height: calc(100vh - 4rem);
   overflow-y: auto;
+}
+
+.store-sidebar.collapsed {
+  display: none;
 }
 
 .filters-container {
@@ -508,21 +516,23 @@
 
 /* Products Grid */
 .products-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-  gap: 1.25rem;
-  padding: 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding: 1.5rem 0;
   margin-bottom: 2rem;
 }
 
+
 .products-grid.list-view {
-  grid-template-columns: 1fr;
+  flex-direction: column;
 }
 
 .products-grid.list-view .product-card {
   display: flex;
   flex-direction: row;
   max-width: none;
+  margin: 0 0 1rem 0;
 }
 
 .products-grid.list-view .product-image-container {
@@ -543,8 +553,9 @@
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
   transition: all 0.3s ease;
   position: relative;
-  max-width: 320px;
-  margin: auto;
+  max-width: 220px;
+  flex: 1 1 calc(20% - 16px);
+  margin: 8px;
 }
 
 .product-card:hover {
@@ -1259,29 +1270,24 @@
   .store-layout {
     grid-template-columns: 1fr;
   }
-  
+
   .store-sidebar {
     display: none;
   }
-  
+
   .mobile-filter-toggle {
     display: block;
   }
-  
-  .hero-content {
-    flex-direction: column;
-    text-align: center;
+
+  .product-card {
+    flex: 1 1 calc(33.333% - 16px);
   }
-  
-  .hero-text h1 {
-    font-size: 2rem;
-  }
-  
+
   .products-header {
     flex-direction: column;
     gap: 1rem;
   }
-  
+
   .sort-controls {
     justify-content: space-between;
     width: 100%;
@@ -1292,22 +1298,12 @@
   .store-container {
     padding: 0 0.5rem;
   }
-  
-  .store-hero {
-    padding: 2rem 0;
-    margin-bottom: 1rem;
+
+  .product-card {
+    flex: 1 1 calc(33.333% - 16px);
   }
-  
-  .hero-text h1 {
-    font-size: 1.75rem;
-  }
-  
-  .hero-text p {
-    font-size: 1rem;
-  }
-  
+
   .products-grid {
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
     gap: 1rem;
   }
   
@@ -1331,24 +1327,20 @@
 }
 
 @media (max-width: 480px) {
-  .products-grid {
-    grid-template-columns: 1fr;
+  .product-card {
+    flex: 1 1 100%;
   }
-  
+
   .balance-card {
     min-width: auto;
     width: 100%;
   }
-  
-  .hero-text h1 {
-    font-size: 1.5rem;
-  }
-  
+
   .sort-controls {
     flex-direction: column;
     gap: 0.5rem;
   }
-  
+
   .sort-select {
     min-width: auto;
     width: 100%;

--- a/crunevo/static/js/store.js
+++ b/crunevo/static/js/store.js
@@ -94,6 +94,13 @@ class CrunevoStore {
                 this.toggleMobileFilters();
             });
         }
+
+        const sidebarToggle = document.getElementById('toggleSidebarBtn');
+        if (sidebarToggle) {
+            sidebarToggle.addEventListener('click', () => {
+                this.toggleSidebar();
+            });
+        }
     }
 
     setupInfiniteScroll() {
@@ -554,6 +561,23 @@ class CrunevoStore {
         }
     }
 
+    toggleSidebar() {
+        const sidebar = document.querySelector('.store-sidebar');
+        const layout = document.querySelector('.store-layout');
+        const btn = document.getElementById('toggleSidebarBtn');
+
+        if (sidebar && layout && btn) {
+            sidebar.classList.toggle('collapsed');
+            layout.classList.toggle('sidebar-collapsed');
+
+            if (sidebar.classList.contains('collapsed')) {
+                btn.innerHTML = '<i class="bi bi-sliders"></i>';
+            } else {
+                btn.innerHTML = '<i class="bi bi-sliders"></i> Filtros';
+            }
+        }
+    }
+
     closeMobileFilters() {
         const overlay = document.getElementById('offcanvasOverlay');
         const filters = document.getElementById('offcanvasFilters');
@@ -608,6 +632,12 @@ function closeMobileFilters() {
     }
 }
 
+function toggleSidebar() {
+    if (window.store) {
+        window.store.toggleSidebar();
+    }
+}
+
 function clearAllFilters() {
     if (window.store) {
         window.store.clearAllFilters();
@@ -624,6 +654,7 @@ function openProductRequestModal() {
 // Expose functions for inline event handlers
 window.clearAllFilters = clearAllFilters;
 window.openProductRequestModal = openProductRequestModal;
+window.toggleSidebar = toggleSidebar;
 
 // Initialize store when DOM is loaded
 document.addEventListener('DOMContentLoaded', function() {

--- a/crunevo/templates/store/store.html
+++ b/crunevo/templates/store/store.html
@@ -11,28 +11,11 @@
 
 {% block content %}
 <div class="store-wrapper">
-  <!-- Hero Section -->
-  <section class="store-hero">
-    <div class="store-container">
-      <div class="hero-content">
-        <div class="hero-text">
-          <h1>🛍️ Marketplace CRUNEVO</h1>
-          <p>Descubre productos educativos, tecnología y accesorios diseñados especialmente para estudiantes. ¡Canjea con Crolars o compra directamente con precios exclusivos!</p>
-        </div>
-        <div class="hero-balance">
-          <div class="balance-card">
-            <i class="bi bi-coin"></i>
-            <div class="balance-info">
-              <span class="balance-amount">{{ current_user.credits or 0 }}</span>
-              <span class="balance-label">Crolars disponibles</span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-
   <div class="store-container">
+    <h2 class="mb-4 ms-3 mt-3">Marketplace</h2>
+    <button type="button" id="toggleSidebarBtn" class="btn btn-light d-none d-lg-inline-flex align-items-center ms-3 mb-2">
+      <i class="bi bi-sliders"></i> Filtros
+    </button>
     <div class="store-layout">
       <!-- Sidebar Filters -->
       <aside class="store-sidebar">


### PR DESCRIPTION
## Summary
- drop hero banner in `store.html`
- add simple `Marketplace` heading and sidebar toggle button
- allow collapsing sidebar via JS
- refactor product grid to show up to 5 items per row
- document change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686b564af31c832598fbf9645327ffc0