### PR TITLE
Enable personal space prototype

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -753,3 +753,4 @@
 - Added prototype personal space with localStorage blocks and focus/dark modes (PR personal-space-proto).
 - Banner superior eliminado en cursos para que la página inicie con "Mis Cursos Inscritos" (PR courses-banner-remove).
 - Se corrigió la previsualización y subida de imágenes en el modal de publicaciones, limitando tamaño con CSS y enviando los archivos en feed.js (PR feed-upload-image-fix).
+- Habilitado el blueprint personal_routes en /espacio-personal y enlace en menú de usuario (PR personal-space-enable).

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -318,6 +318,7 @@ def create_app():
     from .routes.main_routes import main_bp
     from .routes.story_routes import stories_bp
     from .routes.developer_routes import developer_bp
+    from .routes.personal_routes import personal_bp
     from .routes.personal_space_routes import personal_space_bp
 
     is_admin = os.environ.get("ADMIN_INSTANCE") == "1"
@@ -427,6 +428,7 @@ def create_app():
         app.register_blueprint(saved_bp)
         app.register_blueprint(dashboard_bp)
         app.register_blueprint(settings_bp)
+        app.register_blueprint(personal_bp)
         app.register_blueprint(personal_space_bp)
 
         from .routes.carrera_routes import carrera_bp

--- a/crunevo/routes/personal_routes.py
+++ b/crunevo/routes/personal_routes.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, render_template
 from flask_login import login_required
 
-personal_bp = Blueprint("personal", __name__, url_prefix="/espacio-personal-proto")
+personal_bp = Blueprint("personal", __name__, url_prefix="/espacio-personal")
 
 
 @personal_bp.route("/")

--- a/crunevo/templates/components/launcher_menu.html
+++ b/crunevo/templates/components/launcher_menu.html
@@ -8,7 +8,7 @@
         <i class="bi bi-person-circle fs-3 text-primary"></i>
         <span class="small mt-1">Perfil</span>
       </a>
-      <a href="{{ url_for('personal_space.index') if 'personal_space.index' in url_for.__globals__.get('current_app', {}).view_functions else '/espacio-personal' }}" class="launcher-item">
+      <a href="{{ url_for('personal.space') }}" class="launcher-item">
         <i class="bi bi-house-heart fs-3 text-info"></i>
         <span class="small mt-1">Espacio</span>
       </a>

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -99,6 +99,9 @@
               <li><a class="dropdown-item" href="{{ url_for('saved.list_saved') }}">
                 <i class="bi bi-bookmark me-2"></i>Guardados
               </a></li>
+              <li><a class="dropdown-item" href="{{ url_for('personal.space') }}">
+                <i class="bi bi-house-gear me-2"></i>Mi Espacio Personal
+              </a></li>
               <li><hr class="dropdown-divider"></li>
               <li><span class="dropdown-item-text">
                 <i class="bi bi-coin me-2"></i>{{ current_user.credits }} Crolars


### PR DESCRIPTION
## Summary
- register personal routes blueprint for `/espacio-personal`
- link launcher and profile menu to the new personal space
- document blueprint activation in AGENTS notes

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6872eed4f7b48325890a7741c1805129