### PR TITLE
Fix profile menu item and purple verified badge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -732,3 +732,4 @@
 - Comment modal now reuses image_gallery macro for consistent gallery layout with feed (PR gallery-modal-unify).
 - Navbar cleaned: removed Ranking link, backpack moved into personal space with new block. Launcher menu redesigned with grid of app icons. (PR grid-launcher-refresh)
 - Launcher menu modernized with new component and CSS; floating options icon removed from profile via main.js (PR profile-launcher-redesign)
+- Removed empty 'misiones' item from user dropdown and styled verified badge in purple (PR perfil-menu-badge-fix).

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -109,8 +109,12 @@
 }
 
 .verified-badge {
-  color: var(--blue-link);
+  background-color: transparent !important;
+  border: none !important;
+  color: #a855f7 !important;
   font-size: 14px;
+  padding: 4px 8px;
+  border-radius: 4px;
 }
 
 .user-career {

--- a/crunevo/static/css/main.css
+++ b/crunevo/static/css/main.css
@@ -623,13 +623,14 @@ textarea.form-control {
 }
 
 .verified-badge {
-  background: linear-gradient(135deg, var(--crunevo-success), #38a169);
-  color: white;
-  border-radius: var(--radius-lg);
+  background-color: transparent !important;
+  border: none !important;
+  color: #a855f7 !important;
+  border-radius: 4px;
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);
-  padding: var(--space-1) var(--space-2);
+  padding: 4px 8px;
   font-size: 0.7rem;
   font-weight: 600;
 }

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -96,8 +96,6 @@
               <li><a class="dropdown-item" href="{{ url_for('auth.perfil') }}">
                 <i class="bi bi-person me-2"></i>Mi Perfil
               </a></li>
-              <li><a class="dropdown-item" href="{{ url_for('auth.perfil', tab='misiones') }}">
-              </a></li>
               <li><a class="dropdown-item" href="{{ url_for('saved.list_saved') }}">
                 <i class="bi bi-bookmark me-2"></i>Guardados
               </a></li>


### PR DESCRIPTION
## Summary
- remove empty entry in user dropdown
- style `.verified-badge` with purple color and no border
- document changes in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68708294e4508325a48186dce0e4ae3b