### PR TITLE
Add plain /health endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -726,3 +726,4 @@
 - Comment modal now uses vertical gallery with fullscreen view on mobile (PR comment-modal-vertical)
 - Fixed comments not loading in photo view by aligning markup and gallery lookup (PR comment-photo-view-fix)
 - Photo view route now passes photo_index and loads comments dynamically via dataset (PR photo-view-comments-fix)
+- /health endpoint now returns plain "ok" with status 200 and test updated (PR health-endpoint-plain).

--- a/crunevo/wsgi.py
+++ b/crunevo/wsgi.py
@@ -1,9 +1,9 @@
 from crunevo.app import create_app
-from typing import Dict
+from typing import Tuple
 
 app = create_app()
 
 
 @app.route("/health")
-def health() -> Dict[str, str]:
-    return {"status": "ok"}
+def health() -> Tuple[str, int]:
+    return "ok", 200

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -5,8 +5,8 @@ from crunevo.app import create_app
 def test_health_endpoint():
     os.environ["ENABLE_TALISMAN"] = "0"
     app = create_app()
-    app.add_url_rule("/health", "health", lambda: {"status": "ok"})
+    app.add_url_rule("/health", "health", lambda: ("ok", 200))
     with app.test_client() as client:
         resp = client.get("/health")
         assert resp.status_code == 200
-        assert resp.get_json() == {"status": "ok"}
+        assert resp.data == b"ok"


### PR DESCRIPTION
## Summary
- update `/health` endpoint to return plain text 200
- adjust health test for plain text
- document latest change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686f5c2a30b883258f54f47e5371e721