### PR TITLE
Onboarding UI tweaks and floating buttons fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -684,3 +684,4 @@
 - Added missing backpack templates (journal, new_entry, view_entry) to fix TemplateNotFound errors (PR backpack-templates-fix).
 - Fixed mobile header overlap, restored notes icon in bottom nav and improved notification filters for responsiveness (PR mobile-visual-fixes).
 - Rediseñadas /onboarding/pending y /onboarding/change_email con tarjeta centrada e íconos Bootstrap (PR onboarding-pages-redesign).
+- Mejorados formularios de verificación y botones flotantes reposicionados sobre la barra inferior (PR onboarding-floating-fix).

--- a/crunevo/static/css/modern-components.css
+++ b/crunevo/static/css/modern-components.css
@@ -591,7 +591,7 @@
   opacity: 0;
   visibility: hidden;
   transform: translateY(20px);
-  z-index: 1000;
+  z-index: 1055;
 }
 
 .scroll-to-top.visible {
@@ -607,6 +607,12 @@
 
 .scroll-to-top:active {
   transform: translateY(0);
+}
+
+@media (max-width: 768px) {
+  .scroll-to-top {
+    bottom: 90px;
+  }
 }
 
 /* ============================================

--- a/crunevo/static/css/store.css
+++ b/crunevo/static/css/store.css
@@ -28,6 +28,11 @@
   --dark-hover: #374151;
 }
 
+@keyframes fadeInUp {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
 /* Base Store Styles */
 .store-wrapper {
   min-height: 100vh;
@@ -1141,7 +1146,8 @@
   position: fixed;
   bottom: 2rem;
   right: 2rem;
-  z-index: 1000;
+  z-index: 1055;
+  animation: fadeInUp 0.4s ease both;
 }
 
 .floating-cart-btn {
@@ -1316,7 +1322,7 @@
   }
   
   .floating-cart {
-    bottom: 1rem;
+    bottom: 90px;
     right: 1rem;
   }
   

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -153,18 +153,7 @@
     </div>
     {% endif %}
 
-    <!-- Shopping cart button for store pages -->
-    {% if request.path.startswith('/store') and 'store.view_cart' in url_for.__globals__.get('current_app', {}).view_functions %}
-    <a href="{{ url_for('store.view_cart') }}" 
-       class="btn btn-primary rounded-circle position-fixed shadow-lg d-lg-none mobile-overlay-btn"
-       style="bottom: 80px; right: 20px; width: 56px; height: 56px; display: flex; align-items: center; justify-content: center;">
-      <i class="bi bi-cart fs-5"></i>
-      <span id="mobileCartBadge" 
-            class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger {% if CART_COUNT == 0 %}tw-hidden{% endif %}">
-        {{ CART_COUNT }}
-      </span>
-    </a>
-    {% endif %}
+
 
     <!-- Mobile bottom navigation -->
     {% if request.endpoint not in ['auth.login', 'onboarding.register'] and not config.ADMIN_INSTANCE %}
@@ -224,14 +213,19 @@
         width: 60px;
         height: 60px;
         border: none;
-        z-index: 1000;
+        z-index: 1055;
         transition: all 0.3s ease;
-        animation: pulse 2s infinite;
+        animation: fadeInUp 0.4s ease both, pulse 2s infinite;
     }
 
     .floating-btn:hover {
         transform: scale(1.1);
         box-shadow: 0 8px 25px rgba(102, 126, 234, 0.4) !important;
+    }
+
+    @keyframes fadeInUp {
+        from { opacity: 0; transform: translateY(20px); }
+        to { opacity: 1; transform: translateY(0); }
     }
 
     @keyframes pulse {
@@ -258,13 +252,24 @@
         position: fixed;
         bottom: 30px;
         right: 100px;
-        z-index: 1000;
+        z-index: 1055;
     }
     .quick-notes {
         position: fixed;
         bottom: 30px;
         right: 170px;
-        z-index: 1000;
+        z-index: 1055;
+    }
+
+    @media (max-width: 768px) {
+        .floating-btn,
+        .shortcut-help,
+        .quick-notes {
+            bottom: 90px !important;
+        }
+        main {
+            padding-bottom: 5rem !important;
+        }
     }
     </style>
 

