### PR TITLE
Fix feed HTTPS redirect during tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -708,3 +708,4 @@
 - Improved accessibility: added alt text to various images, aria-labels to icon-only buttons and removed gray background from `.facebook-gallery` (PR accessibility-alt-labels).
 - Galería ajustada como Facebook: dos verticales lado a lado, preview máximo 5 imágenes con overlay '+X' (PR fb-gallery-improve)
 - Multi-image layouts now adapt height automatically without forced aspect ratio (PR gallery-auto-height)
+- Talisman ahora no fuerza HTTPS en modo de pruebas para evitar redirecciones (task feed fix).

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -186,7 +186,7 @@ def create_app():
         talisman.init_app(
             app,
             content_security_policy=csp,
-            force_https=True,
+            force_https=not app.config.get("TESTING", False),
             strict_transport_security=True,
         )
     login_manager.login_view = "auth.login"


### PR DESCRIPTION
## Summary
- avoid HTTPS enforcement when running tests so feed routes work
- document the change in `AGENTS.md`

## Testing
- `make fmt`
- `make test` *(fails: 7 failed)*

------
https://chatgpt.com/codex/tasks/task_e_686de65044f48325bf98eba5a59d2e5b