### PR TITLE
Fix store interactions and dark-mode styles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -673,3 +673,5 @@
 - Moved publish product button to header and fixed store initialization for sidebar toggle (PR store-publish-btn-pos).
 - Restored /admin/store management view and added user actions (historial, rol y activación). Mobile nav se oculta en modo admin para evitar 404 de notificaciones (PR admin-panel-fixes).
 - Fixed Mi Carrera header gradient visibility in light mode, added dark theme styles and footer now adapts to theme automatically (PR career-header-gradient-fix).
+- Fixed store.js initialization block and moved sidebar toggle button next to page title; added extra_js block in base template (PR store-js-init-fix).
+- Updated career header gradient and dark-mode footer styles; defined new CSS tokens (PR career-footer-style-fix).

--- a/crunevo/routes/admin_routes.py
+++ b/crunevo/routes/admin_routes.py
@@ -37,7 +37,6 @@ from crunevo.models import (
 from crunevo.utils.helpers import admin_required
 from crunevo.utils.credits import add_credit
 from crunevo.utils.ranking import calculate_weekly_ranking
-from .store_routes import store_index
 from crunevo.constants.credit_reasons import CreditReasons
 from datetime import datetime, timedelta
 import csv
@@ -169,9 +168,7 @@ def user_activity(user_id):
         .order_by(UserActivity.timestamp.desc())
         .all()
     )
-    return render_template(
-        "admin/user_history.html", user=user, activities=activities
-    )
+    return render_template("admin/user_history.html", user=user, activities=activities)
 
 
 @admin_bp.route("/users/<int:user_id>/role", methods=["POST"])
@@ -368,13 +365,15 @@ def export_products():
     writer = csv.writer(output)
     writer.writerow(["ID", "Nombre", "Precio", "Crolars", "Stock"])
     for p in products:
-        writer.writerow([
-            p.id,
-            p.name,
-            f"{p.price:.2f}",
-            p.price_credits or "",
-            p.stock,
-        ])
+        writer.writerow(
+            [
+                p.id,
+                p.name,
+                f"{p.price:.2f}",
+                p.price_credits or "",
+                p.stock,
+            ]
+        )
 
     output.seek(0)
     response = make_response(output.getvalue())

--- a/crunevo/static/css/carrera.css
+++ b/crunevo/static/css/carrera.css
@@ -1,8 +1,8 @@
 
 /* Career Module Styles */
 .career-header {
-  background: linear-gradient(135deg, #a16ae8, #8ac6ff);
-  color: white;
+  background: linear-gradient(120deg, #a18cd1 0%, #fbc2eb 100%);
+  color: #fff;
   padding: 2rem;
   border-radius: 1rem;
   margin-bottom: 1.5rem;

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -757,6 +757,15 @@ html[data-bs-theme="dark"] footer a {
   color: #ccc !important;
 }
 
+.dark-mode footer {
+  background-color: var(--dark-bg);
+  color: var(--light-text);
+}
+
+.dark-mode footer a {
+  color: var(--light-text);
+}
+
 @media (min-width: 768px) {
   .error-page {
     max-width: 500px;

--- a/crunevo/static/css/tokens.css
+++ b/crunevo/static/css/tokens.css
@@ -12,6 +12,10 @@
   --gray-100: #f7fafc;
   --gray-50 : #fafbfc;
 
+  /* Extra global colors */
+  --light-text: #f8f9fa;
+  --dark-bg: #1e1e1e;
+
   /* Soft brand colors - elegant and refined */
   --primary : #6b73ff;
   --primary-dark: #5850ec;

--- a/crunevo/static/js/store.js
+++ b/crunevo/static/js/store.js
@@ -659,6 +659,7 @@ window.toggleSidebar = toggleSidebar;
 
 // Initialize store when DOM is loaded
 function initCrunevoStore() {
+    console.log('Store iniciado');
     window.store = new CrunevoStore();
 
     // Publish product form handler

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -326,6 +326,7 @@ if ('serviceWorker' in navigator) {
     </script>
 
     {% block body_end %}{% endblock %}
+    {% block extra_js %}{% endblock %}
     <script src="{{ url_for('static', filename='js/enhanced-ui.js') }}" defer></script>
 </body>
 </html>

--- a/crunevo/templates/store/store.html
+++ b/crunevo/templates/store/store.html
@@ -13,16 +13,18 @@
 <div class="store-wrapper">
   <div class="store-container">
     <div class="store-header d-flex flex-column flex-lg-row align-items-start align-items-lg-center justify-content-between ms-3 mt-3 gap-2">
-      <h2 class="mb-3 mb-lg-0">Marketplace</h2>
+      <div class="d-flex align-items-center gap-2">
+        <h2 class="mb-3 mb-lg-0">Marketplace</h2>
+        <button type="button" id="toggleSidebarBtn" onclick="toggleSidebar()" class="btn btn-light d-none d-lg-inline-flex align-items-center">
+          <i class="bi bi-sliders"></i> Filtros
+        </button>
+      </div>
       <div class="d-flex align-items-center gap-2">
         {% if current_user.is_authenticated %}
         <button type="button" class="btn btn-primary btn-publish-product" onclick="openPublishProductModal()">
           🛒 Publicar producto
         </button>
         {% endif %}
-        <button type="button" id="toggleSidebarBtn" class="btn btn-light d-none d-lg-inline-flex align-items-center">
-          <i class="bi bi-sliders"></i> Filtros
-        </button>
       </div>
     </div>
     <div class="store-layout">


### PR DESCRIPTION
## Summary
- ensure `extra_js` block is used for page scripts
- tweak store header layout and sidebar toggle
- add console log for store initialization
- update career page gradient and add dark mode footer rules
- define new CSS tokens for light text and dark background
- remove unused import flagged by formatter
- document fixes in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686b678f0f408325ad39802dbe7aaf2f