### PR TITLE
Unify comment modal layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -727,3 +727,4 @@
 - Fixed comments not loading in photo view by aligning markup and gallery lookup (PR comment-photo-view-fix)
 - Photo view route now passes photo_index and loads comments dynamically via dataset (PR photo-view-comments-fix)
 - /health endpoint now returns plain "ok" with status 200 and test updated (PR health-endpoint-plain).
+- Redesigned comment modal with two-column layout and updated post_detail.html to match (PR unified-comment-modal).

--- a/crunevo/templates/components/comment_modal.html
+++ b/crunevo/templates/components/comment_modal.html
@@ -1,6 +1,6 @@
 <!-- Modal de Comentarios con Galería Completa -->
 <div class="modal fade" id="commentsModal-{{ post.id }}" tabindex="-1" aria-labelledby="commentsModalLabel-{{ post.id }}" aria-hidden="true">
-  <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable modal-fullscreen-sm-down">
+  <div class="modal-dialog modal-xl modal-dialog-centered modal-fullscreen-sm-down">
     <div class="modal-content">
       <!-- Header del Modal -->
       <div class="modal-header border-0 pb-0">
@@ -19,106 +19,99 @@
 
       <!-- Contenido del Post -->
       <div class="modal-body p-0">
-        <!-- Texto del Post -->
-        {% if post.content %}
-        <div class="px-4 py-3">
-          <p class="mb-0">{{ post.content }}</p>
-        </div>
-        {% endif %}
-
-        <!-- Galería Completa de Imágenes -->
-        {% if post.images or (post.file_url and not post.file_url.endswith('.pdf')) %}
-        <div class="modal-gallery-container">
-          {% if post.images %}
-            {% set image_count = post.images|length %}
-            {% set image_urls = post.images | map(attribute='url') | list %}
-          {% else %}
-            {% set image_count = 1 %}
-            {% set image_urls = [post.file_url] %}
-          {% endif %}
-
-          <div class="facebook-gallery-modal modal-gallery-vertical" data-post-id="{{ post.id }}" data-images='{{ image_urls | tojson }}'>
-            {% for url in image_urls %}
-            <div class="modal-gallery-item">
-              <img src="{{ url }}"
-                   alt="Imagen {{ loop.index }} de {{ image_count }}"
-                   onclick="openImageModal('{{ url }}', {{ loop.index0 }}, '{{ post.id }}', event)"
-                   loading="lazy"
-                   class="modal-gallery-image" />
-            </div>
-            {% endfor %}
-          </div>
-        </div>
-        {% endif %}
-
-        <!-- Acciones del Post (Me gusta, etc.) -->
-        <div class="modal-post-actions px-4 py-2 border-top border-bottom">
-          <div class="d-flex justify-content-around">
-            <button class="modal-action-btn like-btn {{ 'active' if user_reactions.get(post.id) }}"
-                    data-post-id="{{ post.id }}"
-                    data-reaction="🔥">
-              <i class="bi bi-fire{{ '-fill' if user_reactions.get(post.id) else '' }}"></i>
-              <span>Me gusta</span>
-            </button>
-            <button class="modal-action-btn share-btn" data-post-id="{{ post.id }}">
-              <i class="bi bi-share"></i>
-              <span>Compartir</span>
-            </button>
-            <button class="modal-action-btn save-btn" data-post-id="{{ post.id }}">
-              <i class="bi bi-bookmark"></i>
-              <span>Guardar</span>
-            </button>
-          </div>
-        </div>
-
-        <!-- Sección de Comentarios -->
-        <div class="modal-comments-section">
-          <!-- Lista de Comentarios Existentes -->
-          <div class="comments-list" id="commentsList-{{ post.id }}">
-            {% for comment in post.comments[:10] %}
-            <div class="comment-item d-flex mb-3">
-              <img src="{{ comment.author.avatar_url if comment.author else url_for('static', filename='img/default.png') }}" 
-                   alt="{{ comment.author.username if comment.author else 'Usuario' }}"
-                   class="rounded-circle me-2" 
-                   style="width: 32px; height: 32px; object-fit: cover;">
-              <div class="flex-grow-1">
-                <div class="comment-bubble bg-light rounded-3 p-2">
-                  <div class="comment-author fw-semibold small">
-                    {{ comment.author.username if comment.author else 'Usuario eliminado' }}
-                  </div>
-                  <div class="comment-text">{{ comment.body }}</div>
+        <div class="row g-0">
+          <div class="col-md-7 p-3">
+            {% if post.content %}
+            <p class="mb-3">{{ post.content }}</p>
+            {% endif %}
+            {% if post.images or (post.file_url and not post.file_url.endswith('.pdf')) %}
+            <div class="modal-gallery-container mb-3">
+              {% if post.images %}
+                {% set image_count = post.images|length %}
+                {% set image_urls = post.images | map(attribute='url') | list %}
+              {% else %}
+                {% set image_count = 1 %}
+                {% set image_urls = [post.file_url] %}
+              {% endif %}
+              <div class="facebook-gallery-modal modal-gallery-vertical" data-post-id="{{ post.id }}" data-images='{{ image_urls | tojson }}'>
+                {% for url in image_urls %}
+                <div class="modal-gallery-item">
+                  <img src="{{ url }}"
+                       alt="Imagen {{ loop.index }} de {{ image_count }}"
+                       onclick="openImageModal('{{ url }}', {{ loop.index0 }}, '{{ post.id }}', event)"
+                       loading="lazy"
+                       class="modal-gallery-image" />
                 </div>
