### PR TITLE
Fix missing note file_type column on startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -741,3 +741,4 @@
 - Notes upload now accepts DOCX and PPTX, storing original files and generating PDF previews. Added download of original PPTX (PR docx-pptx-upload).
 - Added notes_count helper and updated templates to use it, preventing database errors when column missing (PR notes-count-helper).
 - Nota detail ahora usa includes para visor según tipo de archivo y se guarda note.file_type en la base de datos (PR note-file-type-viewer).
+- Auto-creation del campo note.file_type si falta en la base de datos para evitar errores en /notes (QA note-file-type-hotfix).


### PR DESCRIPTION
## Summary
- ensure `note.file_type` column is created if migrations didn't run
- document the hotfix in `AGENTS.md`

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68717d307ac483258082fae7ef4813d3