### PR TITLE
Redesign achievements in profile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -734,3 +734,4 @@
 - Launcher menu modernized with new component and CSS; floating options icon removed from profile via main.js (PR profile-launcher-redesign)
 - Removed empty 'misiones' item from user dropdown and styled verified badge in purple (PR perfil-menu-badge-fix).
 - Rediseñados logros en perfil público e interno con tarjetas responsivas, progreso y logros bloqueados; perfil_publico incluye perfil.css y feed.py usa import diferido de tasks (PR achievements-ui-fix).
+- Módulo de logros renovado: tarjetas con tooltips, secciones de desbloqueados y bloqueados, botón 'Ver todos' y soporte responsivo/dark (PR achievements-redesign-modern).

--- a/crunevo/routes/auth_routes.py
+++ b/crunevo/routes/auth_routes.py
@@ -364,6 +364,14 @@ def perfil():
     total_achievements = len(ACHIEVEMENT_DETAILS)
     user_achievements_map = {a.badge_code: a for a in all_user_achievements}
 
+    unlocked_achievements = []
+    locked_achievements = []
+    for code, info in ACHIEVEMENT_DETAILS.items():
+        if code in user_achievements_map:
+            unlocked_achievements.append((code, info))
+        else:
+            locked_achievements.append((code, info))
+
     misiones = None
     progresos = None
     group_missions = None
@@ -443,6 +451,8 @@ def perfil():
         total_achievements=total_achievements,
         user_achievements_map=user_achievements_map,
         user_achievements=all_user_achievements,
+        unlocked_achievements=unlocked_achievements,
+        locked_achievements=locked_achievements,
     )
 
 

--- a/crunevo/static/css/perfil.css
+++ b/crunevo/static/css/perfil.css
@@ -100,50 +100,50 @@
   margin-top: 4px;
 }
 
