### PR TITLE
Improve gallery auto height

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -707,3 +707,4 @@
 - Galería ahora detecta orientación de imágenes al haber dos fotos y aplica clases `.two-horizontal` o `.two-vertical` para evitar recortes (PR gallery-orientation-detect).
 - Improved accessibility: added alt text to various images, aria-labels to icon-only buttons and removed gray background from `.facebook-gallery` (PR accessibility-alt-labels).
 - Galería ajustada como Facebook: dos verticales lado a lado, preview máximo 5 imágenes con overlay '+X' (PR fb-gallery-improve)
+- Multi-image layouts now adapt height automatically without forced aspect ratio (PR gallery-auto-height)

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -804,6 +804,8 @@ body[data-bs-theme="dark"] .comment-box {
   border-radius: 10px;
   overflow: hidden;
   position: relative;
+  align-items: stretch;
+  grid-auto-rows: minmax(0, auto);
 }
 
 /* Single image layout */
@@ -856,8 +858,8 @@ body[data-bs-theme="dark"] .comment-box {
   grid-template-columns: 1fr 1fr;
   grid-template-rows: 1fr 1fr;
   gap: 2px;
-  aspect-ratio: 1 / 1;
-  grid-auto-rows: 1fr;
+  aspect-ratio: auto;
+  grid-auto-rows: minmax(0, auto);
 }
 
 .facebook-gallery .large-image {
@@ -885,8 +887,8 @@ body[data-bs-theme="dark"] .comment-box {
   grid-template-columns: 1fr 1fr;
   grid-template-rows: 1fr 1fr;
   gap: 2px;
-  aspect-ratio: 1 / 1;
-  grid-auto-rows: 1fr;
+  aspect-ratio: auto;
+  grid-auto-rows: minmax(0, auto);
 }
 
 /* Five+ images layout */
@@ -895,8 +897,8 @@ body[data-bs-theme="dark"] .comment-box {
   grid-template-columns: 1fr 1fr;
   grid-template-rows: 1fr 1fr;
   gap: 2px;
-  aspect-ratio: 1 / 1;
-  grid-auto-rows: 1fr;
+  aspect-ratio: auto;
+  grid-auto-rows: minmax(0, auto);
 }
 
 .facebook-gallery .small-images-grid {
@@ -986,10 +988,19 @@ body[data-bs-theme="dark"] .comment-box {
   }
 }
 
+@media (min-width: 992px) {
+  .facebook-gallery.three-images,
+  .facebook-gallery.four-images,
+  .facebook-gallery.five-plus-images {
+    aspect-ratio: auto;
+  }
+}
+
 /* New responsive gallery layout */
 .post-image-wrapper {
   display: block;
   width: 100%;
+  height: auto;
   border-radius: 10px;
   overflow: hidden;
 }


### PR DESCRIPTION
## Summary
- tune facebook-gallery base rules for auto height
- allow three/four/five-image galleries to size naturally
- add desktop override removing aspect-ratio
- ensure post-image-wrapper height is auto
- document changes in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686dd2e54c008325a3080d028916d3db