### PR TITLE
Implement file type detection for notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -740,3 +740,4 @@
   DOCX and converts PPTX to PDF with LibreOffice for inline display (PR notes-office-viewer).
 - Notes upload now accepts DOCX and PPTX, storing original files and generating PDF previews. Added download of original PPTX (PR docx-pptx-upload).
 - Added notes_count helper and updated templates to use it, preventing database errors when column missing (PR notes-count-helper).
+- Nota detail ahora usa includes para visor según tipo de archivo y se guarda note.file_type en la base de datos (PR note-file-type-viewer).

--- a/crunevo/models/note.py
+++ b/crunevo/models/note.py
@@ -8,6 +8,7 @@ class Note(db.Model):
     description = db.Column(db.Text, default="")
     filename = db.Column(db.String(200), default="")
     original_file_url = db.Column(db.String(200), default="")
+    file_type = db.Column(db.String(20), default="")
     tags = db.Column(db.String(200), default="")
     category = db.Column(db.String(100), default="")
     language = db.Column(db.String(20), default="")

--- a/crunevo/routes/notes_routes.py
+++ b/crunevo/routes/notes_routes.py
@@ -144,6 +144,17 @@ def upload_note():
             )
             return redirect(url_for("notes.upload_note"))
 
+        if ext == ".pdf":
+            ftype = "pdf"
+        elif ext in {".jpg", ".jpeg", ".png", ".webp"}:
+            ftype = "image"
+        elif ext == ".docx":
+            ftype = "docx"
+        elif ext == ".pptx":
+            ftype = "pptx"
+        else:
+            ftype = "other"
+
         from crunevo.utils import plagiarism
 
         file_hash = plagiarism.compute_hash(f.stream)
@@ -284,6 +295,7 @@ def upload_note():
             description=description,
             filename=filepath,
             original_file_url=original_url,
+            file_type=ftype,
             tags=request.form.get("tags"),
             category=category,
             language=request.form.get("language"),
@@ -402,7 +414,19 @@ def import_file(source, file_id):
     with open(path, "wb") as f:
         f.write(res.content)
 
-    note = Note(title=name, filename=path, author=current_user)
+    ext = os.path.splitext(path)[1].lower()
+    if ext == ".pdf":
+        ftype = "pdf"
+    elif ext in {".jpg", ".jpeg", ".png", ".webp"}:
+        ftype = "image"
+    elif ext == ".docx":
+        ftype = "docx"
+    elif ext == ".pptx":
+        ftype = "pptx"
+    else:
+        ftype = "other"
+
+    note = Note(title=name, filename=path, file_type=ftype, author=current_user)
     db.session.add(note)
     db.session.commit()
     return redirect(url_for("notes.view_note", id=note.id))
@@ -463,17 +487,19 @@ def detail(note_id):
         path = path.split("?")[0]
         return os.path.splitext(path)[1].lower()
 
