### PR TITLE
Unify floating buttons under feed FAB

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -748,3 +748,4 @@
 - Feed now returns is_saved and user_reaction, keeping save button and reactions active on reload (PR feed-save-reaction-persist).
 - Feed desktop now shows expandable '+' button with search, notifications and chat shortcuts (PR feed-desktop-fab)
 - Floating '+' button now expands to the left showing quick notes, shortcuts and Crunebot (PR feed-fab-left-buttons)
+- FAB buttons unified: quick notes, shortcuts and Crunebot merged into single floating menu; old buttons removed (PR feed-fab-unify)

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -161,88 +161,14 @@
     {% include 'components/mobile_bottom_nav.html' %}
     {% endif %}
 
-      <!-- Floating Crunebot Button -->
-      {% if current_user.is_authenticated and 'ia.ia_chat' in current_app.view_functions %}
-      <div class="floating-crunebot d-none d-lg-block">
-          <button class="btn btn-primary rounded-circle shadow-lg floating-btn"
-                  onclick="window.location.href='{{ url_for('ia.ia_chat') }}'"
-                  title="Hablar con Crunebot">
-              <i class="bi bi-robot fs-5"></i>
-          </button>
-      </div>
-      {% endif %}
-
-    {% if request.endpoint not in ['auth.login', 'onboarding.register'] %}
-    {% include 'components/shortcut_help.html' %}
-    {% include 'components/quick_notes.html' %}
-    {% endif %}
+    {# Floating quick actions now live inside the FAB on feed pages #}
 
 
     <!-- Bootstrap JS -->
     <script src="{{ url_for('static', filename='vendor/bootstrap.bundle.min.js') }}"></script>
 
     <style>
-    .floating-btn {
-        position: fixed;
-        bottom: 30px;
-        right: 30px;
-        width: 60px;
-        height: 60px;
-        border: none;
-        z-index: 1055;
-        transition: all 0.3s ease;
-        animation: fadeInUp 0.4s ease both, pulse 2s infinite;
-    }
-
-    .floating-btn:hover {
-        transform: scale(1.1);
-        box-shadow: 0 8px 25px rgba(102, 126, 234, 0.4) !important;
-    }
-
-    @keyframes fadeInUp {
-        from { opacity: 0; transform: translateY(20px); }
-        to { opacity: 1; transform: translateY(0); }
-    }
-
-    @keyframes pulse {
-        0% {
-            box-shadow: 0 0 0 0 rgba(102, 126, 234, 0.7);
-        }
-        70% {
-            box-shadow: 0 0 0 10px rgba(102, 126, 234, 0);
-        }
-        100% {
-            box-shadow: 0 0 0 0 rgba(102, 126, 234, 0);
-        }
-    }
-
-    @media (max-width: 991.98px) {
-        .floating-crunebot {
-            display: none !important;
-        }
-        .shortcut-help {
-            display: none !important;
-        }
-    }
-    .shortcut-help {
-        position: fixed;
-        bottom: 30px;
-        right: 100px;
-        z-index: 1055;
-    }
-    .quick-notes {
-        position: fixed;
-        bottom: 30px;
-        right: 170px;
-        z-index: 1055;
-    }
-
     @media (max-width: 768px) {
-        .floating-btn,
-        .shortcut-help,
-        .quick-notes {
-            bottom: 90px !important;
-        }
         main {
             padding-bottom: 5rem !important;
         }

--- a/crunevo/templates/components/quick_notes.html
+++ b/crunevo/templates/components/quick_notes.html
@@ -1,9 +1,3 @@
-<div class="quick-notes d-none d-lg-block">
-  <button class="btn btn-secondary rounded-circle shadow-lg floating-btn" data-bs-toggle="modal" data-bs-target="#quickNotesModal" title="Notas rápidas">
-    <i class="bi bi-journal-text fs-5"></i>
-  </button>
-</div>
-
 <div class="modal fade" id="quickNotesModal" tabindex="-1" aria-labelledby="quickNotesLabel" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">

--- a/crunevo/templates/components/shortcut_help.html
+++ b/crunevo/templates/components/shortcut_help.html
@@ -1,9 +1,3 @@
-<div class="shortcut-help d-none d-lg-block">
-  <button class="btn btn-secondary rounded-circle shadow-lg floating-btn" data-bs-toggle="modal" data-bs-target="#shortcutHelpModal" title="Atajos de teclado">
-    <i class="bi bi-question-lg fs-5"></i>
-  </button>
-</div>
-
 <div class="modal fade" id="shortcutHelpModal" tabindex="-1" aria-labelledby="shortcutHelpLabel" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">

--- a/crunevo/templates/feed/feed.html
+++ b/crunevo/templates/feed/feed.html
@@ -259,8 +259,22 @@
 {{ super() }}
 <div id="fab-container" class="d-none d-lg-block">
   <button id="fab-main" class="fab-button">+</button>
-  <button class="fab-sub d-none" data-bs-toggle="modal" data-bs-target="#quickNotesModal" title="Notas rápidas">📝</button>
-  <button class="fab-sub d-none" data-bs-toggle="modal" data-bs-target="#shortcutHelpModal" title="Atajos">⌨️</button>
-  <button class="fab-sub d-none" onclick="window.location.href='/ia'" title="Hablar con Crunebot">🤖</button>
+  <button class="fab-sub btn rounded-circle shadow-lg tw-text-white d-none"
+          data-bs-toggle="modal" data-bs-target="#quickNotesModal"
+          title="Notas rápidas" style="background-color:#6f42c1;">
+    <i class="bi bi-journal-text fs-5"></i>
+  </button>
+  <button class="fab-sub btn rounded-circle shadow-lg tw-text-white d-none"
+          data-bs-toggle="modal" data-bs-target="#shortcutHelpModal"
+          title="Atajos" style="background-color:#0d6efd;">
+    <i class="bi bi-keyboard fs-5"></i>
+  </button>
+  <button class="fab-sub btn rounded-circle shadow-lg tw-text-white d-none"
+          onclick="window.location.href='/ia'"
+          title="Crunebot" style="background-color:#198754;">
+    <i class="bi bi-robot fs-5"></i>
+  </button>
 </div>
+{% include 'components/quick_notes.html' %}
+{% include 'components/shortcut_help.html' %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove duplicate quick action buttons from base template
- keep quick notes and shortcut modals only
- move modern action buttons into the feed FAB
- update AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6872db54c1ec83259b8c3641c02a8ee3