### PR TITLE
Fix achievements grid and progress

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -733,3 +733,4 @@
 - Navbar cleaned: removed Ranking link, backpack moved into personal space with new block. Launcher menu redesigned with grid of app icons. (PR grid-launcher-refresh)
 - Launcher menu modernized with new component and CSS; floating options icon removed from profile via main.js (PR profile-launcher-redesign)
 - Removed empty 'misiones' item from user dropdown and styled verified badge in purple (PR perfil-menu-badge-fix).
+- Rediseñados logros en perfil público e interno con tarjetas responsivas, progreso y logros bloqueados; perfil_publico incluye perfil.css y feed.py usa import diferido de tasks (PR achievements-ui-fix).

--- a/crunevo/constants/achievement_details.py
+++ b/crunevo/constants/achievement_details.py
@@ -21,12 +21,12 @@ ACHIEVEMENT_DETAILS = {
         "description": "Ayudaste a otro usuario en el foro",
     },
     "embajador_crunevo": {
-        "title": "Embajador Crunevo \ud83c\udf3c",
+        "title": "Embajador Crunevo",
         "icon": "bi-people-fill",
         "description": "Invitaste a 10 o m\u00e1s usuarios",
     },
     "aliado_educativo": {
-        "title": "Aliado educativo \ud83d\udcac",
+        "title": "Aliado educativo",
         "icon": "bi-chat-square-text",
         "description": "Un referido subi\u00f3 apuntes",
     },

--- a/crunevo/routes/auth_routes.py
+++ b/crunevo/routes/auth_routes.py
@@ -246,7 +246,7 @@ def perfil():
         Comment,
         Purchase,
     )
-    from crunevo.constants import ACHIEVEMENT_CATEGORIES
+    from crunevo.constants import ACHIEVEMENT_DETAILS, ACHIEVEMENT_CATEGORIES
 
     saved = SavedPost.query.filter_by(user_id=current_user.id).all()
     posts = [Post.query.get(sp.post_id) for sp in saved if Post.query.get(sp.post_id)]
@@ -352,13 +352,17 @@ def perfil():
     recent_activities = recent_activities[:5]
 
     ach_type = request.args.get("tipo")
-    achievements = current_user.achievements
+    all_user_achievements = current_user.achievements
+    achievements = all_user_achievements
     if ach_type:
         achievements = [
             a
-            for a in achievements
+            for a in all_user_achievements
             if ACHIEVEMENT_CATEGORIES.get(a.badge_code) == ach_type
         ]
+
+    total_achievements = len(ACHIEVEMENT_DETAILS)
+    user_achievements_map = {a.badge_code: a for a in all_user_achievements}
 
     misiones = None
     progresos = None
@@ -436,6 +440,9 @@ def perfil():
         participation_percentage=participation_percentage,
         recent_activities=recent_activities,
         purchases=purchases,
+        total_achievements=total_achievements,
+        user_achievements_map=user_achievements_map,
+        user_achievements=all_user_achievements,
     )
 
 

--- a/crunevo/static/css/perfil.css
+++ b/crunevo/static/css/perfil.css
@@ -129,6 +129,12 @@
   border-color: var(--crunevo-primary);
 }
 
