### PR TITLE
Fix career header gradient and dark footer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -671,3 +671,4 @@
 - Permite publicar productos desde la tienda con modal y ruta /store/publicar-producto; productos se crean con is_approved=False (PR store-user-publish).
 - Added gradient header and basic tab navigation for Mi Carrera; initialization moved to main.js to avoid extra DOMContentLoaded listener (PR career-header-fix).
 - Moved publish product button to header and fixed store initialization for sidebar toggle (PR store-publish-btn-pos).
+- Fixed Mi Carrera header gradient visibility in light mode, added dark theme styles and footer now adapts to theme automatically (PR career-header-gradient-fix).

--- a/crunevo/static/css/carrera.css
+++ b/crunevo/static/css/carrera.css
@@ -8,6 +8,10 @@
   margin-bottom: 1.5rem;
 }
 
+[data-bs-theme="dark"] .career-header {
+  background: linear-gradient(135deg, #3b3b58, #1e293b);
+}
+
 .career-nav .nav-link {
   color: #64748B;
   border: none;

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -96,7 +96,7 @@
     </main>
 
     <!-- Enhanced footer -->
-    <footer class="text-center py-4 mt-5" style="position: relative; z-index: 1000; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); border-top: 1px solid #e0e0e0;">
+    <footer class="text-center py-4 mt-5">
       <div class="container">
         <div class="row align-items-center">
           <div class="col-md-6 text-md-start">

--- a/crunevo/templates/carrera/index.html
+++ b/crunevo/templates/carrera/index.html
@@ -10,7 +10,7 @@
     <!-- Main Content -->
     <div class="col-12">
       <!-- Header Section -->
-      <div class="career-header bg-gradient text-white rounded-4 p-4 mb-4">
+      <div class="career-header text-white rounded-4 p-4 mb-4">
         <div class="row align-items-center">
           <div class="col-md-8">
             <h1 class="h2 mb-2">


### PR DESCRIPTION
## Summary
- remove bootstrap gradient class from career header
- style career header gradient for light/dark modes
- let footer background switch with theme
- document the change in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686b646b9a1483259113de4bb162d684