### PR TITLE
Implement product publishing flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -668,3 +668,4 @@
 - Exposed openProductRequestModal and clearAllFilters on window to avoid ReferenceError when used inline (PR store-js-global-functions).
 - Added note to README explaining how to resolve Fly.io warning about the app not listening on 0.0.0.0:8080 (PR fly-port-doc).
 - Sidebar in store page can be collapsed with a new button, hero header removed and product grid shows up to 5 items per row (PR store-collapse-sidebar).
+- Permite publicar productos desde la tienda con modal y ruta /store/publicar-producto; productos se crean con is_approved=False (PR store-user-publish).

--- a/crunevo/models/product.py
+++ b/crunevo/models/product.py
@@ -17,6 +17,7 @@ class Product(db.Model):
     category = db.Column(db.String(50))
     download_url = db.Column(db.String(255))
     allow_multiple = db.Column(db.Boolean, default=True)
+    is_approved = db.Column(db.Boolean, default=True)
 
     @property
     def first_image(self) -> str | None:

--- a/crunevo/routes/store_routes.py
+++ b/crunevo/routes/store_routes.py
@@ -649,3 +649,33 @@ def my_requests():
         .all()
     )
     return render_template("store/my_requests.html", requests=reqs)
+
+
+@store_bp.route("/publicar-producto", methods=["POST"])
+@activated_required
+def publish_product():
+    name = request.form.get("name", "").strip()
+    price = request.form.get("price", type=float) or 0
+    stock = request.form.get("stock", type=int) or 0
+    category = request.form.get("category")
+    description = request.form.get("description")
+    image = request.files.get("image")
+
+    image_url = None
+    if image:
+        from crunevo.utils.image_optimizer import upload_optimized_image
+
+        image_url = upload_optimized_image(image, folder="products")
+
+    product = Product(
+        name=name,
+        price=price,
+        stock=stock,
+        category=category,
+        description=description,
+        image=image_url,
+        is_approved=False,
+    )
+    db.session.add(product)
+    db.session.commit()
+    return "OK"

--- a/crunevo/static/js/store.js
+++ b/crunevo/static/js/store.js
@@ -644,37 +644,38 @@ function clearAllFilters() {
     }
 }
 