-                <div class="comment-meta mt-1">
-                  <small class="text-muted">{{ comment.timestamp|timesince }}</small>
-                  <button class="btn btn-link btn-sm p-0 ms-2 text-muted">Responder</button>
-                </div>
+                {% endfor %}
               </div>
             </div>
-            {% endfor %}
-          </div>
-
-          <!-- Formulario para Agregar Comentario -->
-          <div class="add-comment-form mt-3">
-            <form class="comment-form d-flex align-items-center" data-post-id="{{ post.id }}" onsubmit="submitModalComment(event, '{{ post.id }}')">
-              <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" 
-                   alt="{{ current_user.username }}"
-                   class="rounded-circle me-2" 
-                   style="width: 32px; height: 32px; object-fit: cover;">
-              <div class="flex-grow-1 position-relative">
-                <input type="text" 
-                       class="form-control comment-input rounded-pill" 
-                       placeholder="Escribe un comentario..." 
-                       name="body"
-                       style="padding-right: 40px;">
-                <button type="submit" 
-                        class="btn position-absolute end-0 top-50 translate-middle-y me-2"
-                        style="border: none; background: none; color: #1877F2;"
-                        disabled>
-                  <i class="bi bi-send-fill"></i>
+            {% endif %}
+            <div class="modal-post-actions px-2 py-2 border-top border-bottom">
+              <div class="d-flex justify-content-around">
+                <button class="modal-action-btn like-btn {{ 'active' if user_reactions.get(post.id) }}"
+                        data-post-id="{{ post.id }}"
+                        data-reaction="🔥">
+                  <i class="bi bi-fire{{ '-fill' if user_reactions.get(post.id) else '' }}"></i>
+                  <span>Me gusta</span>
+                </button>
+                <button class="modal-action-btn share-btn" data-post-id="{{ post.id }}">
+                  <i class="bi bi-share"></i>
+                  <span>Compartir</span>
+                </button>
+                <button class="modal-action-btn save-btn" data-post-id="{{ post.id }}">
+                  <i class="bi bi-bookmark"></i>
+                  <span>Guardar</span>
                 </button>
               </div>
-              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            </form>
+            </div>
+          </div>
+          <div class="col-md-5 border-start p-3" id="modal-comments-area">
+            <div class="modal-comments-section">
+              <div class="comments-list" id="commentsList-{{ post.id }}">
+                {% for comment in post.comments[:10] %}
+                <div class="comment-item d-flex mb-3">
+                  <img src="{{ comment.author.avatar_url if comment.author else url_for('static', filename='img/default.png') }}"
+                       alt="{{ comment.author.username if comment.author else 'Usuario' }}"
+                       class="rounded-circle me-2"
+                       style="width: 32px; height: 32px; object-fit: cover;">
+                  <div class="flex-grow-1">
+                    <div class="comment-bubble bg-light rounded-3 p-2">
+                      <div class="comment-author fw-semibold small">
+                        {{ comment.author.username if comment.author else 'Usuario eliminado' }}
+                      </div>
+                      <div class="comment-text">{{ comment.body }}</div>
+                    </div>
+                    <div class="comment-meta mt-1">
+                      <small class="text-muted">{{ comment.timestamp|timesince }}</small>
+                      <button class="btn btn-link btn-sm p-0 ms-2 text-muted">Responder</button>
+                    </div>
+                  </div>
+                </div>
+                {% endfor %}
+              </div>
+              <div class="add-comment-form mt-3">
+                <form class="comment-form d-flex align-items-center" data-post-id="{{ post.id }}" onsubmit="submitModalComment(event, '{{ post.id }}')">
+                  <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}"
+                       alt="{{ current_user.username }}"
+                       class="rounded-circle me-2"
+                       style="width: 32px; height: 32px; object-fit: cover;">
+                  <div class="flex-grow-1 position-relative">
+                    <input type="text"
+                           class="form-control comment-input rounded-pill"
+                           placeholder="Escribe un comentario..."
+                           name="body"
+                           style="padding-right: 40px;">
+                    <button type="submit"
+                            class="btn position-absolute end-0 top-50 translate-middle-y me-2"
+                            style="border: none; background: none; color: #1877F2;"
+                            disabled>
+                      <i class="bi bi-send-fill"></i>
+                    </button>
+                  </div>
+                  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                </form>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/crunevo/templates/feed/post_detail.html
+++ b/crunevo/templates/feed/post_detail.html
@@ -6,8 +6,10 @@
 {% block og_description %}{{ og_description or (post.content|striptags)|truncate(100) }}{% endblock %}
 {% if og_image %}{% block og_image %}{{ og_image }}{% endblock %}{% endif %}
 {% block content %}
