### PR TITLE
Redesign onboarding pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -683,3 +683,4 @@
 - Added desktop application launcher menu with grid icon, links to profile, personal space, missions, ranking, league, backpack and challenges; CSS and JS integrated (PR desktop-launcher-menu).
 - Added missing backpack templates (journal, new_entry, view_entry) to fix TemplateNotFound errors (PR backpack-templates-fix).
 - Fixed mobile header overlap, restored notes icon in bottom nav and improved notification filters for responsiveness (PR mobile-visual-fixes).
+- Rediseñadas /onboarding/pending y /onboarding/change_email con tarjeta centrada e íconos Bootstrap (PR onboarding-pages-redesign).

--- a/crunevo/templates/onboarding/change_email.html
+++ b/crunevo/templates/onboarding/change_email.html
@@ -2,17 +2,23 @@
 {% import 'components/csrf.html' as csrf %}
 
 {% block content %}
-<div class="tw-min-h-screen tw-flex tw-items-center tw-justify-center tw-bg-gradient-to-b tw-from-indigo-50 tw-to-purple-100 dark:tw-from-gray-900 dark:tw-to-gray-800 tw-px-4">
-  <div class="tw-bg-white dark:tw-bg-gray-900 tw-rounded-2xl tw-shadow-lg tw-p-8 tw-max-w-md tw-w-full tw-text-center">
-    <div class="tw-text-4xl tw-mb-4 tw-text-indigo-600">✉️</div>
-    <h1 class="tw-text-2xl tw-font-semibold tw-mb-4">Cambiar dirección de correo</h1>
-    <form method="POST" class="tw-space-y-4">
+<div class="container d-flex justify-content-center align-items-center tw-min-h-screen tw-bg-gradient-to-b tw-from-indigo-50 tw-to-purple-100 dark:tw-from-gray-900 dark:tw-to-gray-800">
+  <div class="card shadow-lg p-4 text-center tw-max-w-md tw-w-full" style="max-width: 500px;">
+    <div class="mb-3">
+      <i class="bi bi-envelope-edit text-purple fs-1"></i>
+    </div>
+    <h4 class="mb-3">Cambiar dirección de correo</h4>
+    <form method="POST" action="{{ url_for('onboarding.change_email') }}">
       {{ csrf.csrf_field() }}
-      <input type="email" name="email" placeholder="Nuevo correo" class="tw-w-full tw-p-3 tw-border tw-rounded-lg" required>
-      <button type="submit" class="tw-w-full tw-bg-indigo-600 tw-text-white tw-py-2 tw-rounded-lg hover:tw-bg-indigo-700">📤 Actualizar y reenviar</button>
+      <div class="mb-3">
+        <input type="email" name="email" class="form-control" placeholder="Nuevo correo" autocomplete="email" required>
+      </div>
+      <button type="submit" class="btn btn-success">
+        <i class="bi bi-check2-circle me-1"></i> Actualizar y reenviar
+      </button>
     </form>
-    <div class="tw-mt-4">
-      <a href="{{ url_for('onboarding.pending') }}" class="tw-text-sm tw-text-gray-500 hover:tw-underline">← Volver</a>
+    <div class="mt-3">
+      <a href="{{ url_for('onboarding.pending') }}" class="text-muted small">← Volver</a>
     </div>
   </div>
 </div>

--- a/crunevo/templates/onboarding/pending.html
+++ b/crunevo/templates/onboarding/pending.html
@@ -1,22 +1,24 @@
 {% extends 'base.html' %}
 {% import 'components/csrf.html' as csrf %}
 {% block content %}
-<div class="tw-min-h-screen tw-flex tw-items-center tw-justify-center tw-bg-gradient-to-b tw-from-indigo-50 tw-to-purple-100 dark:tw-from-gray-900 dark:tw-to-gray-800 tw-px-4">
-  <div class="tw-bg-white dark:tw-bg-gray-900 tw-rounded-2xl tw-shadow-2xl tw-p-8 tw-max-w-md tw-w-full tw-text-center tw-space-y-4">
-    <div class="tw-text-5xl tw-mb-2 tw-text-indigo-600 animate-bounce">📩</div>
-    <h1 class="tw-text-2xl tw-font-semibold">¡Estás a un paso de entrar a CRUNEVO!</h1>
-    <p class="tw-text-gray-600 dark:tw-text-gray-300">Hemos enviado un correo de verificación a <strong>tu dirección registrada</strong>. Haz clic en el enlace para activar tu cuenta.</p>
-
-    <form method="post" action="{{ url_for('onboarding.resend') }}" class="tw-mb-2" onsubmit="this.querySelector('button').disabled=true;">
-      {{ csrf.csrf_field() }}
-      <button type="submit" class="tw-w-full tw-bg-indigo-600 tw-text-white tw-py-2 tw-rounded-lg hover:tw-bg-indigo-700 tw-transition">📧 Reenviar correo</button>
-    </form>
-
-    <div>
-      <a href="{{ url_for('onboarding.change_email') }}" class="tw-text-sm tw-text-blue-600 hover:tw-underline">✍️ Cambiar dirección de correo</a>
+<div class="container d-flex justify-content-center align-items-center tw-min-h-screen tw-bg-gradient-to-b tw-from-indigo-50 tw-to-purple-100 dark:tw-from-gray-900 dark:tw-to-gray-800">
+  <div class="card shadow-lg p-4 text-center tw-max-w-md tw-w-full" style="max-width: 500px;">
+    <div class="mb-3">
+      <i class="bi bi-envelope-check-fill text-primary fs-1"></i>
     </div>
-    <div class="tw-mt-2">
-      <a href="{{ url_for('feed.feed_home') }}" class="tw-text-sm tw-text-gray-500 hover:tw-underline">← Volver al inicio</a>
+    <h4 class="mb-3">¡Estás a un paso de entrar a CRUNEVO!</h4>
+    <p class="text-muted">Hemos enviado un correo de verificación a <strong>tu dirección registrada</strong>. Haz clic en el enlace para activar tu cuenta.</p>
+    <form method="post" action="{{ url_for('onboarding.resend') }}" onsubmit="this.querySelector('button').disabled=true;">
+      {{ csrf.csrf_field() }}
+      <button type="submit" class="btn btn-primary mt-2">
+        <i class="bi bi-arrow-repeat me-1"></i> Reenviar correo
+      </button>
+    </form>
+    <div class="mt-4">
+      <a href="{{ url_for('onboarding.change_email') }}" class="text-warning d-block mb-1">
+        <i class="bi bi-pencil-square"></i> Cambiar dirección de correo
+      </a>
+      <a href="{{ url_for('feed.feed_home') }}" class="text-muted small">← Volver al inicio</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- integrate email pending and change email screens with consistent card design
- use bootstrap icons for clarity
- document latest change in AGENTS guidelines

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686c19308cd0832581f0f61112a1c185