### PR TITLE
Add DB-backed block creation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -759,3 +759,4 @@
 
 - Focus mode now persists using localStorage and starting the personal space creates Nota, Kanban and Objetivo blocks. Added aria-labels for accessibility. (PR personal-space-persistence)
 - Theme color meta tag updates with dark mode and various buttons have aria-labels and titles for accessibility. (PR personal-space-ui-fixes)
+- Added Block model, migration and /api/create-block endpoint with JS integration for suggestions (PR personal-space-db-blocks).

--- a/crunevo/models/__init__.py
+++ b/crunevo/models/__init__.py
@@ -44,6 +44,7 @@ from .story import Story  # noqa: F401
 from .group_mission import GroupMission, GroupMissionParticipant  # noqa: F401
 from .user_block import UserBlock  # noqa: F401
 from .personal_block import PersonalBlock  # noqa: F401
+from .block import Block  # noqa: F401
 from .league import AcademicTeam, TeamMember, LeagueMonth, TeamAction  # noqa: F401
 from .knowledge_backpack import KnowledgeBackpack  # noqa: F401
 from .knowledge_backpack import LearningEntry  # noqa: F401

--- a/crunevo/models/block.py
+++ b/crunevo/models/block.py
@@ -1,0 +1,38 @@
+from datetime import datetime
+from crunevo.extensions import db
+
+
+class Block(db.Model):
+    __tablename__ = "blocks"
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    type = db.Column(db.String(50), nullable=False)
+    title = db.Column(db.String(255), default="Nuevo bloque")
+    content = db.Column(db.Text)
+    metadata_json = db.Column("metadata", db.JSON, default={})
+    is_featured = db.Column(db.Boolean, default=False)
+    order_index = db.Column(db.Integer, default=0)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(
+        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+    user = db.relationship("User", backref="blocks")
+
+    def get_metadata(self):
+        return self.metadata_json or {}
+
+    def set_metadata(self, value):
+        self.metadata_json = value or {}
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "type": self.type,
+            "title": self.title,
+            "content": self.content,
+            "metadata": self.get_metadata(),
+            "order_index": self.order_index,
+            "is_featured": self.is_featured,
+        }

--- a/crunevo/routes/personal_space_routes.py
+++ b/crunevo/routes/personal_space_routes.py
@@ -12,6 +12,7 @@ from flask import (
 from flask_login import login_required, current_user
 from crunevo.extensions import db
 from crunevo.models.personal_block import PersonalBlock
+from crunevo.models.block import Block
 from crunevo.utils.helpers import activated_required
 from datetime import datetime
 import json  # noqa: F401
@@ -209,6 +210,26 @@ def reorder_blocks():
     db.session.commit()
 
     return jsonify({"success": True, "message": "Orden actualizado"})
+
+
+@personal_space_bp.route("/api/create-block", methods=["POST"])
+@login_required
+@activated_required
+def api_create_block_simple():
+    """Create a simple Block record"""
+    data = request.get_json() or {}
+
+    block = Block(
+        user_id=current_user.id,
+        type=data.get("type"),
+        title=data.get("title", "Nuevo bloque"),
+        content=data.get("content", ""),
+        order_index=data.get("order_index", 0),
+    )
+    block.set_metadata(data.get("metadata", {}))
+    db.session.add(block)
+    db.session.commit()
+    return jsonify({"success": True, "block_id": block.id})
 
 
 @personal_space_bp.route("/api/suggestions")

--- a/crunevo/static/js/personal-space.js
+++ b/crunevo/static/js/personal-space.js
@@ -315,7 +315,7 @@ function handleModalEvents(e) {
 }
 
 function apiCreateBlock(blockData) {
-    return fetch('/espacio-personal/api/blocks', {
+    return fetch('/espacio-personal/api/create-block', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
@@ -395,9 +395,18 @@ function getDefaultMetadata(type) {
 }
 
 function startPersonalSpace() {
-    // Create initial blocks: note, kanban and goal
-    ['nota', 'kanban', 'objetivo'].forEach(type => createNewBlock(type));
+    ['nota', 'kanban', 'objetivo'].forEach(type => {
+        fetch('/espacio-personal/api/create-block', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRFToken': getCsrfToken()
+            },
+            body: JSON.stringify({ type })
+        });
+    });
     showNotification('Espacio inicial creado', 'success');
+    setTimeout(() => window.location.reload(), 500);
 }
 
 // Block Editing Functions
@@ -945,17 +954,44 @@ function handleSuggestionClick(e) {
         switch (action) {
             case 'create_objetivo_block':
                 if (!blockTypeExists('objetivo')) {
-                    createNewBlock('objetivo');
+                    fetch('/espacio-personal/api/create-block', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'X-CSRFToken': getCsrfToken()
+                        },
+                        body: JSON.stringify({ type: 'objetivo', metadata: { progress: 0 } })
+                    })
+                    .then(res => res.json())
+                    .then(data => { if (data.success) window.location.reload(); });
                 }
                 break;
             case 'create_nota_block':
                 if (!blockTypeExists('nota')) {
-                    createNewBlock('nota');
+                    fetch('/espacio-personal/api/create-block', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'X-CSRFToken': getCsrfToken()
+                        },
+                        body: JSON.stringify({ type: 'nota' })
+                    })
+                    .then(res => res.json())
+                    .then(data => { if (data.success) window.location.reload(); });
                 }
                 break;
             case 'create_kanban_block':
                 if (!blockTypeExists('kanban')) {
-                    createNewBlock('kanban');
+                    fetch('/espacio-personal/api/create-block', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'X-CSRFToken': getCsrfToken()
+                        },
+                        body: JSON.stringify({ type: 'kanban', metadata: { columns: { "Por hacer": [], "En curso": [], "Hecho": [] } } })
+                    })
+                    .then(res => res.json())
+                    .then(data => { if (data.success) window.location.reload(); });
                 }
                 break;
             case 'create_bloque_block':

