### PR TITLE
Fix store toasts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -744,3 +744,4 @@
 - fly.toml now runs 'flask db upgrade' automatically so new columns like file_type are applied (QA fly-release-db-upgrade).
 - Auto-creation del campo note.file_type si falta en la base de datos para evitar errores en /notes (QA note-file-type-hotfix).
 - Vista previa de archivos en /notes/upload unificada: viewer.js maneja detección y muestra solo pdfPreview, docxPreview, imgPreview o pptPreview. Backend valida un único archivo por nota. (PR notes-upload-preview-fix)
+- Toasts de la tienda ya no se muestran al cargar; main.js solo auto-muestra los que tienen data-autoshow (PR store-toast-trigger-fix).

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -747,7 +747,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
-  document.querySelectorAll('.toast').forEach((t) => {
+  document.querySelectorAll('.toast[data-autoshow]').forEach((t) => {
     new bootstrap.Toast(t).show();
   });
 

--- a/crunevo/templates/components/toast.html
+++ b/crunevo/templates/components/toast.html
@@ -1,5 +1,5 @@
 {% macro toast(message) %}
-<div class="toast align-items-center text-bg-primary border-0" role="alert" aria-live="assertive" aria-atomic="true" data-bs-delay="3000">
+<div class="toast align-items-center text-bg-primary border-0" role="alert" aria-live="assertive" aria-atomic="true" data-bs-delay="3000" data-autoshow="true">
   <div class="d-flex">
     <div class="toast-body">
       {{ message }}


### PR DESCRIPTION
## Summary
- prevent automatic toast display unless `data-autoshow` is set
- only flash toasts are auto shown

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6872cba9d0188325a5bdfe45cb443b45