### PR TITLE
Fix mobile navbar overlap and notifications UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -682,3 +682,4 @@
 - Reinstated edit_product route in admin panel to fix manage_store errors (PR admin-edit-link-fix).
 - Added desktop application launcher menu with grid icon, links to profile, personal space, missions, ranking, league, backpack and challenges; CSS and JS integrated (PR desktop-launcher-menu).
 - Added missing backpack templates (journal, new_entry, view_entry) to fix TemplateNotFound errors (PR backpack-templates-fix).
+- Fixed mobile header overlap, restored notes icon in bottom nav and improved notification filters for responsiveness (PR mobile-visual-fixes).

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -28,6 +28,7 @@ body {
     padding-top: 56px;
   }
   main {
+    margin-top: 64px;
     padding-top: 1rem;
     margin-bottom: 4rem;
   }
@@ -511,6 +512,8 @@ html {
   backdrop-filter: blur(10px);
   transition: all 0.3s ease;
   margin-bottom: 0.75rem;
+  width: 100%;
+  word-wrap: break-word;
 }
 
 .notification-card:hover {

--- a/crunevo/templates/components/mobile_bottom_nav.html
+++ b/crunevo/templates/components/mobile_bottom_nav.html
@@ -16,7 +16,7 @@
         <a href="{{ url_for('notes.list_notes') if 'notes.list_notes' in url_for.__globals__.get('current_app', {}).view_functions else '#' }}"
            class="nav-item {{ 'active' if request.endpoint == 'notes.list_notes' }}">
           <div class="nav-icon">
-            <i class="bi bi-journal{{ '-text-fill' if request.endpoint == 'notes.list_notes' }}"></i>
+            <i class="bi bi-file-text"></i>
           </div>
           <span class="nav-label">Apuntes</span>
         </a>

--- a/crunevo/templates/notificaciones/lista.html
+++ b/crunevo/templates/notificaciones/lista.html
@@ -7,12 +7,12 @@
     {{ csrf.csrf_field() }}
     <button class="btn btn-sm btn-outline-secondary">Marcar todo como leído</button>
   </form>
-  <div class="btn-group mb-3" id="notiFilterGroup" role="group">
-    <button class="btn btn-outline-primary active" data-noti-filter="all">Todos</button>
-    <button class="btn btn-outline-warning" data-noti-filter="reaction">❤️ Reacciones</button>
-    <button class="btn btn-outline-info" data-noti-filter="comment">📝 Comentarios</button>
-    <button class="btn btn-outline-danger" data-noti-filter="report">⚠️ Reportes</button>
-    <button class="btn btn-outline-purple" data-noti-filter="achievement">🏆 Logros</button>
+  <div class="d-flex flex-nowrap overflow-auto py-2 gap-2 px-2 mb-3" id="notiFilterGroup" role="group">
+    <button class="btn btn-sm btn-outline-primary active" data-noti-filter="all">Todos</button>
+    <button class="btn btn-sm btn-outline-warning" data-noti-filter="reaction">❤️ Reacciones</button>
+    <button class="btn btn-sm btn-outline-info" data-noti-filter="comment">📝 Comentarios</button>
+    <button class="btn btn-sm btn-outline-danger" data-noti-filter="report">⚠️ Reportes</button>
+    <button class="btn btn-sm btn-outline-purple" data-noti-filter="achievement">🏆 Logros</button>
   </div>
   {% for n in notificaciones %}
   {% set msg = n.message.lower() %}


### PR DESCRIPTION
## Summary
- tweak main margin to avoid mobile navbar overlap
- keep notes icon visible in bottom nav
- improve notifications filter layout for mobile
- ensure notification cards wrap properly
- document changes in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686c0db98b70832595e29f959d1083c8