-function openProductRequestModal() {
+
+function openPublishProductModal() {
     const modal = new bootstrap.Modal(
-        document.getElementById('productRequestModal')
+        document.getElementById('publishProductModal')
     );
     modal.show();
 }
 
 // Expose functions for inline event handlers
 window.clearAllFilters = clearAllFilters;
-window.openProductRequestModal = openProductRequestModal;
+window.openPublishProductModal = openPublishProductModal;
 window.toggleSidebar = toggleSidebar;
 
 // Initialize store when DOM is loaded
 document.addEventListener('DOMContentLoaded', function() {
     window.store = new CrunevoStore();
 
-    // Product request form handler
-    const requestForm = document.getElementById('productRequestForm');
-    if (requestForm) {
-        requestForm.addEventListener('submit', async function(e) {
+    // Publish product form handler
+    const publishForm = document.getElementById('publishProductForm');
+    if (publishForm) {
+        publishForm.addEventListener('submit', async function(e) {
             e.preventDefault();
 
             const submitBtn = this.querySelector('button[type="submit"]');
             const originalHTML = submitBtn.innerHTML;
 
-            submitBtn.innerHTML = '<div class="spinner-border spinner-border-sm me-2" role="status"></div>Enviando...';
+            submitBtn.innerHTML = '<div class="spinner-border spinner-border-sm me-2" role="status"></div>Publicando...';
             submitBtn.disabled = true;
 
             try {
                 const formData = new FormData(this);
-                const response = await fetch('/store/solicitar-producto', {
+                const response = await fetch('/store/publicar-producto', {
                     method: 'POST',
                     body: formData,
                     headers: {
@@ -683,23 +684,17 @@ document.addEventListener('DOMContentLoaded', function() {
                 });
 
                 if (response.ok) {
-                    // Show success toast
-                    window.store.showToast('requestToast');
-
-                    // Close modal
-                    const modal = bootstrap.Modal.getInstance(document.getElementById('productRequestModal'));
+                    window.store.showToast('publishToast');
+                    const modal = bootstrap.Modal.getInstance(document.getElementById('publishProductModal'));
                     modal.hide();
-
-                    // Reset form
                     this.reset();
                 } else {
-                    throw new Error('Error submitting request');
+                    throw new Error('Error submitting product');
                 }
             } catch (error) {
-                console.error('Error submitting product request:', error);
-                window.store.showToast('errorToast', 'Error al enviar la solicitud');
+                console.error('Error publishing product:', error);
+                window.store.showToast('errorToast', 'Error al publicar el producto');
             } finally {
-                // Reset button
                 submitBtn.innerHTML = originalHTML;
                 submitBtn.disabled = false;
             }

--- a/crunevo/templates/store/store.html
+++ b/crunevo/templates/store/store.html
@@ -12,7 +12,12 @@
 {% block content %}
 <div class="store-wrapper">
   <div class="store-container">
-    <h2 class="mb-4 ms-3 mt-3">Marketplace</h2>
+    <h2 class="mb-4 ms-3 mt-3 d-inline-block">Marketplace</h2>
+    {% if current_user.is_authenticated %}
+    <button type="button" class="btn btn-primary btn-publish-product ms-2 mt-3" onclick="openPublishProductModal()">
+      🛒 Publicar producto
+    </button>
+    {% endif %}
     <button type="button" id="toggleSidebarBtn" class="btn btn-light d-none d-lg-inline-flex align-items-center ms-3 mb-2">
       <i class="bi bi-sliders"></i> Filtros
     </button>
@@ -352,20 +357,6 @@
           </button>
         </div>
 
-        <!-- Product Request Section -->
-        <div class="product-request-section">
-          <div class="request-icon">
-            <i class="bi bi-plus-circle"></i>
-          </div>
-          <h3 class="request-title">¿No encuentras lo que buscas?</h3>
-          <p class="request-description">
-            Solicita que agreguemos un producto específico al marketplace. Nuestro equipo revisará tu solicitud y te notificaremos cuando esté disponible.
-          </p>
-          <button type="button" class="btn-request-product" onclick="openProductRequestModal()">
-            <i class="bi bi-send"></i>
-            Solicitar producto
-          </button>
-        </div>
       </main>
     </div>
   </div>
@@ -398,59 +389,58 @@
   </div>
 </div>
 
-<!-- Product Request Modal -->
-<div class="modal fade" id="productRequestModal" tabindex="-1">
+
+<!-- Publish Product Modal -->
+<div class="modal fade" id="publishProductModal" tabindex="-1">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">Solicitar producto</h5>
+        <h5 class="modal-title">Publicar producto</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
-      <form id="productRequestForm">
+      <form id="publishProductForm" enctype="multipart/form-data">
         <div class="modal-body">
           <div class="mb-3">
-            <label for="requestProductName" class="form-label">Nombre del producto *</label>
-            <input type="text" class="form-control" id="requestProductName" required>
+            <label for="publishName" class="form-label">Nombre del producto</label>
+            <input type="text" class="form-control" id="publishName" name="name" required>
           </div>
           <div class="mb-3">
-            <label for="requestCategory" class="form-label">Categoría *</label>
-            <select class="form-select" id="requestCategory" required>
+            <label for="publishPrice" class="form-label">Precio en soles</label>
+            <input type="number" step="0.01" min="0" class="form-control" id="publishPrice" name="price">
+          </div>
+          <div class="mb-3">
+            <label for="publishStock" class="form-label">Stock</label>
+            <input type="number" min="0" class="form-control" id="publishStock" name="stock">
+          </div>
+          <div class="mb-3">
+            <label for="publishCategory" class="form-label">Categoría</label>
+            <select class="form-select" id="publishCategory" name="category">
               <option value="">Seleccionar categoría</option>
-              <option value="Tecnología">Tecnología</option>
-              <option value="Libros">Libros</option>
-              <option value="Accesorios">Accesorios</option>
-              <option value="Cuadernos">Cuadernos</option>
-              <option value="Comestibles">Comestibles</option>
-              <option value="Otro">Otro</option>
+              {% for cat in categories %}
+              <option value="{{ cat }}">{{ cat }}</option>
+              {% endfor %}
             </select>
           </div>
           <div class="mb-3">
-            <label for="requestDescription" class="form-label">Descripción del producto</label>
-            <textarea class="form-control" id="requestDescription" rows="3" 
-                      placeholder="Describe el producto que te gustaría ver en el marketplace..."></textarea>
+            <label for="publishDescription" class="form-label">Descripción</label>
+            <textarea class="form-control" id="publishDescription" name="description" rows="3"></textarea>
           </div>
           <div class="mb-3">
-            <label for="requestImage" class="form-label">Imagen de referencia (opcional)</label>
-            <input type="file" class="form-control" id="requestImage" accept="image/*">
+            <label for="publishImage" class="form-label">Imagen</label>
+            <input type="file" class="form-control" id="publishImage" name="image" accept="image/*">
           </div>
-          <div class="mb-3">
-            <label for="requestComment" class="form-label">Comentarios adicionales</label>
-            <textarea class="form-control" id="requestComment" rows="2" 
-                      placeholder="¿Por qué sería útil este producto para los estudiantes?"></textarea>
+          <div class="alert alert-info" role="alert">
+            🛠️ Este producto será enviado para revisión. Estará visible una vez aprobado por un administrador.
           </div>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-          <button type="submit" class="btn btn-primary">
-            <i class="bi bi-send"></i>
-            Enviar solicitud
-          </button>
+          <button type="submit" class="btn btn-primary">Publicar</button>
         </div>
       </form>
     </div>
   </div>
 </div>
-
 <!-- Toast Notifications -->
 <div class="toast-container position-fixed bottom-0 end-0 p-3">
   <div id="cartToast" class="toast" role="alert">
@@ -475,16 +465,17 @@
     </div>
   </div>
 
-  <div id="requestToast" class="toast" role="alert">
+  <div id="publishToast" class="toast" role="alert">
     <div class="toast-header">
       <i class="bi bi-check-circle text-success me-2"></i>
-      <strong class="me-auto">Solicitud</strong>
+      <strong class="me-auto">Producto</strong>
       <button type="button" class="btn-close" data-bs-dismiss="toast"></button>
     </div>
     <div class="toast-body">
-      Tu solicitud de producto ha sido enviada exitosamente
+      Producto enviado para revisión
     </div>
   </div>
+
 
   <div id="errorToast" class="toast" role="alert">
     <div class="toast-header">

--- a/migrations/versions/add_product_is_approved.py
+++ b/migrations/versions/add_product_is_approved.py
@@ -1,0 +1,38 @@
+"""add is_approved flag to product
+
+Revision ID: add_product_is_approved
+Revises: e8fb5094eccf
+Create Date: 2025-08-30 00:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def has_col(table: str, column: str, conn) -> bool:
+    inspector = sa.inspect(conn)
+    return any(c["name"] == column for c in inspector.get_columns(table))
+
+revision = "add_product_is_approved"
+down_revision = "add_product_request"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    with op.batch_alter_table("product") as batch_op:
+        if not has_col("product", "is_approved", conn):
+            batch_op.add_column(
+                sa.Column(
+                    "is_approved",
+                    sa.Boolean(),
+                    nullable=True,
+                    server_default=sa.true(),
+                )
+            )
+
+
+def downgrade():
+    with op.batch_alter_table("product") as batch_op:
+        batch_op.drop_column("is_approved", if_exists=True)


### PR DESCRIPTION
## Summary
- let students publish products from store via new modal
- create `/store/publicar-producto` route saving unapproved products
- remove product request UI and JS
- add `is_approved` field to Product model with migration
- document update in `AGENTS.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b5b325a488325b60e5a8db347f0da