### PR TITLE
Fix photo modal panel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -727,3 +727,4 @@
 - Fixed comments not loading in photo view by aligning markup and gallery lookup (PR comment-photo-view-fix)
 - Photo view route now passes photo_index and loads comments dynamically via dataset (PR photo-view-comments-fix)
 - /health endpoint now returns plain "ok" with status 200 and test updated (PR health-endpoint-plain).
+- Removed duplicate image modal markup from base.html to ensure photo view loads post details correctly (PR photo-modal-duplicate-fix).

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -176,31 +176,6 @@
     {% include 'components/quick_notes.html' %}
     {% endif %}
 
-    <!-- Image Modal -->
-    <div id="imageModal" class="image-modal hidden" role="dialog" aria-modal="true" onclick="outsideImageClick(event)" tabindex="-1">
-      <button type="button" class="close" aria-label="Cerrar" onclick="closeImageModal()">✖</button>
-      <div class="modal-body-wrapper">
-        <div class="modal-image-container position-relative">
-          <a id="modalImageLink" target="_blank" rel="noopener">
-            <img class="modal-content" id="modalImage" alt="Imagen">
-          </a>
-          <div class="zoom-controls">
-            <button type="button" aria-label="Acercar" onclick="zoomIn()"><i class="bi bi-plus-lg"></i></button>
-            <button type="button" aria-label="Alejar" onclick="zoomOut()"><i class="bi bi-dash-lg"></i></button>
-            <button type="button" aria-label="Ajustar" onclick="resetZoom()"><i class="bi bi-arrows-fullscreen"></i></button>
-          </div>
-          <button type="button" class="modal-nav prev" aria-label="Imagen anterior" onclick="prevImage()"><i class="bi bi-chevron-left"></i></button>
-          <button type="button" class="modal-nav next" aria-label="Siguiente imagen" onclick="nextImage()"><i class="bi bi-chevron-right"></i></button>
-        </div>
-        <div class="text-center mt-2">
-          <a id="openImageNewTab" target="_blank" class="text-decoration-none link-light" rel="noopener">
-            Abrir imagen <i class="bi bi-box-arrow-up-right"></i>
-          </a>
-        </div>
-        <div id="imageModalInfo" class="modal-details"></div>
-      </div>
-      <div class="modal-counter" id="modalCounter"></div>
-    </div>
 
     <!-- Bootstrap JS -->
     <script src="{{ url_for('static', filename='vendor/bootstrap.bundle.min.js') }}"></script>


### PR DESCRIPTION
## Summary
- remove old image modal markup from base template so fetches target the new modal
- note change in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686fdaa235988325bfbf79ac32cad3ef