### PR TITLE
Fix trending variable names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -715,3 +715,4 @@
 - Revisado feed por duplicados y añadido console.log de currentPage en feed.js (PR feed-duplicate-debug).
 - Corregida duplicación de posts antiguos verificando existencia en el DOM y en api_feed; se añadieron headers de seguridad y mejoras de accesibilidad. (PR feed-dup-accessibility-fix)
 - Ajustado .fb-post y .fb-gallery para que la tarjeta crezca con imágenes múltiples (PR post-card-auto-height).
+- Fixed trending.html variables to weekly_posts and top_notes to avoid UndefinedError (PR trending-variable-fix).

--- a/crunevo/templates/feed/trending.html
+++ b/crunevo/templates/feed/trending.html
@@ -117,7 +117,7 @@
         <h2 class="section-title">Publicaciones más votadas</h2>
       </div>
 
-      {% for post in trending_posts[:5] %}
+      {% for post in weekly_posts[:5] %}
       <div class="trending-post">
         <div class="d-flex align-items-start gap-3">
           <img src="{{ post.author.avatar_url or url_for('static', filename='img/default.png') }}" 
@@ -158,7 +158,7 @@
         <h2 class="section-title">Apuntes más relevantes</h2>
       </div>
 
-      {% for note in trending_notes[:5] %}
+      {% for note in top_notes[:5] %}
       <div class="trending-post">
         <div class="d-flex align-items-start gap-3">
           <img src="{{ note.author.avatar_url or url_for('static', filename='img/default.png') }}" 


### PR DESCRIPTION
## Summary
- fix trending page by referencing weekly_posts and top_notes
- document change in AGENTS log

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686e193cbe1883259566e84df4e0dfc5