-.achievement-grid {
+.achievements-section {
+  margin-bottom: 2rem;
+}
+
+.achievements-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
-  gap: 16px;
-  padding: 20px;
-  background: linear-gradient(135deg, #F8FAFC, #F1F5F9);
-  border-radius: 16px;
-  border: 1px solid var(--crunevo-gray-200);
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
 }
 
-.achievement-item {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+@media (min-width: 768px) {
+  .achievements-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+.achievement-card {
+  background: var(--bs-body-bg);
+  border: 1px solid var(--gray-300);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+  padding: 1rem;
   text-align: center;
-  padding: 16px;
-  background: white;
-  border-radius: 12px;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  cursor: pointer;
-  border: 2px solid transparent;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.achievement-item:hover {
+.achievement-card:hover {
   transform: translateY(-4px);
-  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.1);
-  border-color: var(--crunevo-primary);
+  box-shadow: var(--shadow-medium);
 }
 
-.achievement-item.locked {
-  opacity: 0.5;
+.achievement-card.locked {
+  opacity: 0.6;
   filter: grayscale(80%);
-  pointer-events: none;
 }
 
-.achievement-icon {
-  font-size: 28px;
-  margin-bottom: 8px;
+.icon-wrapper {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
 }
 
-.achievement-title {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--crunevo-gray-700);
+[data-bs-theme="dark"] .achievement-card {
+  background: var(--gray-800);
+  border-color: var(--gray-700);
 }
 
 .profile-sections {

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -1052,6 +1052,7 @@ document.addEventListener('DOMContentLoaded', () => {
     removeFloatingOptions();
 
     applyGalleryOrientation();
+    initAchievementsShowMore();
 
   // Bootstrap collapse handles the mobile menu
 
@@ -1360,6 +1361,22 @@ function highlightNewAchievements() {
         const el = document.getElementById(`achievement-${a.code}`);
         if (el) el.classList.add('bounce-once', 'fade-in');
     });
+}
+
+function initAchievementsShowMore() {
+  document.querySelectorAll('[data-show-more-target]').forEach((section) => {
+    const btn = section.parentElement.querySelector('.show-more-btn');
+    if (!btn) return;
+    const hidden = section.querySelectorAll('.extra');
+    if (hidden.length === 0) {
+      btn.remove();
+      return;
+    }
+    btn.addEventListener('click', () => {
+      hidden.forEach((el) => el.classList.remove('d-none'));
+      btn.remove();
+    });
+  });
 }
 
 function initQuickNotes() {

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -373,34 +373,53 @@
             </div>
             <small class="text-muted">Has desbloqueado {{ user_achievements|length }}/{{ total_achievements }} logros</small>
           </div>
-          <div class="row row-cols-2 row-cols-md-3 g-3">
-            {% for code, info in ACHIEVEMENT_DETAILS.items() %}
-            {% set ua = user_achievements_map.get(code) %}
-            <div class="col">
-              <div class="card achievement-card border-0 shadow-sm text-center {% if not ua %}locked{% endif %}" {% if not ua %}data-bs-toggle="tooltip" title="Aún no obtenido"{% endif %}>
-                <div class="card-body p-3">
-                  <div class="achievement-icon mb-2">
-                    <i class="bi {{ info.icon }} display-4 {% if ua %}text-warning{% else %}text-muted{% endif %}"></i>
-                  </div>
-                  <h6 class="fw-bold mb-1">{{ info.title }}</h6>
-                  {% if ua %}
-                  <small class="text-muted">{{ ua.timestamp|timesince }}</small>
-                  {% else %}
-                  <small class="text-muted">Bloqueado</small>
-                  {% endif %}
+          <div class="achievements-section">
+            <h6 class="fw-bold mb-2">Logros obtenidos</h6>
+            <div class="achievements-grid" data-show-more-target>
+              {% for code, info in unlocked_achievements %}
+              {% set ua = user_achievements_map.get(code) %}
+              <div class="achievement-card {% if loop.index > 12 %}d-none extra{% endif %}" data-bs-toggle="tooltip" title="{{ info.description }}">
+                <div class="icon-wrapper mb-2">
+                  <i class="bi {{ info.icon }} display-6 text-warning"></i>
                 </div>
+                <h6 class="fw-semibold mb-1">{{ info.title }}</h6>
+                <small class="text-muted">{{ ua.timestamp|timesince }}</small>
               </div>
+              {% endfor %}
             </div>
-            {% endfor %}
-            {% if user_achievements|length == 0 %}
-            <div class="col-12">
-              <div class="text-center py-5">
-                <i class="bi bi-award display-1 text-muted mb-3"></i>
-                <p class="text-muted">Aún no has desbloqueado ningún logro. ¡Sigue participando en CRUNEVO para comenzar!</p>
-              </div>
+            {% if unlocked_achievements|length > 12 %}
+            <div class="text-center mt-2">
+              <button type="button" class="btn btn-sm btn-outline-primary show-more-btn">Ver todos</button>
             </div>
             {% endif %}
           </div>
+
+          <div class="achievements-section mt-4">
+            <h6 class="fw-bold mb-2">Logros por desbloquear</h6>
+            <div class="achievements-grid" data-show-more-target>
+              {% for code, info in locked_achievements %}
+              <div class="achievement-card locked {% if loop.index > 12 %}d-none extra{% endif %}" data-bs-toggle="tooltip" title="Aún no desbloqueado">
+                <div class="icon-wrapper mb-2">
+                  <i class="bi {{ info.icon }} display-6 text-muted"></i>
+                </div>
+                <h6 class="fw-semibold mb-1">{{ info.title }}</h6>
+                <small class="text-muted">Aún no desbloqueado</small>
+              </div>
+              {% endfor %}
+            </div>
+            {% if locked_achievements|length > 12 %}
+            <div class="text-center mt-2">
+              <button type="button" class="btn btn-sm btn-outline-primary show-more-btn">Ver todos</button>
+            </div>
+            {% endif %}
+          </div>
+
+          {% if user_achievements|length == 0 %}
+          <div class="text-center py-5">
+            <i class="bi bi-award display-1 text-muted mb-3"></i>
+            <p class="text-muted">Aún no has desbloqueado ningún logro. ¡Sigue participando en CRUNEVO para comenzar!</p>
+          </div>
+          {% endif %}
         </div>
 
         <!-- Referrals Tab -->


### PR DESCRIPTION
## Summary
- overhaul achievements tab on profile
- separate unlocked and locked achievements in responsive grid
- add show-more button
- support dark theme with updated CSS
- document the change in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68713a0279ac8325bd47d1d540b4afd6