### PR TITLE
Fix 429 error page link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -688,3 +688,4 @@
 - Tarjetas del feed sin 'Vista rápida' y apuntes con Vista Rápida y botones unificados (PR notes-feed-card-fix).
 - Mejorado perfil con carga de avatar y vista previa; botón flotante "Guardar cambios" y nueva ruta /perfil/avatar (PR profile-avatar-preview).
 - Fixed notes list template to avoid Jinja 'with' syntax using variable assignment (QA notes-list-jinja-fix).
+- Updated 429 error page to fallback to '/' when 'feed.feed_home' route is missing, preventing BuildError (QA 429-feed-link-fallback).

--- a/crunevo/templates/errors/429.html
+++ b/crunevo/templates/errors/429.html
@@ -13,7 +13,7 @@
     <p class="lead text-muted mb-4">
       Has realizado demasiadas acciones en poco tiempo. Intenta nuevamente en unos minutos.
     </p>
-    <a href="{{ url_for('feed.feed_home') }}" class="btn btn-primary btn-lg">
+    <a href="{{ url_for('feed.feed_home') if 'feed.feed_home' in url_for.__globals__.get('current_app', {}).view_functions else '/' }}" class="btn btn-primary btn-lg">
       <i class="bi bi-house-fill me-2"></i>Regresar al inicio
     </a>
   </div>


### PR DESCRIPTION
## Summary
- prevent BuildError when feed blueprint is missing by adding fallback link in 429 error page
- document the fix in AGENTS.md for future reference

## Testing
- `make fmt`
- `make test` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686c4d2ffc208325a15cbd074ccfd6e5