### PR TITLE
Unify feed post template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -710,3 +710,4 @@
 - Multi-image layouts now adapt height automatically without forced aspect ratio (PR gallery-auto-height)
 - Talisman ahora no fuerza HTTPS en modo de pruebas para evitar redirecciones (task feed fix).
 - Restored base.html to fix blank feed after redesign (PR feed-base-restore).
+- Unificada carga de posts en /feed usando un solo template moderno y API HTML (PR feed-post-unify).

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -652,20 +652,17 @@ class CrunevoFeedManager {
 
     try {
       this.currentPage++;
-      const response = await fetch(`/feed/api/feed?page=${this.currentPage}&categoria=${this.currentFilter}`);
-      const items = await response.json();
+      const response = await fetch(`/feed/api/feed?page=${this.currentPage}&categoria=${this.currentFilter}&format=html`);
+      const data = await response.json();
 
-      if (items.length === 0) {
+      if (!data.html || data.count === 0) {
         const end = document.getElementById('feedEnd');
         if (end) end.style.display = 'none';
         return;
       }
 
       const container = document.getElementById('feedContainer');
-      items.forEach(item => {
-        const html = this.renderFeedItem(item);
-        if (html) container.insertAdjacentHTML('beforeend', html);
-      });
+      container.insertAdjacentHTML('beforeend', data.html);
 
       this.initPostInteractions();
       this.initGalleryEnhancements();
@@ -677,48 +674,6 @@ class CrunevoFeedManager {
     }
   }
 
-  renderFeedItem(item) {
-    if (item.item_type === 'post') {
-      return `
-        <div class="post-card" data-post-id="${item.id}">
-          <div class="post-header">
-            <img src="${item.author_avatar || '/static/img/default.png'}" alt="Avatar" class="post-avatar">
-            <div class="post-user-info">
-              <h6 class="post-username">${item.author_username}</h6>
-              <small class="post-timestamp">${item.created_at}</small>
-            </div>
-            <button class="post-options" aria-label="Opciones">
-              <i class="bi bi-three-dots"></i>
-            </button>
-          </div>
-          <div class="post-content">
-            <p class="post-text">${item.content || ''}</p>
-          </div>
-          <div class="post-actions">
-            <div class="action-buttons">
-              <button class="action-btn like-btn" data-post-id="${item.id}">
-                <i class="bi bi-fire"></i>
-                <span>Me gusta</span>
-              </button>
-              <button class="action-btn comment-btn" data-post-id="${item.id}">
-                <i class="bi bi-chat"></i>
-                <span>Comentar</span>
-              </button>
-              <button class="action-btn share-btn" data-post-id="${item.id}">
-                <i class="bi bi-share"></i>
-                <span>Compartir</span>
-              </button>
-              <button class="action-btn save-btn" data-post-id="${item.id}">
-                <i class="bi bi-bookmark"></i>
-                <span>Guardar</span>
-              </button>
-            </div>
-          </div>
-        </div>
-      `;
-    }
-    return '';
-  }
 
   initModals() {
     document.querySelectorAll('.modal').forEach(modalEl => {


### PR DESCRIPTION
## Summary
- modify `/api/feed` to optionally return HTML post cards
- remove old JS template and fetch rendered cards for infinite scroll
- document the change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686df007050c8325aed5800c38158ce6