### PR TITLE
Fix gallery aspect ratio desktop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -702,3 +702,4 @@
 - Ensured gallery images stretch properly and modal selection stays within each post (PR gallery-layout-fix).
 - Added grid-row rules for post-image-grid to avoid collapsed layouts (QA post-image-grid-rows).
 - Fixed multi-image preview layout and ensured modal only shows images from the selected post (PR gallery-preview-fix).
+- Ajustada altura de .facebook-gallery con aspect-ratio para evitar recortes de imagenes en escritorio (PR gallery-aspect-ratio-fix).

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -838,7 +838,7 @@ body[data-bs-theme="dark"] .comment-box {
   grid-template-columns: 1fr 1fr;
   grid-template-rows: 1fr 1fr;
   gap: 2px;
-  height: 240px;
+  aspect-ratio: 1 / 1;
 }
 
 .facebook-gallery .large-image {
@@ -866,7 +866,7 @@ body[data-bs-theme="dark"] .comment-box {
   grid-template-columns: 1fr 1fr;
   grid-template-rows: 1fr 1fr;
   gap: 2px;
-  height: 240px;
+  aspect-ratio: 1 / 1;
 }
 
 /* Five+ images layout */
@@ -875,7 +875,7 @@ body[data-bs-theme="dark"] .comment-box {
   grid-template-columns: 1fr 1fr;
   grid-template-rows: 1fr 1fr;
   gap: 2px;
-  height: 240px;
+  aspect-ratio: 1 / 1;
 }
 
 .facebook-gallery .small-images-grid {
@@ -942,6 +942,7 @@ body[data-bs-theme="dark"] .comment-box {
   .facebook-gallery.five-plus-images {
     grid-template-columns: 1fr;
     height: auto;
+    aspect-ratio: auto;
   }
   
   .facebook-gallery .large-image {
@@ -958,6 +959,7 @@ body[data-bs-theme="dark"] .comment-box {
   .facebook-gallery.two-images,
   .facebook-gallery.four-images {
     height: 180px;
+    aspect-ratio: auto;
   }
 }
 


### PR DESCRIPTION
## Summary
- adjust `.facebook-gallery` grid styles to use `aspect-ratio` instead of fixed heights
- document change in AGENTS.md

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686cbd9bb08c83259a7775e60931406a