### PR TITLE
Fix feed crash from missing notes column

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -739,3 +739,4 @@
 - Added Word (.docx) and PowerPoint (.pptx) viewer for notes. Uses Mammoth.js for
   DOCX and converts PPTX to PDF with LibreOffice for inline display (PR notes-office-viewer).
 - Notes upload now accepts DOCX and PPTX, storing original files and generating PDF previews. Added download of original PPTX (PR docx-pptx-upload).
+- Added notes_count helper and updated templates to use it, preventing database errors when column missing (PR notes-count-helper).

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -130,9 +130,10 @@ def create_app():
             "URGENT_REPORTS": urgent_count,
             "NEW_ACHIEVEMENTS": new_achievements,
             "get_hall_membership": get_hall_membership,
+            "notes_count": notes_count,
         }
 
-    from .utils.helpers import timesince, get_hall_membership
+    from .utils.helpers import timesince, get_hall_membership, notes_count
     from .cache.link_preview import extract_first_url, get_preview
 
     app.jinja_env.filters["timesince"] = timesince

--- a/crunevo/routes/auth_routes.py
+++ b/crunevo/routes/auth_routes.py
@@ -266,7 +266,7 @@ def perfil():
     activity_total = (
         len(current_user.post_comments or [])
         + len(current_user.posts or [])
-        + len(current_user.notes or [])
+        + Note.query.filter_by(user_id=current_user.id).count()
     )
     participation_percentage = (
         min(100, int((activity_total / 30) * 100)) if activity_total else 0

--- a/crunevo/templates/admin/manage_users.html
+++ b/crunevo/templates/admin/manage_users.html
@@ -32,7 +32,7 @@
               <span class="badge bg-info">{{ user_clubs }} clubes</span>
             </td>
             <td>
-              {% set is_verified = user.notes|length >= 5 and user.completed_missions >= 10 %}
+                {% set is_verified = notes_count(user) >= 5 and user.completed_missions >= 10 %}
               {% if is_verified %}
                 <span class="badge bg-success">
                   <i class="bi bi-check-circle-fill"></i> Verificado

--- a/crunevo/templates/admin/user_activity.html
+++ b/crunevo/templates/admin/user_activity.html
@@ -3,7 +3,7 @@
 <h3>Actividad reciente de {{ user.username }}</h3>
 <ul>
   <li>Último login: {{ user.last_login or "Desconocido" }}</li>
-  <li>Apuntes subidos: {{ user.notes|length }}</li>
+  <li>Apuntes subidos: {{ notes_count(user) }}</li>
   <li>Comentarios hechos: {{ user.comments|length }}</li>
 </ul>
 {% endblock %}

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -205,7 +205,7 @@
                   <div class="stats-list">
                     <div class="d-flex justify-content-between mb-2">
                       <span>Apuntes subidos</span>
-                      <span class="fw-bold">{{ user.notes|length }}</span>
+                        <span class="fw-bold">{{ notes_count(user) }}</span>
                     </div>
                     <div class="d-flex justify-content-between mb-2">
                       <span>Comentarios hechos</span>
@@ -258,7 +258,7 @@
 
         <!-- Notes Tab -->
         <div class="tab-pane fade {% if tab == 'apuntes' %}show active{% endif %}" id="notes-tab">
-          {% if user.notes %}
+          {% if notes_count(user) %}
           <div class="row g-3">
             {% for note in user.notes[:12] %}
             <div class="col-md-6">
@@ -267,10 +267,10 @@
             {% endfor %}
           </div>
 
-          {% if user.notes|length > 12 %}
+          {% if notes_count(user) > 12 %}
           <div class="text-center mt-4">
             <a href="{{ url_for('notes.list_notes') if 'notes.list_notes' in url_for.__globals__.get('current_app', {}).view_functions else '/notes' }}" class="btn btn-outline-primary">
-              Ver todos los apuntes ({{ user.notes|length }})
+              Ver todos los apuntes ({{ notes_count(user) }})
             </a>
           </div>
           {% endif %}
@@ -469,7 +469,7 @@
 
               <div class="d-flex justify-content-between mb-2">
                 <span><i class="bi bi-journal-text me-1"></i> Apuntes subidos</span>
-                <span class="fw-bold">{{ user.notes|length }}</span>
+                <span class="fw-bold">{{ notes_count(user) }}</span>
               </div>
               <div class="d-flex justify-content-between">
                 <span><i class="bi bi-coin me-1"></i> Crolars acumulados</span>
@@ -556,7 +556,7 @@ document.addEventListener('DOMContentLoaded', function() {
       data: {
         labels: ['Apuntes', 'Comentarios', 'Misiones', 'Clubes'],
         datasets: [{
-          data: [{{ user.notes|length }}, {{ user.comments|length }}, {{ completed_missions_count }}, {{ user_clubs|length }}],
+          data: [{{ notes_count(user) }}, {{ user.comments|length }}, {{ completed_missions_count }}, {{ user_clubs|length }}],
           backgroundColor: ['#667eea', '#764ba2', '#f093fb', '#f5576c']
         }]
       },

--- a/crunevo/templates/components/sidebar_left_feed.html
+++ b/crunevo/templates/components/sidebar_left_feed.html
@@ -30,7 +30,7 @@
         </div>
         <div class="col-4">
           <div class="stat-item">
-            <div class="fw-bold text-info">{{ current_user.notes|length }}</div>
+              <div class="fw-bold text-info">{{ notes_count(current_user) }}</div>
             <div class="small text-muted">Apuntes</div>
           </div>
         </div>
@@ -66,7 +66,7 @@
           <a href="{{ url_for('notes.list_notes') if 'notes.list_notes' in url_for.__globals__.get('current_app', {}).view_functions else '/notes' }}" class="nav-link {{ 'active' if request.endpoint == 'notes.list_notes' }}">
             <i class="bi bi-journal-text"></i>
             <span class="fw-semibold">Apuntes</span>
-            <span class="badge bg-primary rounded-pill ms-auto">{{ current_user.notes|length }}</span>
+              <span class="badge bg-primary rounded-pill ms-auto">{{ notes_count(current_user) }}</span>
           </a>
         </li>
 

--- a/crunevo/utils/certificate_generator.py
+++ b/crunevo/utils/certificate_generator.py
@@ -6,6 +6,7 @@ from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 from reportlab.lib.units import inch
 from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer
 from reportlab.lib import colors
+from crunevo.models import Note
 
 
 def generate_certificate_pdf(user, certificate_type):
@@ -134,7 +135,7 @@ def check_certificate_eligibility(user):
         eligible.append("misiones")
 
     # Check notes uploaded
-    notes_count = len(user.notes) if user.notes else 0
+    notes_count = Note.query.filter_by(user_id=user.id).count()
     if notes_count >= 3:
         eligible.append("apuntes")
 

--- a/crunevo/utils/helpers.py
+++ b/crunevo/utils/helpers.py
@@ -2,7 +2,7 @@ from functools import wraps
 from datetime import datetime
 from flask import redirect, url_for, flash
 from flask_login import current_user, login_required
-from crunevo.models import User
+from crunevo.models import User, Note
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy import inspect
 
@@ -134,3 +134,14 @@ def timesince(dt):
         return f"hace {hours} hora{'s' if hours != 1 else ''}"
     days = hours // 24
     return f"hace {days} d\u00eda{'s' if days != 1 else ''}"
+
+
+def notes_count(user):
+    """Return number of notes for a given user safely."""
+    if not user or not hasattr(user, "id"):
+        return 0
+    try:
+        return Note.query.filter_by(user_id=user.id).count()
+    except SQLAlchemyError:
+        db.session.rollback()
+        return 0


### PR DESCRIPTION
## Summary
- add `notes_count` helper in helpers.py and expose via app context
- use `notes_count` in sidebar, profile and admin templates
- update certificate generator and auth routes to query count safely
- document changes in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68717062cec88325bde667d6e6d41738