-    ext = get_ext(note.original_file_url or note.filename)
-    if ext == ".pdf":
-        ftype = "pdf"
-    elif ext in {".jpg", ".jpeg", ".png", ".webp"}:
-        ftype = "image"
-    elif ext == ".docx":
-        ftype = "docx"
-    elif ext == ".pptx":
-        ftype = "pptx"
-    else:
-        ftype = "other"
+    ftype = note.file_type
+    if not ftype:
+        ext = get_ext(note.original_file_url or note.filename)
+        if ext == ".pdf":
+            ftype = "pdf"
+        elif ext in {".jpg", ".jpeg", ".png", ".webp"}:
+            ftype = "image"
+        elif ext == ".docx":
+            ftype = "docx"
+        elif ext == ".pptx":
+            ftype = "pptx"
+        else:
+            ftype = "other"
 
     return render_template(
         "notes/detalle.html",
@@ -499,17 +525,19 @@ def embed_note(note_id):
         path = path.split("?")[0]
         return os.path.splitext(path)[1].lower()
 
-    ext = get_ext(note.original_file_url or note.filename)
-    if ext == ".pdf":
-        ftype = "pdf"
-    elif ext in {".jpg", ".jpeg", ".png", ".webp"}:
-        ftype = "image"
-    elif ext == ".docx":
-        ftype = "docx"
-    elif ext == ".pptx":
-        ftype = "pptx"
-    else:
-        ftype = "other"
+    ftype = note.file_type
+    if not ftype:
+        ext = get_ext(note.original_file_url or note.filename)
+        if ext == ".pdf":
+            ftype = "pdf"
+        elif ext in {".jpg", ".jpeg", ".png", ".webp"}:
+            ftype = "image"
+        elif ext == ".docx":
+            ftype = "docx"
+        elif ext == ".pptx":
+            ftype = "pptx"
+        else:
+            ftype = "other"
 
     return render_template("notes/embed.html", note=note, file_type=ftype)
 

--- a/crunevo/templates/components/viewer_docx.html
+++ b/crunevo/templates/components/viewer_docx.html
@@ -1,0 +1,1 @@
+<div id="noteViewer" data-url="{{ note.filename }}" data-type="docx" class="mx-auto" style="max-width:850px;"></div>

--- a/crunevo/templates/components/viewer_pdf.html
+++ b/crunevo/templates/components/viewer_pdf.html
@@ -1,0 +1,1 @@
+<div id="noteViewer" data-url="{{ note.filename }}" data-type="pdf" class="mx-auto" style="max-width:850px;"></div>

--- a/crunevo/templates/notes/detalle.html
+++ b/crunevo/templates/notes/detalle.html
@@ -3,14 +3,24 @@
 {% block content %}
 <div class="container-xl my-4">
   <div class="row g-4">
-    <div class="col-md-9 order-md-2">
-      <div id="noteViewer" data-url="{{ note.filename }}" data-type="{{ file_type }}"></div>
-      <button type="button" class="btn btn-outline-secondary btn-sm mt-2" id="fullscreenBtn">Pantalla completa</button>
-      {% if note.original_file_url and file_type == 'pptx' %}
-      <p class="text-muted small mt-2"><a href="{{ url_for('notes.download_note', note_id=note.id) }}">Descargar original (.pptx)</a></p>
+    <div class="col-md-9 order-md-2 text-center">
+      {% set ftype = note.file_type or file_type %}
+      {% if ftype == 'pdf' %}
+        {% include 'components/viewer_pdf.html' %}
+      {% elif ftype == 'docx' %}
+        {% include 'components/viewer_docx.html' %}
+      {% elif ftype == 'pptx' %}
+        {% include 'components/viewer_pdf.html' %}
+        {% if note.original_file_url %}
+        <a href="{{ note.original_file_url }}" download class="btn btn-outline-primary btn-sm mt-2">Descargar presentación original (.pptx)</a>
+        {% endif %}
+      {% elif ftype == 'image' %}
+        <img src="{{ note.filename }}" class="img-fluid rounded shadow-sm mx-auto" style="max-width:850px;" alt="Vista previa de imagen">
       {% else %}
-      <p class="text-muted small mt-2"><a href="{{ url_for('notes.download_note', note_id=note.id) }}">Descargar archivo</a></p>
+        <p class="alert alert-info mx-auto" style="max-width:850px;">No se pudo previsualizar este archivo.</p>
       {% endif %}
+      <button type="button" class="btn btn-outline-secondary btn-sm mt-2" id="fullscreenBtn">Pantalla completa</button>
+      <p class="text-muted small mt-2"><a href="{{ url_for('notes.download_note', note_id=note.id) }}">Descargar archivo</a></p>
     </div>
     <div class="col-md-3 order-md-1">
       <h1 class="h5" id="noteTitle">{{ note.title }}</h1>

--- a/crunevo/templates/notes/embed.html
+++ b/crunevo/templates/notes/embed.html
@@ -8,7 +8,18 @@
   <title>{{ note.title }}</title>
 </head>
 <body class="p-2">
-  <div id="noteViewer" data-url="{{ note.filename }}" data-type="{{ file_type }}"></div>
+  {% set ftype = note.file_type or file_type %}
+  {% if ftype == 'pdf' %}
+    {% include 'components/viewer_pdf.html' %}
+  {% elif ftype == 'docx' %}
+    {% include 'components/viewer_docx.html' %}
+  {% elif ftype == 'pptx' %}
+    {% include 'components/viewer_pdf.html' %}
+  {% elif ftype == 'image' %}
+    <img src="{{ note.filename }}" class="img-fluid rounded shadow-sm mx-auto" style="max-width:850px;" alt="Vista previa de imagen">
+  {% else %}
+    <p class="alert alert-info mx-auto" style="max-width:850px;">No se pudo previsualizar este archivo.</p>
+  {% endif %}
   <script src="{{ url_for('static', filename='pdfjs/pdf.min.js') }}"></script>
   <script src="{{ url_for('static', filename='vendor/mammoth.browser.min.js') }}"></script>
   <script src="{{ url_for('static', filename='js/viewer.js') }}"></script>

--- a/crunevo/templates/notes/upload.html
+++ b/crunevo/templates/notes/upload.html
@@ -188,6 +188,7 @@
       } else if (file.type.startsWith('image/')) {
         imgPrev.src = URL.createObjectURL(file);
         imgPrev.onload = () => URL.revokeObjectURL(imgPrev.src);
+        imgPrev.onerror = () => imgPrev.classList.add('tw-hidden');
         imgPrev.classList.remove('tw-hidden');
       } else if (file.name.endsWith('.docx')) {
         const reader = new FileReader();

--- a/migrations/versions/bdd3abdf7084_add_note_file_type.py
+++ b/migrations/versions/bdd3abdf7084_add_note_file_type.py
@@ -1,0 +1,34 @@
+"""add note file_type column
+
+Revision ID: bdd3abdf7084
+Revises: 056ac5a1f108
+Create Date: 2025-12-01 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def has_col(table: str, column: str, conn) -> bool:
+    inspector = sa.inspect(conn)
+    return any(c["name"] == column for c in inspector.get_columns(table))
+
+
+revision = "bdd3abdf7084"
+down_revision = "add_note_original_url"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    with op.batch_alter_table("note", schema=None) as batch_op:
+        if not has_col("note", "file_type", conn):
+            batch_op.add_column(
+                sa.Column("file_type", sa.String(length=20), nullable=True)
+            )
+
+
+def downgrade():
+    with op.batch_alter_table("note", schema=None) as batch_op:
+        batch_op.drop_column("file_type", if_exists=True)


### PR DESCRIPTION
## Summary
- add `file_type` column to notes
- generate migration for new column
- store `file_type` on upload and imports
- display viewers conditionally in note detail and embed
- handle image preview errors
- document changes in `AGENTS.md`

## Testing
- `make fmt`
- `make test` *(fails: KeyboardInterrupt after success)*

------
https://chatgpt.com/codex/tasks/task_e_687174c7e6a083258096af2f73aeb5d7