### PR TITLE
Fix feed crash with pending migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -739,3 +739,4 @@
 - Added Word (.docx) and PowerPoint (.pptx) viewer for notes. Uses Mammoth.js for
   DOCX and converts PPTX to PDF with LibreOffice for inline display (PR notes-office-viewer).
 - Notes upload now accepts DOCX and PPTX, storing original files and generating PDF previews. Added download of original PPTX (PR docx-pptx-upload).
+- User.notes_count property counts notes without loading them; sidebar and profile stats use this to avoid DB errors if migrations are pending (PR notes-count-fix).

--- a/crunevo/models/user.py
+++ b/crunevo/models/user.py
@@ -1,6 +1,9 @@
 from flask_login import UserMixin
 from crunevo.security.passwords import generate_hash, verify_hash
 from crunevo.extensions import db, login_manager
+from sqlalchemy import func
+
+from .note import Note
 
 # Default avatar used when no image is uploaded
 DEFAULT_AVATAR_URL = (
@@ -43,6 +46,14 @@ class User(UserMixin, db.Model):
     def is_friend(self, other_user):
         """Placeholder friendship check."""
         return False
+
+    @property
+    def notes_count(self) -> int:
+        """Return the number of notes authored by the user without loading them."""
+        return (
+            db.session.query(func.count(Note.id)).filter_by(user_id=self.id).scalar()
+            or 0
+        )
 
 
 @login_manager.user_loader

--- a/crunevo/routes/auth_routes.py
+++ b/crunevo/routes/auth_routes.py
@@ -263,10 +263,11 @@ def perfil():
     user_level = min(
         10, (current_user.points or 0) // 100 + current_user.verification_level
     )
+
     activity_total = (
         len(current_user.post_comments or [])
         + len(current_user.posts or [])
-        + len(current_user.notes or [])
+        + Note.query.filter_by(user_id=current_user.id).count()
     )
     participation_percentage = (
         min(100, int((activity_total / 30) * 100)) if activity_total else 0
@@ -627,7 +628,9 @@ def delete_account():
 
     for post in current_user.posts:
         db.session.delete(post)
-    for note in current_user.notes:
+    from crunevo.models import Note
+
+    for note in Note.query.filter_by(user_id=current_user.id).all():
         db.session.delete(note)
     for comment in current_user.comments:
         db.session.delete(comment)

--- a/crunevo/templates/components/sidebar_left_feed.html
+++ b/crunevo/templates/components/sidebar_left_feed.html
@@ -30,7 +30,7 @@
         </div>
         <div class="col-4">
           <div class="stat-item">
-            <div class="fw-bold text-info">{{ current_user.notes|length }}</div>
+            <div class="fw-bold text-info">{{ current_user.notes_count }}</div>
             <div class="small text-muted">Apuntes</div>
           </div>
         </div>
@@ -66,7 +66,7 @@
           <a href="{{ url_for('notes.list_notes') if 'notes.list_notes' in url_for.__globals__.get('current_app', {}).view_functions else '/notes' }}" class="nav-link {{ 'active' if request.endpoint == 'notes.list_notes' }}">
             <i class="bi bi-journal-text"></i>
             <span class="fw-semibold">Apuntes</span>
-            <span class="badge bg-primary rounded-pill ms-auto">{{ current_user.notes|length }}</span>
+            <span class="badge bg-primary rounded-pill ms-auto">{{ current_user.notes_count }}</span>
           </a>
         </li>
 


### PR DESCRIPTION
## Summary
- add `notes_count` property on `User`
- avoid loading notes relationships in templates and routes
- update profile delete logic to query notes directly
- document fix in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68717062cec88325bde667d6e6d41738