### PR TITLE
Implement inline comments and post detail view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -727,3 +727,6 @@
 - Fixed comments not loading in photo view by aligning markup and gallery lookup (PR comment-photo-view-fix)
 - Photo view route now passes photo_index and loads comments dynamically via dataset (PR photo-view-comments-fix)
 - /health endpoint now returns plain "ok" with status 200 and test updated (PR health-endpoint-plain).
+- Reimplemented inline comments in feed with AJAX loading and unified post detail
+  using the same post card component. Comments expand below each post and the
+  detail view shows a "Volver al feed" button. (PR feed-inline-comments)

--- a/crunevo/templates/components/post_card.html
+++ b/crunevo/templates/components/post_card.html
@@ -4,6 +4,8 @@
 {% set reaction_counts = reaction_counts if reaction_counts is defined else {} %}
 {% set user_reactions = user_reactions if user_reactions is defined else {} %}
 {% import 'components/image_gallery.html' as gallery %}
+{% import 'components/csrf.html' as csrf %}
+{% set show_comments = show_comments if show_comments is defined else False %}
 
 <article class="facebook-post" data-post-id="{{ post.id }}" data-comment-permission="{{ post.comment_permission }}">
   <!-- Post Header -->
@@ -153,7 +155,7 @@
       <span class="action-count">{{ post_reactions.get('🔥', '') }}</span>
     </button>
 
-    <button class="fb-action-btn comment-btn" data-post-id="{{ post.id }}" onclick="openCommentsModal('{{ post.id }}')">
+    <button class="fb-action-btn comment-btn" data-post-id="{{ post.id }}">
       <i class="bi bi-chat"></i>
       <span class="action-text">Comentar</span>
       <span class="action-count">{{ post.comments|length if post.comments|length > 0 else '' }}</span>
@@ -171,7 +173,16 @@
   </div>
 </article>
 
-<!-- Comments Modal -->
-{% with post=post, user_reactions=user_reactions %}
-{% include 'components/comment_modal.html' %}
-{% endwith %}
+<section id="comments-{{ post.id }}" class="comments-section" data-post-id="{{ post.id }}"{% if not show_comments %} style="display:none;"{% endif %}>
+  <form method="post" class="comment-form" data-post-id="{{ post.id }}">
+    {{ csrf.csrf_field() }}
+    <div class="comment-input-container">
+      <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" class="comment-avatar-img" width="32" height="32" alt="avatar">
+      <textarea class="comment-input" placeholder="Escribe un comentario..." rows="1" required></textarea>
+      <button type="submit" class="comment-submit-btn" disabled>
+        <i class="bi bi-send-fill"></i>
+      </button>
+    </div>
+  </form>
+  <div class="comments-container"></div>
+</section>

--- a/crunevo/templates/feed/post_detail.html
+++ b/crunevo/templates/feed/post_detail.html
@@ -1,110 +1,14 @@
 {% extends 'base.html' %}
 {% import 'components/csrf.html' as csrf %}
-{% import 'components/reactions.html' as react %}
-{% import 'components/image_gallery.html' as gallery %}
 {% block og_title %}{{ og_title or 'Publicación de ' ~ (post.author.username if post.author else 'usuario') }}{% endblock %}
 {% block og_description %}{{ og_description or (post.content|striptags)|truncate(100) }}{% endblock %}
 {% if og_image %}{% block og_image %}{{ og_image }}{% endblock %}{% endif %}
 {% block content %}
