### PR TITLE
Improve profile banner editing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -690,3 +690,4 @@
 - Fixed notes list template to avoid Jinja 'with' syntax using variable assignment (QA notes-list-jinja-fix).
 - Updated 429 error page to fallback to '/' when 'feed.feed_home' route is missing, preventing BuildError (QA 429-feed-link-fallback).
 - Galería de imágenes del feed adaptada: primera imagen grande y cuadrícula responsiva para el resto; CSS ajustado (PR feed-gallery-responsive).
+- Perfil mejorado: botones de avatar y banner con previsualización y estadísticas completas (PR profile-banner-fixes)

--- a/crunevo/routes/auth_routes.py
+++ b/crunevo/routes/auth_routes.py
@@ -465,6 +465,21 @@ def update_avatar():
     return redirect(url_for("auth.perfil"))
 
 
+@auth_bp.route("/perfil/banner", methods=["POST"])
+@activated_required
+def update_banner():
+    file = request.files.get("banner")
+    if not file or not file.filename:
+        flash("No se seleccionó ninguna imagen", "danger")
+        return redirect(url_for("auth.perfil"))
+
+    res = cloudinary.uploader.upload(file, resource_type="image")
+    current_user.banner_url = res["secure_url"]
+    db.session.commit()
+    flash("Banner actualizado")
+    return redirect(url_for("auth.perfil"))
+
+
 @auth_bp.route("/user/<int:user_id>")
 @activated_required
 def public_profile(user_id):

--- a/crunevo/static/css/perfil.css
+++ b/crunevo/static/css/perfil.css
@@ -189,7 +189,7 @@
   position: absolute;
   bottom: 0;
   left: 50%;
-  transform: translateX(-50%);
+  transform: translateX(-50%) scale(0.8);
   background: #8B5CF6;
   color: white;
   border: none;
@@ -201,7 +201,12 @@
   align-items: center;
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
   cursor: pointer;
-  transition: background 0.2s ease;
+  opacity: 0;
+  transition: all 0.3s ease;
+}
+.profile-avatar-container:hover .avatar-edit-btn {
+  opacity: 1;
+  transform: translateX(-50%) scale(1);
 }
 
 .avatar-edit-btn:hover {
@@ -226,5 +231,5 @@
 }
 
 .profile-header {
-  padding-top: 80px;
+  padding-top: 0;
 }

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -892,6 +892,25 @@ document.addEventListener('DOMContentLoaded', () => {
     };
   }
 
+  const bannerInput = document.getElementById('bannerInput');
+  const bannerPreview = document.getElementById('bannerPreview');
+  const saveBannerBtn = document.getElementById('saveBannerBtn');
+  if (bannerInput && bannerPreview) {
+    bannerInput.addEventListener('change', () => {
+      const file = bannerInput.files[0];
+      if (file) {
+        const reader = new FileReader();
+        reader.onload = (e) => {
+          bannerPreview.src = e.target.result;
+          if (saveBannerBtn) {
+            saveBannerBtn.classList.remove('d-none');
+          }
+        };
+        reader.readAsDataURL(file);
+      }
+    });
+  }
+
   const mainImage = document.getElementById('mainImage');
   if (mainImage) {
     document.querySelectorAll('.product-thumb').forEach((img) => {

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -22,14 +22,18 @@
       <div class="card border-0 shadow-sm mb-4 profile-header">
         <div class="position-relative">
           <div class="profile-header-bg position-relative" style="height: 200px;">
-  {% if user.banner_url %}
-  <img src="{{ user.banner_url }}" class="w-100 h-100 object-fit-cover" alt="Banner">
-  {% endif %}
+  <img src="{{ user.banner_url or url_for('static', filename='img/default.png') }}" id="bannerPreview" class="w-100 h-100 object-fit-cover" alt="Banner">
 
   {% if current_user.id == user.id %}
-  <button class="profile-banner-edit" onclick="editBanner()">
-    <i class="bi bi-camera"></i> Cambiar Banner
-  </button>
+  <form id="bannerForm" method="POST" enctype="multipart/form-data"
+        action="{{ url_for('auth.update_banner') }}" class="position-absolute end-0 top-0 p-2">
+    {{ csrf.csrf_field() }}
+    <input type="file" name="banner" id="bannerInput" accept="image/*" hidden>
+    <button type="button" class="profile-banner-edit" onclick="document.getElementById('bannerInput').click()">
+      <i class="bi bi-camera"></i> Cambiar Banner
+    </button>
+    <button type="submit" id="saveBannerBtn" class="btn btn-success d-none mt-2">Guardar Banner</button>
+  </form>
   {% endif %}
 </div>
         </div>
@@ -439,6 +443,15 @@
               </div>
               <div class="progress" style="height: 6px;">
                 <div class="progress-bar bg-success" style="width: {{ participation_percentage }}%"></div>
+              </div>
+
+              <div class="d-flex justify-content-between mb-2">
+                <span><i class="bi bi-journal-text me-1"></i> Apuntes subidos</span>
+                <span class="fw-bold">{{ user.notes|length }}</span>
+              </div>
+              <div class="d-flex justify-content-between">
+                <span><i class="bi bi-coin me-1"></i> Crolars acumulados</span>
+                <span class="fw-bold">{{ user.credits }}</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- tweak profile avatar button hover effect and remove header padding
- allow changing banner with preview and save button
- add banner update route
- show stats for uploaded notes and crolars
- document work in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686c69104660832596ef2f106e01d246