### PR TITLE
Fix gallery previews and modal image scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -701,3 +701,4 @@
 - Updated main.js selector so photo routes load correctly with new gallery classes (PR gallery-modal-selector-fix).
 - Ensured gallery images stretch properly and modal selection stays within each post (PR gallery-layout-fix).
 - Added grid-row rules for post-image-grid to avoid collapsed layouts (QA post-image-grid-rows).
+- Fixed multi-image preview layout and ensured modal only shows images from the selected post (PR gallery-preview-fix).

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -827,6 +827,7 @@ body[data-bs-theme="dark"] .comment-box {
 .facebook-gallery.two-images {
   display: grid;
   grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr;
   gap: 2px;
   height: 240px;
 }
@@ -835,6 +836,7 @@ body[data-bs-theme="dark"] .comment-box {
 .facebook-gallery.three-images {
   display: grid;
   grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
   gap: 2px;
   height: 240px;
 }
@@ -871,6 +873,7 @@ body[data-bs-theme="dark"] .comment-box {
 .facebook-gallery.five-plus-images {
   display: grid;
   grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
   gap: 2px;
   height: 240px;
 }

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -847,14 +847,20 @@ function resetZoom() {
   applyZoom();
 }
 
-function openImageModal(src, index, postId) {
+function openImageModal(src, index, postId, evt) {
   if (index === undefined || index === null || isNaN(index)) {
     console.error('Índice inválido para modal:', index);
     return;
   }
   
-  // Get image list from data attribute or fallback to DOM search
-  const container = document.querySelector(`[data-post-id='${postId}']`);
+  let container = null;
+  if (evt && evt.currentTarget) {
+    container = evt.currentTarget.closest('.facebook-gallery-wrapper');
+  }
+  if (!container) {
+    container = document.querySelector(`[data-post-id='${postId}']`);
+  }
+
   if (container && container.dataset.images) {
     try {
       imageList = JSON.parse(container.dataset.images);
@@ -862,9 +868,8 @@ function openImageModal(src, index, postId) {
       imageList = [];
     }
   }
-  if (!imageList.length) {
-    const selector = `[data-post-id='${postId}'] .gallery-image`;
-    imageList = Array.from(document.querySelectorAll(selector)).map((img) => img.src);
+  if (!imageList.length && container) {
+    imageList = Array.from(container.querySelectorAll('.gallery-image')).map((img) => img.src);
   }
   
   currentImageIndex = index;

--- a/crunevo/templates/components/image_gallery.html
+++ b/crunevo/templates/components/image_gallery.html
@@ -10,7 +10,7 @@
            class="gallery-image single-image" 
            alt="Imagen 1 de {{ count }}" 
            loading="lazy" 
-           onclick="openImageModal('{{ urls[0] }}', 0, '{{ post_id }}')" 
+           onclick="openImageModal('{{ urls[0] }}', 0, '{{ post_id }}', event)"
            role="button" 
            tabindex="0" />
     </div>
@@ -22,7 +22,7 @@
            class="gallery-image" 
            alt="Imagen {{ loop.index }} de {{ count }}" 
            loading="lazy" 
-           onclick="openImageModal('{{ url }}', {{ loop.index0 }}, '{{ post_id }}')" 
+           onclick="openImageModal('{{ url }}', {{ loop.index0 }}, '{{ post_id }}', event)"
            role="button" 
            tabindex="0" />
       {% endfor %}
@@ -34,7 +34,7 @@
            class="gallery-image large-image" 
            alt="Imagen 1 de {{ count }}" 
            loading="lazy" 
-           onclick="openImageModal('{{ urls[0] }}', 0, '{{ post_id }}')" 
+           onclick="openImageModal('{{ urls[0] }}', 0, '{{ post_id }}', event)"
            role="button" 
            tabindex="0" />
       <div class="small-images-column">
@@ -43,7 +43,7 @@
              class="gallery-image small-image" 
              alt="Imagen {{ loop.index + 1 }} de {{ count }}" 
              loading="lazy" 
-             onclick="openImageModal('{{ url }}', {{ loop.index0 + 1 }}, '{{ post_id }}')" 
+             onclick="openImageModal('{{ url }}', {{ loop.index0 + 1 }}, '{{ post_id }}', event)"
              role="button" 
              tabindex="0" />
         {% endfor %}
@@ -57,7 +57,7 @@
            class="gallery-image" 
            alt="Imagen {{ loop.index }} de {{ count }}" 
            loading="lazy" 
-           onclick="openImageModal('{{ url }}', {{ loop.index0 }}, '{{ post_id }}')" 
+           onclick="openImageModal('{{ url }}', {{ loop.index0 }}, '{{ post_id }}', event)"
            role="button" 
            tabindex="0" />
       {% endfor %}
@@ -69,7 +69,7 @@
            class="gallery-image large-image" 
            alt="Imagen 1 de {{ count }}" 
            loading="lazy" 
-           onclick="openImageModal('{{ urls[0] }}', 0, '{{ post_id }}')" 
+           onclick="openImageModal('{{ urls[0] }}', 0, '{{ post_id }}', event)"
            role="button" 
            tabindex="0" />
       <div class="small-images-grid">
@@ -79,12 +79,12 @@
                class="gallery-image grid-image" 
                alt="Imagen {{ loop.index + 1 }} de {{ count }}" 
                loading="lazy" 
-               onclick="openImageModal('{{ url }}', {{ loop.index0 + 1 }}, '{{ post_id }}')" 
+               onclick="openImageModal('{{ url }}', {{ loop.index0 + 1 }}, '{{ post_id }}', event)"
                role="button" 
                tabindex="0" />
           {% if loop.index == 3 and count > 4 %}
-          <div class="image-overlay" 
-               onclick="openImageModal('{{ url }}', {{ loop.index0 + 1 }}, '{{ post_id }}')" 
+          <div class="image-overlay"
+               onclick="openImageModal('{{ url }}', {{ loop.index0 + 1 }}, '{{ post_id }}', event)"
                role="button" 
                tabindex="0">
             <span class="overlay-text">+{{ count - 4 }}</span>


### PR DESCRIPTION
## Summary
- tweak CSS grid rows for facebook gallery layouts
- scope image modal to clicked post element
- pass event to openImageModal from gallery macro
- document gallery fix in AGENTS log

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686cb972469c8325bd914df2101bac19