--- a/crunevo/templates/onboarding/change_email.html
+++ b/crunevo/templates/onboarding/change_email.html
@@ -2,12 +2,12 @@
 {% import 'components/csrf.html' as csrf %}
 
 {% block content %}
-<div class="container d-flex justify-content-center align-items-center tw-min-h-screen tw-bg-gradient-to-b tw-from-indigo-50 tw-to-purple-100 dark:tw-from-gray-900 dark:tw-to-gray-800">
-  <div class="card shadow-lg p-4 text-center tw-max-w-md tw-w-full" style="max-width: 500px;">
-    <div class="mb-3">
-      <i class="bi bi-envelope-edit text-purple fs-1"></i>
+<div class="container py-5 d-flex flex-column justify-content-center align-items-center min-vh-100">
+  <div class="card shadow-sm p-4 mx-auto text-center" style="max-width: 420px;">
+    <div class="mb-4">
+      <i class="bi bi-envelope-edit display-1 text-purple"></i>
     </div>
-    <h4 class="mb-3">Cambiar dirección de correo</h4>
+    <h4 class="fw-bold mb-3">Cambiar dirección de correo</h4>
     <form method="POST" action="{{ url_for('onboarding.change_email') }}">
       {{ csrf.csrf_field() }}
       <div class="mb-3">

--- a/crunevo/templates/onboarding/confirm.html
+++ b/crunevo/templates/onboarding/confirm.html
@@ -17,7 +17,7 @@
         </div>
 
         <div class="input-group mb-3">
-          <input type="email" id="newEmail" class="form-control" placeholder="Nuevo correo">
+          <input type="email" id="newEmail" class="form-control" placeholder="Nuevo correo" autocomplete="email">
           <button class="btn btn-primary" onclick="resendEmail()">
             <i class="bi bi-send-fill me-1"></i> Reenviar
           </button>

--- a/crunevo/templates/onboarding/pending.html
+++ b/crunevo/templates/onboarding/pending.html
@@ -1,12 +1,12 @@
 {% extends 'base.html' %}
 {% import 'components/csrf.html' as csrf %}
 {% block content %}
-<div class="container d-flex justify-content-center align-items-center tw-min-h-screen tw-bg-gradient-to-b tw-from-indigo-50 tw-to-purple-100 dark:tw-from-gray-900 dark:tw-to-gray-800">
-  <div class="card shadow-lg p-4 text-center tw-max-w-md tw-w-full" style="max-width: 500px;">
-    <div class="mb-3">
-      <i class="bi bi-envelope-check-fill text-primary fs-1"></i>
+<div class="container py-5 d-flex flex-column justify-content-center align-items-center min-vh-100">
+  <div class="card shadow-sm p-4 mx-auto text-center" style="max-width: 420px;">
+    <div class="mb-4">
+      <i class="bi bi-envelope-check display-1 text-primary"></i>
     </div>
-    <h4 class="mb-3">¡Estás a un paso de entrar a CRUNEVO!</h4>
+    <h4 class="fw-bold mb-3">¡Estás a un paso de entrar a CRUNEVO!</h4>
     <p class="text-muted">Hemos enviado un correo de verificación a <strong>tu dirección registrada</strong>. Haz clic en el enlace para activar tu cuenta.</p>
     <form method="post" action="{{ url_for('onboarding.resend') }}" onsubmit="this.querySelector('button').disabled=true;">
       {{ csrf.csrf_field() }}


### PR DESCRIPTION
## Summary
- polish email verification pages with centered cards and icons
- allow changing email with improved styles
- fix autocomplete attribute on confirm email page
- remove duplicate mobile cart button and adjust floating actions over bottom nav
- animate floating buttons and set safe offsets
- document changes in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686c1b54fb348325aa5d2ebb3216eaf3