### PR TITLE
Improve feed gallery layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -694,3 +694,5 @@
 - Perfil mejorado: botones de avatar y banner con previsualización y estadísticas completas (PR profile-banner-fixes)
 - Added test ensuring /notes loads correctly with updated include syntax (QA notes-page-test).
 - Feed gallery fully redesigned for responsive grids and like icon now uses `bi-fire` by default (PR fire-icon-gallery-fix).
+- Gallery layout polished with adaptive heights and overlay for extra images using new two-images/four-images classes (PR feed-gallery-polish).
+- Unified gallery item border-radius and added cursor pointer on overlays (PR feed-gallery-tuning).

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -807,6 +807,7 @@ body[data-bs-theme="dark"] .comment-box {
   align-items: center;
   justify-content: center;
   font-size: 1.5rem;
+  cursor: pointer;
 }
 
 /* New responsive gallery layout */
@@ -825,7 +826,13 @@ body[data-bs-theme="dark"] .comment-box {
 }
 
 .post-image-single {
+  display: block;
+  margin: 0 auto;
+  max-width: 100%;
+  max-height: 450px;
   object-fit: contain;
+  background-color: #000;
+  border-radius: 10px;
 }
 
 .post-image-grid {
@@ -834,12 +841,36 @@ body[data-bs-theme="dark"] .comment-box {
   width: 100%;
 }
 
+
+/* Grid layout for exactly two images */
+.post-image-grid.two-images img {
+  height: 240px;
+  object-fit: cover;
+  border-radius: 10px;
+}
+
+
+/* Grid layout for exactly four images */
+.post-image-grid.four-images img {
+  height: 180px;
+  object-fit: cover;
+  border-radius: 10px;
+}
+
 .grid-cols-2 {
   grid-template-columns: repeat(2, 1fr);
 }
 
 .grid-cols-3 {
   grid-template-columns: repeat(3, 1fr);
+}
+
+
+/* Grid thumbnails used when more than four images are present */
+.post-image-grid.grid-cols-3 img {
+  height: 160px;
+  object-fit: cover;
+  border-radius: 10px;
 }
 
 .grid-cols-1-2 {
@@ -852,16 +883,18 @@ body[data-bs-theme="dark"] .comment-box {
   gap: 6px;
 }
 
+
 .post-image-large {
   width: 100%;
-  height: 250px;
+  height: 260px;
   object-fit: cover;
   border-radius: 10px;
 }
 
+
 .post-image-small {
   width: 100%;
-  height: 120px;
+  height: 130px;
   object-fit: cover;
   border-radius: 10px;
 }
@@ -870,7 +903,7 @@ body[data-bs-theme="dark"] .comment-box {
   width: 100%;
   height: 160px;
   object-fit: cover;
-  border-radius: 8px;
+  border-radius: 10px;
 }
 
 @media (max-width: 768px) {

--- a/crunevo/templates/components/image_gallery.html
+++ b/crunevo/templates/components/image_gallery.html
@@ -5,7 +5,7 @@
   {% if count == 1 %}
     <img src="{{ urls[0] }}" class="post-image-single" alt="Imagen 1 de la publicación" loading="lazy" onclick="openImageModal('{{ urls[0] }}', 0, '{{ post_id }}')" />
   {% elif count == 2 %}
-    <div class="post-image-grid grid-cols-2">
+    <div class="post-image-grid grid-cols-2 two-images">
       {% for url in urls[:2] %}
       <img src="{{ url }}" class="post-image-grid-item" alt="Imagen {{ loop.index }} de la publicación" loading="lazy" onclick="openImageModal('{{ url }}', {{ loop.index0 }}, '{{ post_id }}')" />
       {% endfor %}
@@ -20,7 +20,7 @@
       </div>
     </div>
   {% elif count == 4 %}
-    <div class="post-image-grid grid-cols-2">
+    <div class="post-image-grid grid-cols-2 four-images">
       {% for url in urls[:4] %}
       <img src="{{ url }}" class="post-image-grid-item" alt="Imagen {{ loop.index }} de la publicación" loading="lazy" onclick="openImageModal('{{ url }}', {{ loop.index0 }}, '{{ post_id }}')" />
       {% endfor %}
@@ -28,11 +28,11 @@
   {% else %}
     <img src="{{ urls[0] }}" class="post-image-large mb-2" alt="Imagen 1 de la publicación" loading="lazy" onclick="openImageModal('{{ urls[0] }}', 0, '{{ post_id }}')" />
     <div class="post-image-grid grid-cols-3">
-      {% for url in urls[1:5] %}
-      <div class="image-thumb{% if loop.last and count > 5 %} more{% endif %}" onclick="openImageModal('{{ url }}', {{ loop.index }}, '{{ post_id }}')"{% if loop.last and count > 5 %} data-more="+{{ count - 5 }}"{% endif %} role="button" tabindex="0">
-        <img src="{{ url }}" class="post-image-grid-item" alt="Imagen {{ loop.index + 1 }} de la publicación" loading="lazy" />
+      <img src="{{ urls[1] }}" class="post-image-grid-item" alt="Imagen 2 de la publicación" loading="lazy" onclick="openImageModal('{{ urls[1] }}', 1, '{{ post_id }}')" />
+      <img src="{{ urls[2] }}" class="post-image-grid-item" alt="Imagen 3 de la publicación" loading="lazy" onclick="openImageModal('{{ urls[2] }}', 2, '{{ post_id }}')" />
+      <div class="image-thumb{% if count > 5 %} more{% endif %}" onclick="openImageModal('{{ urls[3] }}', 3, '{{ post_id }}')"{% if count > 5 %} data-more="+{{ count - 4 }}"{% endif %} role="button" tabindex="0">
+        <img src="{{ urls[3] }}" class="post-image-grid-item" alt="Imagen 4 de la publicación" loading="lazy" />
       </div>
-      {% endfor %}
     </div>
   {% endif %}
 </div>


### PR DESCRIPTION
## Summary
- polish gallery macro with new layout for 1–10 images
- refine feed.css styles for single images and responsive grids
- log the change in AGENTS.md
- unify grid item radius and pointer for overlay

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686c9a2236248325ba790aa4acffbbc8