### PR TITLE
Fix gallery layout with post-specific modal selector

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -699,3 +699,4 @@
 - Improved gallery overlay condition for 5+ images, pointer cursor and modal navigation via window key events (PR fb-gallery-modal-fix).
 - Fixed modal navigation index handling and added missing image alt attributes (PR gallery-modal-index-fix).
 - Updated main.js selector so photo routes load correctly with new gallery classes (PR gallery-modal-selector-fix).
+- Ensured gallery images stretch properly and modal selection stays within each post (PR gallery-layout-fix).

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -983,10 +983,25 @@ body[data-bs-theme="dark"] .comment-box {
   border-radius: 10px;
 }
 
+
 .post-image-grid {
   display: grid;
   gap: 6px;
   width: 100%;
+}
+
+.post-image-grid img {
+  width: 100%;
+  object-fit: cover;
+  display: block;
+  border-radius: 10px;
+}
+
+.post-image-grid.two-images,
+.post-image-grid.four-images {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 6px;
 }
 
 

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -960,11 +960,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const postId = photoMatch[1];
     const idx = parseInt(photoMatch[2], 10) - 1;
     const container = document.querySelector(`[data-post-id='${postId}']`);
-    if (container) {
-      const imgs = container.querySelectorAll('.gallery-image');
-      if (imgs[idx]) {
-        openImageModal(imgs[idx].src, idx, postId);
-      }
+    const imgs = container?.querySelectorAll('.gallery-image') || [];
+    if (imgs[idx]) {
+      openImageModal(imgs[idx].src, idx, postId);
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure gallery images stretch and grid columns are applied
- make modal selector resilient to missing containers
- document change in AGENTS notes

## Testing
- `make fmt`
- `make test` *(fails: KeyboardInterrupt after tests finish)*

------
https://chatgpt.com/codex/tasks/task_e_686cb1ac9f308325ade8e1e0c5bb6135