### PR TITLE
Improve feed gallery layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -706,3 +706,4 @@
 - Uniformizado collage de imágenes del feed con aspect-ratio y grid-auto-rows; las imágenes se adaptan sin dejar espacios grises (PR feed-gallery-consistent).
 - Galería ahora detecta orientación de imágenes al haber dos fotos y aplica clases `.two-horizontal` o `.two-vertical` para evitar recortes (PR gallery-orientation-detect).
 - Improved accessibility: added alt text to various images, aria-labels to icon-only buttons and removed gray background from `.facebook-gallery` (PR accessibility-alt-labels).
+- Galería ajustada como Facebook: dos verticales lado a lado, preview máximo 5 imágenes con overlay '+X' (PR fb-gallery-improve)

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -837,8 +837,17 @@ body[data-bs-theme="dark"] .comment-box {
 
 /* Two vertical images side by side */
 .facebook-gallery.two-images.two-vertical {
-  grid-template-columns: 1fr 1fr;
-  aspect-ratio: 2 / 1;
+  display: flex;
+  gap: 2px;
+  flex-direction: row;
+  height: auto;
+}
+
+.facebook-gallery.two-images.two-vertical .gallery-image {
+  width: 50%;
+  height: auto;
+  object-fit: cover;
+  aspect-ratio: unset;
 }
 
 /* Three images layout */
@@ -971,7 +980,7 @@ body[data-bs-theme="dark"] .comment-box {
     height: auto;
   }
 
-  .facebook-gallery.two-images,
+  .facebook-gallery.two-images:not(.two-vertical),
   .facebook-gallery.four-images {
     aspect-ratio: 1 / 1;
   }

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -83,8 +83,11 @@ function applyGalleryOrientation() {
     if (imgs.length !== 2) return;
     const update = () => {
       if (imgs[0].naturalWidth && imgs[1].naturalWidth) {
-        const vertical = [...imgs].filter((img) => img.naturalHeight > img.naturalWidth).length;
-        gal.classList.add(vertical === 2 ? 'two-vertical' : 'two-horizontal');
+        const ratio1 = imgs[0].naturalHeight / imgs[0].naturalWidth;
+        const ratio2 = imgs[1].naturalHeight / imgs[1].naturalWidth;
+        const isVertical1 = ratio1 > 1.2;
+        const isVertical2 = ratio2 > 1.2;
+        gal.classList.add(isVertical1 && isVertical2 ? 'two-vertical' : 'two-horizontal');
       }
     };
     imgs.forEach((img) => {

--- a/crunevo/templates/components/image_gallery.html
+++ b/crunevo/templates/components/image_gallery.html
@@ -63,31 +63,31 @@
       {% endfor %}
     </div>
   {% else %}
-    <!-- Five+ images: 1 large left, 3x grid right with overlay -->
+    <!-- Five+ images: 1 large left, 4-grid right with optional overlay -->
     <div class="facebook-gallery five-plus-images">
-      <img src="{{ urls[0] }}" 
-           class="gallery-image large-image" 
-           alt="Imagen 1 de {{ count }}" 
-           loading="lazy" 
+      <img src="{{ urls[0] }}"
+           class="gallery-image large-image"
+           alt="Imagen 1 de {{ count }}"
+           loading="lazy"
            onclick="openImageModal('{{ urls[0] }}', 0, '{{ post_id }}', event)"
-           role="button" 
+           role="button"
            tabindex="0" />
       <div class="small-images-grid">
-        {% for url in urls[1:4] %}
-        <div class="image-container {% if loop.index == 3 %}has-overlay{% endif %}">
-          <img src="{{ url }}" 
-               class="gallery-image grid-image" 
-               alt="Imagen {{ loop.index + 1 }} de {{ count }}" 
-               loading="lazy" 
+        {% for url in urls[1:5] %}
+        <div class="image-container {% if loop.index == 4 and count > 5 %}has-overlay{% endif %}">
+          <img src="{{ url }}"
+               class="gallery-image grid-image"
+               alt="Imagen {{ loop.index + 1 }} de {{ count }}"
+               loading="lazy"
                onclick="openImageModal('{{ url }}', {{ loop.index0 + 1 }}, '{{ post_id }}', event)"
-               role="button" 
+               role="button"
                tabindex="0" />
-          {% if loop.index == 3 and count > 4 %}
+          {% if loop.index == 4 and count > 5 %}
           <div class="image-overlay"
                onclick="openImageModal('{{ url }}', {{ loop.index0 + 1 }}, '{{ post_id }}', event)"
-               role="button" 
+               role="button"
                tabindex="0">
-            <span class="overlay-text">+{{ count - 4 }}</span>
+            <span class="overlay-text">+{{ count - 5 }}</span>
           </div>
           {% endif %}
         </div>


### PR DESCRIPTION
## Summary
- tweak gallery CSS so two vertical images display side-by-side
- update JS orientation detection threshold
- show up to 5 images in gallery preview with overlay on the 5th
- document recent work in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686dc1895d2083258822116d8cf0e427