### PR TITLE
Fix moment error and add csrf field

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -716,3 +716,4 @@
 - Corregida duplicación de posts antiguos verificando existencia en el DOM y en api_feed; se añadieron headers de seguridad y mejoras de accesibilidad. (PR feed-dup-accessibility-fix)
 - Ajustado .fb-post y .fb-gallery para que la tarjeta crezca con imágenes múltiples (PR post-card-auto-height).
 - Fixed trending.html variables to weekly_posts and top_notes to avoid UndefinedError (PR trending-variable-fix).
+- Replaced moment.js filters with timesince/strftime and ensured CSRF macros in producto.html (PR moment-usage-removal).

--- a/crunevo/templates/components/post_card.html
+++ b/crunevo/templates/components/post_card.html
@@ -36,7 +36,7 @@
       </div>
       
       <div class="post-timestamp">
-        {{ moment(post.created_at).fromNow() }}
+        {{ post.created_at|timesince }}
         {% if post.edited %}
         <span class="edited-indicator">· Editado</span>
         {% endif %}
@@ -185,7 +185,7 @@
             <h6 class="modal-title mb-0" id="commentsModalLabel-{{ post.id }}">
               {{ author.username if author else 'Usuario eliminado' }}
             </h6>
-            <small class="text-muted">{{ moment(post.created_at).fromNow() }}</small>
+            <small class="text-muted">{{ post.created_at|timesince }}</small>
           </div>
         </div>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
@@ -225,7 +225,7 @@
                   <p class="comment-text mb-1">{{ comment.body }}</p>
                 </div>
                 <div class="comment-meta d-flex align-items-center gap-3">
-                  <small class="text-muted">{{ moment(comment.timestamp).fromNow() }}</small>
+                  <small class="text-muted">{{ comment.timestamp|timesince }}</small>
                   <button class="btn btn-link btn-sm p-0 text-muted">Responder</button>
                   {% if current_user.is_authenticated and (current_user.id == comment.author_id or current_user.role in ['admin', 'moderator']) %}
                   <button class="btn btn-link btn-sm p-0 text-danger" onclick="deleteComment('{{ comment.id }}', '{{ post.id }}')">

--- a/crunevo/templates/store/producto.html
+++ b/crunevo/templates/store/producto.html
@@ -1,5 +1,6 @@
 
 {% extends "base.html" %}
+{% import "components/csrf.html" as csrf %}
 
 {% block title %}{{ product.name }} - Tienda CRUNEVO{% endblock %}
 
@@ -110,7 +111,7 @@
             {% if current_user.is_authenticated %}
               {% if product.stock > 0 %}
               <form action="{{ url_for('store.add_to_cart') }}" method="POST" class="add-cart-form">
-                {{ csrf_token() }}
+                {{ csrf.csrf_field() }}
                 <input type="hidden" name="product_id" value="{{ product.id }}">
                 <div class="quantity-selector">
                   <label for="quantity">Cantidad:</label>
@@ -133,7 +134,7 @@
               {% endif %}
               
               <form action="{{ url_for('store.toggle_favorite') }}" method="POST" class="favorite-form">
-                {{ csrf_token() }}
+                {{ csrf.csrf_field() }}
                 <input type="hidden" name="product_id" value="{{ product.id }}">
                 <button type="submit" class="btn-favorite {{ 'active' if is_favorite }}">
                   <i class="bi bi-heart{{ '-fill' if is_favorite else '' }}"></i>
@@ -162,7 +163,7 @@
             </div>
             <div class="meta-item">
               <strong>Agregado:</strong>
-              <span>{{ moment(product.created_at).format('DD/MM/YYYY') }}</span>
+              <span>{{ product.created_at.strftime('%d/%m/%Y') }}</span>
             </div>
           </div>
         </div>
@@ -192,7 +193,7 @@
                     </div>
                   </div>
                 </div>
-                <small class="review-date">{{ moment(review.created_at).fromNow() }}</small>
+                <small class="review-date">{{ review.created_at|timesince }}</small>
               </div>
               <p class="review-content">{{ review.content }}</p>
             </div>


### PR DESCRIPTION
## Summary
- replace outdated moment() usage with `timesince` filter in post cards
- show product creation and review dates using strftime and timesince
- ensure forms in producto.html include `csrf_field`
- record these changes in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686e21a7f3748325948f45e9d451215c