--- a/migrations/versions/add_block_model.py
+++ b/migrations/versions/add_block_model.py
@@ -1,0 +1,58 @@
+"""Add Block model"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "add_block_model"
+down_revision = "bdd3abdf7084"
+branch_labels = None
+depends_on = None
+
+
+def has_table(name: str, conn) -> bool:
+    inspector = sa.inspect(conn)
+    return name in inspector.get_table_names()
+
+
+def upgrade():
+    conn = op.get_bind()
+    if not has_table("blocks", conn):
+        op.execute(sa.text("DROP SEQUENCE IF EXISTS blocks_id_seq CASCADE"))
+        op.create_table(
+            "blocks",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "user_id", sa.Integer(), sa.ForeignKey("user.id"), nullable=False
+            ),
+            sa.Column("type", sa.String(length=50), nullable=False),
+            sa.Column(
+                "title", sa.String(length=255), nullable=True, default="Nuevo bloque"
+            ),
+            sa.Column("content", sa.Text(), nullable=True),
+            sa.Column(
+                "metadata", sa.JSON(), nullable=True, server_default=sa.text("'{}'")
+            ),
+            sa.Column(
+                "is_featured",
+                sa.Boolean(),
+                nullable=True,
+                server_default=sa.text("false"),
+            ),
+            sa.Column(
+                "order_index", sa.Integer(), nullable=True, server_default=sa.text("0")
+            ),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.ForeignKeyConstraint(["user_id"], ["user.id"]),
+            if_not_exists=True,
+        )
+        op.create_index(op.f("ix_blocks_user_id"), "blocks", ["user_id"], unique=False)
+        op.create_index(
+            op.f("ix_blocks_order_index"), "blocks", ["order_index"], unique=False
+        )
+
+
+def downgrade():
+    op.drop_index(op.f("ix_blocks_order_index"), table_name="blocks")
+    op.drop_index(op.f("ix_blocks_user_id"), table_name="blocks")
+    op.drop_table("blocks", if_exists=True)


### PR DESCRIPTION
## Summary
- create Block model and migration
- expose `/api/create-block` endpoint
- trigger block creation from smart suggestions and initial setup
- document changes in AGENTS

## Testing
- `make fmt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68730149713c8325b26e59a4198da96a