-<div class="card mb-4 shadow-sm border-0 rounded-4" data-post-id="{{ post.id }}"{% if photo_index %} data-photo-index="{{ photo_index }}"{% endif %}>
-  <div class="card-body p-4">
+<div class="row justify-content-center">
+  <div class="col-md-7">
+    <div class="card mb-4 shadow-sm border-0 rounded-4" data-post-id="{{ post.id }}"{% if photo_index %} data-photo-index="{{ photo_index }}"{% endif %}>
+      <div class="card-body p-4">
     <div class="d-flex align-items-center mb-2">
       {% set author = post.author %}
       {% if author %}
@@ -62,47 +64,54 @@
         </a>
         {% endif %}
       </div>
-
-      <h6 class="mt-3 mb-2">Comentarios</h6>
-      {% if photo_index %}
-      <div id="comment-section" data-post-id="{{ post.id }}" data-photo-index="{{ photo_index }}">
-        <div class="loader"></div>
       </div>
-      {% else %}
-      <div id="comments{{ post.id }}" class="comment-container" data-post-id="{{ post.id }}">
-        {% if post.comments %}
-          {% for c in post.comments|sort(attribute='timestamp', reverse=True) %}
-          <div class="d-flex mb-3 comment comment-item comment-box">
-            <img loading="lazy" src="{{ c.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
-            <div>
-              <div class="small text-muted">
-                <a href="{{ url_for('auth.profile_by_username', username=c.author.username) }}" class="text-decoration-none">{{ c.author.username }}</a> • {{ c.timestamp.strftime('%Y-%m-%d %H:%M') }}
-              </div>
-              <div>{{ c.body }}</div>
-            </div>
-          </div>
-          {% endfor %}
-        {% else %}
-          <p class="text-muted" data-empty-msg>Sé el primero en comentar esta publicación.</p>
-        {% endif %}
-      </div>
-      <form
-        id="commentForm"
-        method="post"
-        action="{{ url_for('feed.comment_post', post_id=post.id) }}"
-        data-container="comments{{ post.id }}"
-        data-avatar="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}"
-        data-username="{{ current_user.username }}"
-      >
-        {{ csrf.csrf_field() }}
-        <div class="input-group mb-2">
-          <input type="text" name="body" class="form-control" placeholder="Añadir comentario" required>
-          <button class="btn btn-primary" type="submit">Enviar</button>
-        </div>
-      </form>
-      {% endif %}
     </div>
   </div>
+  <div class="col-md-5">
+    <div class="card mb-4 shadow-sm border-0 rounded-4">
+      <div class="card-body p-4">
+        <h6 class="mb-3">Comentarios</h6>
+        {% if photo_index %}
+        <div id="comment-section" data-post-id="{{ post.id }}" data-photo-index="{{ photo_index }}">
+          <div class="loader"></div>
+        </div>
+        {% else %}
+        <div id="comments{{ post.id }}" class="comment-container" data-post-id="{{ post.id }}">
+          {% if post.comments %}
+            {% for c in post.comments|sort(attribute='timestamp', reverse=True) %}
+            <div class="d-flex mb-3 comment comment-item comment-box">
+              <img loading="lazy" src="{{ c.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
+              <div>
+                <div class="small text-muted">
+                  <a href="{{ url_for('auth.profile_by_username', username=c.author.username) }}" class="text-decoration-none">{{ c.author.username }}</a> • {{ c.timestamp.strftime('%Y-%m-%d %H:%M') }}
+                </div>
+                <div>{{ c.body }}</div>
+              </div>
+            </div>
+            {% endfor %}
+          {% else %}
+            <p class="text-muted" data-empty-msg>Sé el primero en comentar esta publicación.</p>
+          {% endif %}
+        </div>
+        <form
+          id="commentForm"
+          method="post"
+          action="{{ url_for('feed.comment_post', post_id=post.id) }}"
+          data-container="comments{{ post.id }}"
+          data-avatar="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}"
+          data-username="{{ current_user.username }}"
+        >
+          {{ csrf.csrf_field() }}
+          <div class="input-group mb-2">
+            <input type="text" name="body" class="form-control" placeholder="Añadir comentario" required>
+            <button class="btn btn-primary" type="submit">Enviar</button>
+          </div>
+        </form>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
 {% endblock %}
 
 {% block body_end %}


### PR DESCRIPTION
## Summary
- redesign comment modal with two-column layout
- match `/feed/post/<id>` with the same structure
- log the change in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686f601a1944832592e519bea31160db