### PR TITLE
Enable full personal space

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -760,3 +760,4 @@
 - Focus mode now persists using localStorage and starting the personal space creates Nota, Kanban and Objetivo blocks. Added aria-labels for accessibility. (PR personal-space-persistence)
 - Theme color meta tag updates with dark mode and various buttons have aria-labels and titles for accessibility. (PR personal-space-ui-fixes)
 - Added Block model, migration and /api/create-block endpoint with JS integration for suggestions (PR personal-space-db-blocks).
+- Activated full personal space with Block model, suggestion buttons and reorder support (PR personal-space-full-feature)

--- a/crunevo/models/block.py
+++ b/crunevo/models/block.py
@@ -30,6 +30,7 @@ class Block(db.Model):
         return {
             "id": self.id,
             "type": self.type,
+            "block_type": self.type,
             "title": self.title,
             "content": self.content,
             "metadata": self.get_metadata(),

--- a/crunevo/static/css/personal-space.css
+++ b/crunevo/static/css/personal-space.css
@@ -604,12 +604,12 @@
 /* Focus Mode */
 .focus-mode .ps-header,
 .focus-mode .ps-suggestions,
-.focus-mode .block-card:not([data-block-type="nota"]) {
+.focus-mode .block-card:not([data-type="nota"]) {
     opacity: 0.3;
     pointer-events: none;
 }
 
-.focus-mode .block-card[data-block-type="nota"] {
+.focus-mode .block-card[data-type="nota"] {
     transform: scale(1.02);
     box-shadow: 0 16px 48px rgba(99, 102, 241, 0.2);
 }

--- a/crunevo/static/js/personal-space.js
+++ b/crunevo/static/js/personal-space.js
@@ -136,7 +136,7 @@ function createBlockElement(block) {
     const div = document.createElement('div');
     div.className = `block-card ${block.color}-block ${block.is_featured ? 'featured' : ''}`;
     div.dataset.blockId = block.id;
-    div.dataset.blockType = block.block_type;
+    div.dataset.type = block.type;
 
     div.innerHTML = generateBlockHTML(block);
 
@@ -160,7 +160,7 @@ function generateBlockHTML(block) {
             </div>
             <div class="block-meta">
                 <h6 class="block-title">${block.title || 'Sin título'}</h6>
-                <small class="block-type-label">${typeLabels[block.block_type] || 'Bloque'}</small>
+                <small class="block-type-label">${typeLabels[block.type] || 'Bloque'}</small>
             </div>
             <div class="block-actions">
                 ${block.is_featured ? '<i class="bi bi-star-fill featured-star" title="Destacado"></i>' : ''}
@@ -190,7 +190,7 @@ function generateBlockHTML(block) {
 }
 
 function generateBlockContent(block) {
-    switch (block.block_type) {
+    switch (block.type) {
         case 'nota':
             return `
                 <div class="note-content">
@@ -327,7 +327,7 @@ function apiCreateBlock(blockData) {
 
 function createNewBlock(type) {
     const blockData = {
-        block_type: type,
+        type: type,
         title: getDefaultTitle(type),
         content: '',
         color: 'indigo',
@@ -434,7 +434,7 @@ function showEditBlockModal(blockId) {
     const blockCard = document.querySelector(`[data-block-id="${blockId}"]`);
     if (!blockCard) return;
 
-    const blockType = blockCard.dataset.blockType;
+    const blockType = blockCard.dataset.type;
     currentEditingBlock = blockId;
 
     // Get current block data
@@ -488,7 +488,7 @@ function generateEditForm(block) {
 
     let specificForm = '';
 
-    switch (block.block_type) {
+    switch (block.type) {
         case 'nota':
             specificForm = `
                 <div class="mb-3">
@@ -609,7 +609,7 @@ function initializeEditFormInteractions(block) {
     }
 
     // Task management for lists
-    if (block.block_type === 'lista') {
+    if (block.type === 'lista') {
         document.getElementById('addTaskBtn')?.addEventListener('click', addNewTask);
         document.addEventListener('click', function(e) {
             if (e.target.closest('.remove-task')) {
@@ -644,7 +644,7 @@ function saveCurrentBlock() {
     if (!currentEditingBlock) return;
 
     const blockCard = document.querySelector(`[data-block-id="${currentEditingBlock}"]`);
-    const blockType = blockCard.dataset.blockType;
+    const blockType = blockCard.dataset.type;
 
     const updateData = {
         title: document.getElementById('blockTitle')?.value || '',
@@ -1055,11 +1055,11 @@ function hideDismissedSuggestions() {
 }
 
 function blockTypeExists(type) {
-    return document.querySelector(`.block-card[data-block-type="${type}"]`) !== null;
+    return document.querySelector(`.block-card[data-type="${type}"]`) !== null;
 }
 
 function showOverdueReminders() {
-    const overdueBlocks = document.querySelectorAll('.block-card[data-block-type="recordatorio"]');
+    const overdueBlocks = document.querySelectorAll('.block-card[data-type="recordatorio"]');
     overdueBlocks.forEach(block => {
         if (block.querySelector('.alert-danger')) {
             block.scrollIntoView({ behavior: 'smooth', block: 'center' });

--- a/crunevo/templates/personal_space/components/block_macros.html
+++ b/crunevo/templates/personal_space/components/block_macros.html
@@ -1,0 +1,27 @@
+{% macro render_block_card(block) %}
+{% set meta = block.get_metadata() %}
+<div class="block-card indigo-block" data-block-id="{{ block.id }}" data-type="{{ block.type }}">
+    <div class="block-header mb-2">
+        <h6 class="block-title">{{ block.title or 'Sin título' }}</h6>
+    </div>
+    <div class="block-content">
+        {% if block.type == 'nota' %}
+            <p>{{ block.content or '' }}</p>
+        {% elif block.type == 'kanban' %}
+            <table class="table table-bordered table-sm">
+                <thead>
+                    <tr><th>Por hacer</th><th>En curso</th><th>Hecho</th></tr>
+                </thead>
+            </table>
+        {% elif block.type == 'objetivo' %}
+            {% set progress = meta.get('progress', 0) %}
+            <div class="progress mb-2">
+                <div class="progress-bar" style="width: {{ progress }}%"></div>
+            </div>
+            <small>{{ progress }}% completado</small>
+        {% else %}
+            <p>{{ block.content or '' }}</p>
+        {% endif %}
+    </div>
+</div>
+{% endmacro %}

--- a/crunevo/templates/personal_space/index.html
+++ b/crunevo/templates/personal_space/index.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}Mi Espacio Personal{% endblock %}
+{% from 'personal_space/components/block_macros.html' import render_block_card %}
 
 {% block head %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/personal-space.css') }}">
@@ -77,7 +78,7 @@
         <div class="container-fluid">
             <div class="blocks-grid" id="blocksGrid">
                 {% for block in blocks %}
-                {% include 'personal_space/components/block_card.html' %}
+                {{ render_block_card(block) }}
                 {% endfor %}
 
                 {% if blocks %}


### PR DESCRIPTION
## Summary
- query Block model to render personal space
- expose block type in Block.to_dict
- return created block data from `/api/create-block`
- support reorder for Block and PersonalBlock
- simplify personal space templates via `render_block_card`
- tweak JS and CSS for new data attributes
- document latest changes in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68730ed42ff88325a809184556829776