### PR TITLE
Accessibility fixes for feed and components

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -705,3 +705,4 @@
 - Ajustada altura de .facebook-gallery con aspect-ratio para evitar recortes de imagenes en escritorio (PR gallery-aspect-ratio-fix).
 - Uniformizado collage de imágenes del feed con aspect-ratio y grid-auto-rows; las imágenes se adaptan sin dejar espacios grises (PR feed-gallery-consistent).
 - Galería ahora detecta orientación de imágenes al haber dos fotos y aplica clases `.two-horizontal` o `.two-vertical` para evitar recortes (PR gallery-orientation-detect).
+- Improved accessibility: added alt text to various images, aria-labels to icon-only buttons and removed gray background from `.facebook-gallery` (PR accessibility-alt-labels).

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -804,7 +804,6 @@ body[data-bs-theme="dark"] .comment-box {
   border-radius: 10px;
   overflow: hidden;
   position: relative;
-  background: #f0f2f5;
 }
 
 /* Single image layout */
@@ -819,9 +818,8 @@ body[data-bs-theme="dark"] .comment-box {
   width: 100%;
   height: auto;
   max-height: 500px;
-  object-fit: contain;
-  aspect-ratio: auto;
-  background: #000;
+  object-fit: cover;
+  min-height: auto;
 }
 
 /* Two images base layout */
@@ -946,7 +944,7 @@ body[data-bs-theme="dark"] .comment-box {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  aspect-ratio: 1 / 1;
+  min-height: auto;
 }
 
 .facebook-gallery .gallery-image:hover {

--- a/crunevo/templates/components/post_card.html
+++ b/crunevo/templates/components/post_card.html
@@ -41,7 +41,7 @@
 
       <!-- Post actions dropdown -->
       <div class="dropdown">
-        <button class="btn btn-ghost btn-sm rounded-circle" data-bs-toggle="dropdown">
+        <button class="btn btn-ghost btn-sm rounded-circle" data-bs-toggle="dropdown" aria-label="Opciones de publicación">
           <i class="bi bi-three-dots"></i>
         </button>
         <ul class="dropdown-menu dropdown-menu-end shadow border-0 rounded-3">
@@ -152,9 +152,10 @@
 
 
       <!-- Save Button -->
-      <button class="action-btn-enhanced save-btn" 
+      <button class="action-btn-enhanced save-btn"
               data-post-id="{{ post.id }}"
-              data-tooltip="Guardar">
+              data-tooltip="Guardar"
+              aria-label="Guardar publicación">
         <i class="bi bi-bookmark"></i>
       </button>
     </div>

--- a/crunevo/templates/feed/_post_modal.html
+++ b/crunevo/templates/feed/_post_modal.html
@@ -119,7 +119,7 @@
       </button>
 
       <button class="btn btn-ghost d-flex align-items-center justify-content-center save-btn"
-              data-post-id="{{ post.id }}" style="width: 40px; height: 40px;">
+              data-post-id="{{ post.id }}" style="width: 40px; height: 40px;" aria-label="Guardar publicación">
         <i class="bi bi-bookmark"></i>
       </button>
     </div>
@@ -130,7 +130,7 @@
       {% if post.comments %}
         {% for c in post.comments|sort(attribute='timestamp', reverse=True) %}
         <div class="comment-item d-flex gap-3 mb-3 comment-box">
-          <img src="{{ c.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle" width="32" height="32">
+          <img src="{{ c.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle" width="32" height="32" alt="Avatar de {{ c.author.username }}">
           <div class="flex-grow-1">
             <div class="comment-box p-3 rounded-3">
               <div class="fw-semibold small mb-1">{{ c.author.username }}</div>

--- a/crunevo/templates/notes/upload.html
+++ b/crunevo/templates/notes/upload.html
@@ -59,7 +59,7 @@
               </div>
             </div>
             <canvas id="pdfPreview" class="w-100 border rounded shadow-sm mb-3 tw-hidden" style="max-height:400px;"></canvas>
-            <img loading="lazy" id="imgPreview" class="img-fluid border rounded shadow-sm mb-3 tw-hidden" style="max-height:400px;" />
+            <img loading="lazy" id="imgPreview" class="img-fluid border rounded shadow-sm mb-3 tw-hidden" style="max-height:400px;" alt="Vista previa de imagen" />
 
             <div class="mb-3">
               <label class="form-label" for="privacy">Privacidad *</label>

--- a/crunevo/templates/onboarding/finish.html
+++ b/crunevo/templates/onboarding/finish.html
@@ -20,7 +20,7 @@
           <div class="mb-4">
             <label class="form-label fw-semibold">Foto de perfil</label>
             <div class="mb-3">
-              <img id="avatarPreview" src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle shadow" width="96" height="96">
+              <img id="avatarPreview" src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle shadow" width="96" height="96" alt="Avatar actual">
             </div>
             <input class="form-control mb-2" type="file" id="avatarFileInput" name="avatar_file" accept="image/*">
             <small class="form-text text-muted">o pega un enlace:</small>

--- a/crunevo/templates/personal_space/blocks/bloque_block.html
+++ b/crunevo/templates/personal_space/blocks/bloque_block.html
@@ -7,7 +7,7 @@
             <span class="subject-tag">{{ metadata.get('subject') }}</span>
             {% endif %}
         </div>
-        <button class="btn btn-sm btn-ghost" onclick="toggleBloque({{ block.id }})">
+        <button class="btn btn-sm btn-ghost" onclick="toggleBloque({{ block.id }})" aria-label="Mostrar u ocultar bloque">
             <i class="bi bi-chevron-down"></i>
         </button>
     </div>

--- a/crunevo/templates/personal_space/components/block_card.html
+++ b/crunevo/templates/personal_space/components/block_card.html
@@ -31,10 +31,10 @@
                 {% endif %}
             </span>
             {% endif %}
-            <button class="btn-ghost" onclick="editBlock({{ block.id }})">
+            <button class="btn-ghost" onclick="editBlock({{ block.id }})" aria-label="Editar bloque">
                 <i class="bi bi-pencil"></i>
             </button>
-            <button class="btn-ghost" onclick="deleteBlock({{ block.id }})">
+            <button class="btn-ghost" onclick="deleteBlock({{ block.id }})" aria-label="Eliminar bloque">
                 <i class="bi bi-trash"></i>
             </button>
         </div>

--- a/crunevo/templates/store/compras.html
+++ b/crunevo/templates/store/compras.html
@@ -12,7 +12,7 @@
     <div class="card mb-3">
       <div class="row g-0">
         <div class="col-md-2 text-center">
-          <img loading="lazy" src="{{ compra.product.image_url or '/static/img/producto-default.png' }}" class="img-fluid rounded-start">
+          <img loading="lazy" src="{{ compra.product.image_url or '/static/img/producto-default.png' }}" class="img-fluid rounded-start" alt="{{ compra.product.name }}">
         </div>
         <div class="col-md-10">
           <div class="card-body">


### PR DESCRIPTION
## Summary
- remove gray background from `.facebook-gallery`
- prevent aspect-ratio cropping in feed gallery
- add alt attributes to image previews and avatars
- give icon buttons accessible aria-labels
- document changes in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686db30d256083259ae8dc39bf0537fb