### PR TITLE
Fix image preview and upload for feed posts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -750,3 +750,4 @@
 - Floating '+' button now expands to the left showing quick notes, shortcuts and Crunebot (PR feed-fab-left-buttons)
 - FAB buttons unified: quick notes, shortcuts and Crunebot merged into single floating menu; old buttons removed (PR feed-fab-unify)
 - Corregido bloque extra_css en trending.html reemplazándolo por head_extra para que cargue estilos.
+- Se corrigió la previsualización y subida de imágenes en el modal de publicaciones, limitando tamaño con CSS y enviando los archivos en feed.js (PR feed-upload-image-fix).

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -513,6 +513,38 @@
   cursor: not-allowed;
 }
 
+/* Post creation image preview */
+.preview-item {
+  position: relative;
+  display: inline-block;
+  margin-right: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.preview-image {
+  max-width: 100%;
+  max-height: 300px;
+  object-fit: contain;
+  border-radius: 10px;
+  display: block;
+}
+
+.preview-remove {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
 /* Facebook-style Image Gallery */
 .facebook-gallery-container {
   width: 100%;

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -156,6 +156,9 @@ class ModernFeedManager {
       this.setButtonLoading(submitBtn, true);
 
       const formData = new FormData(form);
+      this.imageFiles.forEach(file => {
+        formData.append('files', file);
+      });
       const response = await this.fetchWithCSRF(form.action || window.location.pathname, {
         method: 'POST',
         body: formData


### PR DESCRIPTION
## Summary
- limit image preview size in post modal via `.preview-image`
- send selected image files when submitting posts
- document change in AGENTS guidelines

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6872e932c1a88325bd1dbacff08fedd6