### PR TITLE
Fix facebook-post overflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -714,3 +714,4 @@
 - Limpieza de plantillas del feed: eliminado feed_mobile, list.html y CSS antiguo. feed_routes usa solo feed/feed.html. (PR feed-templates-cleanup)
 - Revisado feed por duplicados y añadido console.log de currentPage en feed.js (PR feed-duplicate-debug).
 - Corregida duplicación de posts antiguos verificando existencia en el DOM y en api_feed; se añadieron headers de seguridad y mejoras de accesibilidad. (PR feed-dup-accessibility-fix)
+- Ajustado contenedor `.facebook-post` para que se expanda con sus galerías y corregido `fb-gallery img` para evitar recortes. (PR facebook-post-overflow-fix)

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -127,8 +127,8 @@
 }
 
 .fb-gallery img {
-  width: 100%;
-  height: 100%;
+  max-width: 100%;
+  height: auto;
   object-fit: cover;
   display: block;
   cursor: pointer;
@@ -444,5 +444,12 @@ body {
 }
 
 [data-bs-theme="dark"] .fb-attachment {
-  background: #3A3B3C;
+  background: #3A3B3C;}
+
+/* Ensure facebook-post containers expand to fit galleries */
+.facebook-post {
+  display: block;
+  overflow: visible !important;
+  height: auto !important;
+  min-height: unset !important;
 }


### PR DESCRIPTION
## Summary
- ensure gallery images don't break the layout
- allow `.facebook-post` to expand so galleries aren't cut off
- note change in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686e0c18430c8325839af26f29557008