### PR TITLE
Fix admin panel routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -671,3 +671,4 @@
 - Permite publicar productos desde la tienda con modal y ruta /store/publicar-producto; productos se crean con is_approved=False (PR store-user-publish).
 - Added gradient header and basic tab navigation for Mi Carrera; initialization moved to main.js to avoid extra DOMContentLoaded listener (PR career-header-fix).
 - Moved publish product button to header and fixed store initialization for sidebar toggle (PR store-publish-btn-pos).
+- Restored /admin/store management view and added user actions (historial, rol y activación). Mobile nav se oculta en modo admin para evitar 404 de notificaciones (PR admin-panel-fixes).

--- a/crunevo/templates/admin/partials/sidebar.html
+++ b/crunevo/templates/admin/partials/sidebar.html
@@ -15,7 +15,7 @@
   <a class="nav-link {% if request.endpoint == 'admin.admin_logs' %}active{% endif %}" href="{{ url_for('admin.admin_logs') }}">
     <i class="ti ti-clipboard-list me-2"></i> Auditoría
   </a>
-  <a class="nav-link" href="{{ PUBLIC_BASE_URL }}/store" target="_blank">
+  <a class="nav-link {% if request.endpoint == 'admin.manage_store' %}active{% endif %}" href="{{ url_for('admin.manage_store') }}">
     <i class="ti ti-building-store me-2"></i> Tienda
   </a>
   <a class="nav-link {% if request.endpoint == 'admin.product_history' %}active{% endif %}" href="{{ url_for('admin.product_history') }}">

--- a/crunevo/templates/admin/user_history.html
+++ b/crunevo/templates/admin/user_history.html
@@ -1,0 +1,24 @@
+{% extends 'admin/base_admin.html' %}
+{% block admin_content %}
+<h2 class="page-title mb-4">Historial de {{ user.username }}</h2>
+<div class="card shadow-sm">
+  <div class="card-body p-0">
+    <table class="table table-vcenter card-table">
+      <thead>
+        <tr>
+          <th>Fecha</th>
+          <th>Acción</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for act in activities %}
+        <tr>
+          <td>{{ act.timestamp.strftime('%d/%m/%Y %H:%M') }}</td>
+          <td>{{ act.action }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endblock %}

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -167,7 +167,7 @@
     {% endif %}
 
     <!-- Mobile bottom navigation -->
-    {% if request.endpoint not in ['auth.login', 'onboarding.register'] %}
+    {% if request.endpoint not in ['auth.login', 'onboarding.register'] and not config.ADMIN_INSTANCE %}
     {% include 'components/mobile_bottom_nav.html' %}
     {% endif %}
 


### PR DESCRIPTION
## Summary
- restore `/admin/store` management view for products
- add user history, role update and status toggle routes
- hide mobile bottom nav in admin mode
- add CSV export for products
- document admin panel fixes in AGENTS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b63629bbc8325a395d5b0ab8fee26