### PR TITLE
Improve comment modal with carousel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -727,3 +727,4 @@
 - Fixed comments not loading in photo view by aligning markup and gallery lookup (PR comment-photo-view-fix)
 - Photo view route now passes photo_index and loads comments dynamically via dataset (PR photo-view-comments-fix)
 - /health endpoint now returns plain "ok" with status 200 and test updated (PR health-endpoint-plain).
+- Comment modal redesigned with carousel gallery and static backdrop (PR comment-modal-carousel)

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -1448,9 +1448,30 @@ select:focus {
     max-height: 250px;
   }
 
-  .modal-gallery-overlay .overlay-text {
-    font-size: 18px;
-  }
+.modal-gallery-overlay .overlay-text {
+  font-size: 18px;
+}
+}
+
+/* Facebook style comment modal */
+.facebook-post-modal .modal-content {
+  max-height: 90vh;
+}
+
+.facebook-post-modal .modal-left {
+  background: #000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.facebook-post-modal .image-slide {
+  max-height: 90vh;
+  object-fit: contain;
+}
+
+.facebook-post-modal .modal-right {
+  overflow-y: auto;
 }
 
 /* Reduced motion support */

--- a/crunevo/static/js/comment.js
+++ b/crunevo/static/js/comment.js
@@ -30,7 +30,7 @@
   function openCommentsModal(postId) {
     const modalEl = document.getElementById(`commentsModal-${postId}`);
     if (!modalEl) return;
-    const modal = new bootstrap.Modal(modalEl);
+    const modal = new bootstrap.Modal(modalEl, { backdrop: 'static', keyboard: true });
     modal.show();
     setTimeout(() => {
       const input = modalEl.querySelector('.comment-input');

--- a/crunevo/templates/components/comment_modal.html
+++ b/crunevo/templates/components/comment_modal.html
@@ -1,34 +1,9 @@
 <!-- Modal de Comentarios con Galería Completa -->
-<div class="modal fade" id="commentsModal-{{ post.id }}" tabindex="-1" aria-labelledby="commentsModalLabel-{{ post.id }}" aria-hidden="true">
-  <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable modal-fullscreen-sm-down">
-    <div class="modal-content">
-      <!-- Header del Modal -->
-      <div class="modal-header border-0 pb-0">
-        <div class="d-flex align-items-center">
-          <img src="{{ post.author.avatar_url if post.author else url_for('static', filename='img/default.png') }}" 
-               alt="{{ post.author.username if post.author else 'Usuario eliminado' }}"
-               class="rounded-circle me-3" 
-               style="width: 40px; height: 40px; object-fit: cover;">
-          <div>
-            <h6 class="mb-0 fw-bold">{{ post.author.username if post.author else 'Usuario eliminado' }}</h6>
-            <small class="text-muted">{{ post.created_at|timesince }}</small>
-          </div>
-        </div>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
-      </div>
-
-      <!-- Contenido del Post -->
-      <div class="modal-body p-0">
-        <!-- Texto del Post -->
-        {% if post.content %}
-        <div class="px-4 py-3">
-          <p class="mb-0">{{ post.content }}</p>
-        </div>
-        {% endif %}
-
-        <!-- Galería Completa de Imágenes -->
+<div class="modal fade" id="commentsModal-{{ post.id }}" tabindex="-1" aria-labelledby="commentsModalLabel-{{ post.id }}" aria-hidden="true" data-bs-backdrop="static">
+  <div class="modal-dialog modal-xl facebook-post-modal">
+    <div class="modal-content d-flex flex-row">
+      <div class="modal-left col-md-7 p-0">
         {% if post.images or (post.file_url and not post.file_url.endswith('.pdf')) %}
-        <div class="modal-gallery-container">
           {% if post.images %}
             {% set image_count = post.images|length %}
             {% set image_urls = post.images | map(attribute='url') | list %}
@@ -36,89 +11,90 @@
             {% set image_count = 1 %}
             {% set image_urls = [post.file_url] %}
           {% endif %}
-
-          <div class="facebook-gallery-modal modal-gallery-vertical" data-post-id="{{ post.id }}" data-images='{{ image_urls | tojson }}'>
-            {% for url in image_urls %}
-            <div class="modal-gallery-item">
-              <img src="{{ url }}"
-                   alt="Imagen {{ loop.index }} de {{ image_count }}"
-                   onclick="openImageModal('{{ url }}', {{ loop.index0 }}, '{{ post.id }}', event)"
-                   loading="lazy"
-                   class="modal-gallery-image" />
+          <div id="commentCarousel-{{ post.id }}" class="carousel slide" data-bs-touch="true" data-bs-interval="false" data-bs-keyboard="true">
+            <div class="carousel-inner">
+              {% for url in image_urls %}
+              <div class="carousel-item {{ 'active' if loop.first }}">
+                <img src="{{ url }}" class="d-block w-100 image-slide" alt="Imagen {{ loop.index }} de {{ image_count }}" onclick="openImageModal('{{ url }}', {{ loop.index0 }}, '{{ post.id }}', event)">
+              </div>
+              {% endfor %}
             </div>
-            {% endfor %}
+            {% if image_count > 1 %}
+            <button class="carousel-control-prev" type="button" data-bs-target="#commentCarousel-{{ post.id }}" data-bs-slide="prev">
+              <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+              <span class="visually-hidden">Anterior</span>
+            </button>
+            <button class="carousel-control-next" type="button" data-bs-target="#commentCarousel-{{ post.id }}" data-bs-slide="next">
+              <span class="carousel-control-next-icon" aria-hidden="true"></span>
+              <span class="visually-hidden">Siguiente</span>
+            </button>
+            {% endif %}
           </div>
-        </div>
         {% endif %}
-
-        <!-- Acciones del Post (Me gusta, etc.) -->
-        <div class="modal-post-actions px-4 py-2 border-top border-bottom">
-          <div class="d-flex justify-content-around">
-            <button class="modal-action-btn like-btn {{ 'active' if user_reactions.get(post.id) }}"
-                    data-post-id="{{ post.id }}"
-                    data-reaction="🔥">
-              <i class="bi bi-fire{{ '-fill' if user_reactions.get(post.id) else '' }}"></i>
-              <span>Me gusta</span>
-            </button>
-            <button class="modal-action-btn share-btn" data-post-id="{{ post.id }}">
-              <i class="bi bi-share"></i>
-              <span>Compartir</span>
-            </button>
-            <button class="modal-action-btn save-btn" data-post-id="{{ post.id }}">
-              <i class="bi bi-bookmark"></i>
-              <span>Guardar</span>
-            </button>
-          </div>
-        </div>
-
-        <!-- Sección de Comentarios -->
-        <div class="modal-comments-section">
-          <!-- Lista de Comentarios Existentes -->
-          <div class="comments-list" id="commentsList-{{ post.id }}">
-            {% for comment in post.comments[:10] %}
-            <div class="comment-item d-flex mb-3">
-              <img src="{{ comment.author.avatar_url if comment.author else url_for('static', filename='img/default.png') }}" 
-                   alt="{{ comment.author.username if comment.author else 'Usuario' }}"
-                   class="rounded-circle me-2" 
-                   style="width: 32px; height: 32px; object-fit: cover;">
-              <div class="flex-grow-1">
-                <div class="comment-bubble bg-light rounded-3 p-2">
-                  <div class="comment-author fw-semibold small">
-                    {{ comment.author.username if comment.author else 'Usuario eliminado' }}
-                  </div>
-                  <div class="comment-text">{{ comment.body }}</div>
-                </div>
-                <div class="comment-meta mt-1">
-                  <small class="text-muted">{{ comment.timestamp|timesince }}</small>
-                  <button class="btn btn-link btn-sm p-0 ms-2 text-muted">Responder</button>
-                </div>
-              </div>
+      </div>
+      <div class="modal-right col-md-5 p-3 d-flex flex-column">
+        <div class="modal-header border-0 pb-0">
+          <div class="d-flex align-items-center">
+            <img src="{{ post.author.avatar_url if post.author else url_for('static', filename='img/default.png') }}" alt="{{ post.author.username if post.author else 'Usuario eliminado' }}" class="rounded-circle me-3" style="width:40px;height:40px;object-fit:cover;">
+            <div>
+              <h6 class="mb-0 fw-bold">{{ post.author.username if post.author else 'Usuario eliminado' }}</h6>
+              <small class="text-muted">{{ post.created_at|timesince }}</small>
             </div>
-            {% endfor %}
           </div>
-
-          <!-- Formulario para Agregar Comentario -->
-          <div class="add-comment-form mt-3">
-            <form class="comment-form d-flex align-items-center" data-post-id="{{ post.id }}" onsubmit="submitModalComment(event, '{{ post.id }}')">
-              <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" 
-                   alt="{{ current_user.username }}"
-                   class="rounded-circle me-2" 
-                   style="width: 32px; height: 32px; object-fit: cover;">
-              <div class="flex-grow-1 position-relative">
-                <input type="text" 
-                       class="form-control comment-input rounded-pill" 
-                       placeholder="Escribe un comentario..." 
-                       name="body"
-                       style="padding-right: 40px;">
-                <button type="submit" 
-                        class="btn position-absolute end-0 top-50 translate-middle-y me-2"
-                        style="border: none; background: none; color: #1877F2;"
-                        disabled>
-                  <i class="bi bi-send-fill"></i>
-                </button>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+        </div>
+        <div class="modal-body pt-3 flex-grow-1 overflow-auto">
+          {% if post.content %}
+          <p class="mb-3">{{ post.content }}</p>
+          {% endif %}
+          <div class="modal-post-actions px-0 pb-2 border-bottom">
+            <div class="d-flex justify-content-around">
+              <button class="modal-action-btn like-btn {{ 'active' if user_reactions.get(post.id) }}" data-post-id="{{ post.id }}" data-reaction="🔥">
+                <i class="bi bi-fire{{ '-fill' if user_reactions.get(post.id) else '' }}"></i>
+                <span>Me gusta</span>
+              </button>
+              <button class="modal-action-btn share-btn" data-post-id="{{ post.id }}">
+                <i class="bi bi-share"></i>
+                <span>Compartir</span>
+              </button>
+              <button class="modal-action-btn save-btn" data-post-id="{{ post.id }}">
+                <i class="bi bi-bookmark"></i>
+                <span>Guardar</span>
+              </button>
+            </div>
+          </div>
+          <div class="modal-comments-section mt-3">
+            <div class="comments-list" id="commentsList-{{ post.id }}">
+              {% for comment in post.comments[:10] %}
+              <div class="comment-item d-flex mb-3">
+                <img src="{{ comment.author.avatar_url if comment.author else url_for('static', filename='img/default.png') }}" alt="{{ comment.author.username if comment.author else 'Usuario' }}" class="rounded-circle me-2" style="width:32px;height:32px;object-fit:cover;">
+                <div class="flex-grow-1">
+                  <div class="comment-bubble bg-light rounded-3 p-2">
+                    <div class="comment-author fw-semibold small">
+                      {{ comment.author.username if comment.author else 'Usuario eliminado' }}
+                    </div>
+                    <div class="comment-text">{{ comment.body }}</div>
+                  </div>
+                  <div class="comment-meta mt-1">
+                    <small class="text-muted">{{ comment.timestamp|timesince }}</small>
+                    <button class="btn btn-link btn-sm p-0 ms-2 text-muted">Responder</button>
+                  </div>
+                </div>
               </div>
-              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            </form>
+              {% endfor %}
+            </div>
+            <div class="add-comment-form mt-3">
+              <form class="comment-form d-flex align-items-center" data-post-id="{{ post.id }}" onsubmit="submitModalComment(event, '{{ post.id }}')">
+                <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" alt="{{ current_user.username }}" class="rounded-circle me-2" style="width:32px;height:32px;object-fit:cover;">
+                <div class="flex-grow-1 position-relative">
+                  <input type="text" class="form-control comment-input rounded-pill" placeholder="Escribe un comentario..." name="body" style="padding-right:40px;">
+                  <button type="submit" class="btn position-absolute end-0 top-50 translate-middle-y me-2" style="border:none;background:none;color:#1877F2;" disabled>
+                    <i class="bi bi-send-fill"></i>
+                  </button>
+                </div>
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+              </form>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- redesign comment modal with Facebook-style layout
- add Bootstrap carousel for multi-image posts
- prevent accidental close with static backdrop
- document changes in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686f5edf8dec832583d53ce1e76bbd4f