### PR TITLE
Improve Fly port troubleshooting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -667,6 +667,7 @@
 - Mejorada accesibilidad del marketplace: botones con íconos tienen title, campos de dirección con placeholder y overlays usan role="button" (PR accessibility-html-fix).
 - Exposed openProductRequestModal and clearAllFilters on window to avoid ReferenceError when used inline (PR store-js-global-functions).
 - Added note to README explaining how to resolve Fly.io warning about the app not listening on 0.0.0.0:8080 (PR fly-port-doc).
+- Clarified troubleshooting steps for the Fly port warning, suggesting `fly logs -a crunevo2` to verify Gunicorn starts (QA fly-port-troubleshoot).
 - Sidebar in store page can be collapsed with a new button, hero header removed and product grid shows up to 5 items per row (PR store-collapse-sidebar).
 - Permite publicar productos desde la tienda con modal y ruta /store/publicar-producto; productos se crean con is_approved=False (PR store-user-publish).
 - Added gradient header and basic tab navigation for Mi Carrera; initialization moved to main.js to avoid extra DOMContentLoaded listener (PR career-header-fix).

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ This command sets the `DATABASE_URL` secret automatically. Verify it with
 If Fly warns that the app is not listening on `0.0.0.0:8080`, double-check that
 your Dockerfile binds Gunicorn to that address and that `internal_port = 8080`
 is set in `fly.toml`. You can inspect startup errors with `fly logs`.
+If the warning persists even with those settings, run `fly logs -a crunevo2` to
+verify Gunicorn starts correctly. Startup errors will prevent the app from
+binding to port `8080` and trigger this message.
 
 If you want to run the application locally but use a PostgreSQL
 database hosted on Fly.io:


### PR DESCRIPTION
## Summary
- explain how to debug port warnings when deploying on Fly
- record troubleshooting note in AGENTS log

## Testing
- `make fmt`
- `make test` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686f54c1eddc83259a720d67c7712bbf