-<div class="card mb-4 shadow-sm border-0 rounded-4" data-post-id="{{ post.id }}"{% if photo_index %} data-photo-index="{{ photo_index }}"{% endif %}>
-  <div class="card-body p-4">
-    <div class="d-flex align-items-center mb-2">
-      {% set author = post.author %}
-      {% if author %}
-      <img loading="lazy" src="{{ author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
-      <a href="{{ url_for('auth.profile_by_username', username=author.username) }}" class="me-auto text-decoration-none">
-        <strong>{{ author.username }}</strong>
-      </a>
-      {% else %}
-      <img loading="lazy" src="{{ url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
-      <span class="me-auto text-muted">Usuario eliminado</span>
-      {% endif %}
-      <small class="text-muted">{{ post.created_at.strftime('%Y-%m-%d') }}{% if post.edited %} • Editado{% endif %}</small>
-    </div>
-    <p class="card-text">{{ post.content }}</p>
-    {% set preview = post.content | link_preview %}
-    {% if preview %}
-    <div class="link-preview card mb-3">
-      <a href="{{ preview.url }}" target="_blank" rel="noopener" class="text-decoration-none">
-        {% if preview.image %}
-        <img src="{{ preview.image }}" class="card-img-top" alt="Vista previa">
-        {% endif %}
-        <div class="card-body">
-          <strong class="card-title">{{ preview.title }}</strong>
-          {% if preview.description %}
-          <p class="card-text small">{{ preview.description }}</p>
-          {% endif %}
-          <small class="text-muted">{{ preview.site_name }}</small>
-        </div>
-      </a>
-    </div>
-    {% endif %}
-      {% if post.images %}
-      {{ gallery.image_gallery(post.images, post.id) }}
-      {% elif post.file_url %}
-        {% if post.file_url.endswith('.pdf') %}
-        <a href="{{ post.file_url }}" target="_blank" class="btn btn-outline-primary mb-2">Ver PDF</a>
-        {% else %}
-        {{ gallery.image_gallery([{'url': post.file_url}], post.id) }}
-        {% endif %}
-      {% endif %}
-      {% set counts = reaction_counts %}
-      {{ react.reaction_container(post, counts, user_reaction) }}
-
-      <div class="d-flex gap-2 my-3">
-        <button type="button" class="btn btn-outline-secondary btn-sm share-btn" data-share-url="{{ url_for('feed.view_post', post_id=post.id, _external=True) }}">
-          <i class="bi bi-share"></i> Compartir
-        </button>
-        {% if author %}
-        <a href="{{ url_for('auth.profile_by_username', username=author.username) }}" class="btn btn-outline-info btn-sm">Ver perfil</a>
-        <a href="{{ url_for('feed.user_posts', user_id=author.id) }}" class="btn btn-outline-primary btn-sm">
-          Ver más publicaciones de este usuario
-        </a>
-        {% endif %}
-      </div>
-
-      <h6 class="mt-3 mb-2">Comentarios</h6>
-      {% if photo_index %}
-      <div id="comment-section" data-post-id="{{ post.id }}" data-photo-index="{{ photo_index }}">
-        <div class="loader"></div>
-      </div>
-      {% else %}
-      <div id="comments{{ post.id }}" class="comment-container" data-post-id="{{ post.id }}">
-        {% if post.comments %}
-          {% for c in post.comments|sort(attribute='timestamp', reverse=True) %}
-          <div class="d-flex mb-3 comment comment-item comment-box">
-            <img loading="lazy" src="{{ c.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
-            <div>
-              <div class="small text-muted">
-                <a href="{{ url_for('auth.profile_by_username', username=c.author.username) }}" class="text-decoration-none">{{ c.author.username }}</a> • {{ c.timestamp.strftime('%Y-%m-%d %H:%M') }}
-              </div>
-              <div>{{ c.body }}</div>
-            </div>
-          </div>
-          {% endfor %}
-        {% else %}
-          <p class="text-muted" data-empty-msg>Sé el primero en comentar esta publicación.</p>
-        {% endif %}
-      </div>
-      <form
-        id="commentForm"
-        method="post"
-        action="{{ url_for('feed.comment_post', post_id=post.id) }}"
-        data-container="comments{{ post.id }}"
-        data-avatar="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}"
-        data-username="{{ current_user.username }}"
-      >
-        {{ csrf.csrf_field() }}
-        <div class="input-group mb-2">
-          <input type="text" name="body" class="form-control" placeholder="Añadir comentario" required>
-          <button class="btn btn-primary" type="submit">Enviar</button>
-        </div>
-      </form>
-      {% endif %}
-    </div>
-  </div>
-{% endblock %}
-
-{% block body_end %}
-{{ super() }}
+<div class="container my-4">
+  <a href="{{ url_for('feed.view_feed') }}" class="btn btn-link mb-3"><i class="bi bi-arrow-left"></i> Volver al feed</a>
+  {% set item = {'data': post} %}
+  {% set user_reactions = {post.id: user_reaction} %}
+  {% set show_comments = True %}
+  {% include 'components/post_card.html' with context %}
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- expand comments inline in the feed instead of a modal
- reuse `post_card.html` to display posts with comment forms
- show post card on `/feed/post/<id>` with a back link
- add JS helpers to fetch comments via AJAX and display relative times
- document change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686f657713c883258cdc044f85fc79fe