+.achievement-item.locked {
+  opacity: 0.5;
+  filter: grayscale(80%);
+  pointer-events: none;
+}
+
 .achievement-icon {
   font-size: 28px;
   margin-bottom: 8px;

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -367,36 +367,39 @@
 
         <!-- Achievements Tab -->
         <div class="tab-pane fade {% if tab == 'logros' %}show active{% endif %}" id="achievements-tab">
-          <div class="row g-3">
-            {% for achievement in user_achievements %}
-            <div class="col-md-4">
-              <div class="card border-0 shadow-sm text-center achievement-card" id="achievement-{{ achievement.code }}">
+          <div class="mb-3">
+            <div class="progress" style="height: 8px;">
+              <div class="progress-bar bg-success" style="width: {{ (user_achievements|length / total_achievements) * 100 }}%"></div>
+            </div>
+            <small class="text-muted">Has desbloqueado {{ user_achievements|length }}/{{ total_achievements }} logros</small>
+          </div>
+          <div class="row row-cols-2 row-cols-md-3 g-3">
+            {% for code, info in ACHIEVEMENT_DETAILS.items() %}
+            {% set ua = user_achievements_map.get(code) %}
+            <div class="col">
+              <div class="card achievement-card border-0 shadow-sm text-center {% if not ua %}locked{% endif %}" {% if not ua %}data-bs-toggle="tooltip" title="Aún no obtenido"{% endif %}>
                 <div class="card-body p-3">
                   <div class="achievement-icon mb-2">
-                    <i class="bi bi-trophy-fill display-4 text-warning"></i>
+                    <i class="bi {{ info.icon }} display-4 {% if ua %}text-warning{% else %}text-muted{% endif %}"></i>
                   </div>
-                  <h6 class="fw-bold mb-1">{{ achievement.title }}</h6>
-                  <p class="text-muted small mb-2">{{ achievement.description }}</p>
-                  <small class="text-muted">
-                    Desbloqueado {{ achievement.unlocked_date.strftime('%d/%m/%Y') }}
-                  </small>
+                  <h6 class="fw-bold mb-1">{{ info.title }}</h6>
+                  {% if ua %}
+                  <small class="text-muted">{{ ua.timestamp|timesince }}</small>
+                  {% else %}
+                  <small class="text-muted">Bloqueado</small>
+                  {% endif %}
                 </div>
               </div>
             </div>
-            {% else %}
+            {% endfor %}
+            {% if user_achievements|length == 0 %}
             <div class="col-12">
               <div class="text-center py-5">
                 <i class="bi bi-award display-1 text-muted mb-3"></i>
-                <h5 class="text-muted">Sin logros desbloqueados</h5>
-                {% if is_own_profile %}
-                <p class="text-muted mb-3">¡Completa misiones para desbloquear logros!</p>
-                <a href="{{ url_for('auth.perfil', tab='misiones') }}" class="btn btn-primary">
-                  <i class="bi bi-trophy"></i> Ver Misiones
-                </a>
-                {% endif %}
+                <p class="text-muted">Aún no has desbloqueado ningún logro. ¡Sigue participando en CRUNEVO para comenzar!</p>
               </div>
             </div>
-            {% endfor %}
+            {% endif %}
           </div>
         </div>
 

--- a/crunevo/templates/perfil_publico.html
+++ b/crunevo/templates/perfil_publico.html
@@ -1,5 +1,10 @@
 {% extends 'base.html' %}
 {% import 'components/csrf.html' as csrf %}
+
+{% block head_extra %}
+{{ super() }}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/perfil.css') }}">
+{% endblock %}
 {% block content %}
 <div class="container my-4">
   <div class="text-center mb-5">

--- a/crunevo/utils/feed.py
+++ b/crunevo/utils/feed.py
@@ -1,5 +1,4 @@
 from crunevo.models import User
-from crunevo.tasks import task_queue, insert_feed_items
 
 
 def create_feed_item_for_all(
@@ -8,6 +7,8 @@ def create_feed_item_for_all(
     """Enqueue creation of feed items for all or selected users."""
     if owner_ids is None:
         owner_ids = [u.id for u in User.query.with_entities(User.id).all()]
+
+    from crunevo.tasks import task_queue, insert_feed_items
 
     task_queue.enqueue(
         insert_feed_items,


### PR DESCRIPTION
## Summary
- include perfil.css on public profile to restore achievement layout
- show all achievements on internal profile with progress bar and locked state
- add locked style in perfil.css
- lazily import tasks in feed utilities to avoid circular errors
- remove emoji from achievement titles
- document changes in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687087724bb0832589d3ef8af2f37654