### PR TITLE
Fix career header and navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -669,3 +669,4 @@
 - Added note to README explaining how to resolve Fly.io warning about the app not listening on 0.0.0.0:8080 (PR fly-port-doc).
 - Sidebar in store page can be collapsed with a new button, hero header removed and product grid shows up to 5 items per row (PR store-collapse-sidebar).
 - Permite publicar productos desde la tienda con modal y ruta /store/publicar-producto; productos se crean con is_approved=False (PR store-user-publish).
+- Added gradient header and basic tab navigation for Mi Carrera; initialization moved to main.js to avoid extra DOMContentLoaded listener (PR career-header-fix).

--- a/crunevo/static/css/carrera.css
+++ b/crunevo/static/css/carrera.css
@@ -1,7 +1,11 @@
 
 /* Career Module Styles */
 .career-header {
-  background: linear-gradient(135deg, #1E40AF 0%, #059669 100%);
+  background: linear-gradient(135deg, #a16ae8, #8ac6ff);
+  color: white;
+  padding: 2rem;
+  border-radius: 1rem;
+  margin-bottom: 1.5rem;
 }
 
 .career-nav .nav-link {

--- a/crunevo/static/js/carrera.js
+++ b/crunevo/static/js/carrera.js
@@ -682,7 +682,23 @@ class CareerModule {
     }
 }
 
-// Initialize when DOM is loaded
-document.addEventListener('DOMContentLoaded', () => {
+function initCareerPage() {
     window.careerModule = new CareerModule();
-});
+
+    const tabs = document.querySelectorAll('.career-nav .nav-link');
+    const contents = document.querySelectorAll('.tab-pane');
+
+    tabs.forEach((tab) => {
+        tab.addEventListener('click', (e) => {
+            e.preventDefault();
+            tabs.forEach((t) => t.classList.remove('active'));
+            tab.classList.add('active');
+
+            contents.forEach((c) => c.classList.add('d-none'));
+            const target = document.getElementById(tab.dataset.tab);
+            if (target) target.classList.remove('d-none');
+        });
+    });
+}
+
+window.initCareerPage = initCareerPage;

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -500,7 +500,8 @@ class FeedManager {
       const items = await response.json();
 
       if (items.length === 0) {
-        document.getElementById('feedEnd').style.display = 'none';
+        const end = document.getElementById('feedEnd');
+        if (end) end.style.display = 'none';
         return;
       }
 

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -842,6 +842,9 @@ document.addEventListener('DOMContentLoaded', () => {
   initCoursesPage();
   initEventList();
   initPrivateChat();
+  if (typeof initCareerPage === 'function') {
+    initCareerPage();
+  }
 
   const avatarInput = document.getElementById('avatarFileInput');
   const avatarPreview = document.getElementById('avatarPreview');


### PR DESCRIPTION
## Summary
- tweak `.career-header` gradient styles
- expose `initCareerPage` and call it from main entrypoint
- add tab toggling logic
- guard missing element in feed manager
- note change in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686b5eaf2ccc8325877564c67fd1e82b