### PR TITLE
Enable DB-backed blocks in personal space

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -760,3 +760,4 @@
 - Focus mode now persists using localStorage and starting the personal space creates Nota, Kanban and Objetivo blocks. Added aria-labels for accessibility. (PR personal-space-persistence)
 - Theme color meta tag updates with dark mode and various buttons have aria-labels and titles for accessibility. (PR personal-space-ui-fixes)
 - Added Block model, migration and /api/create-block endpoint with JS integration for suggestions (PR personal-space-db-blocks).
+- Personal space now loads blocks from the new Block model, rendering them dynamically with drag & drop and suggestions creating database records. (PR personal-space-blocks-ui)

--- a/crunevo/templates/personal_space/components/block_card.html
+++ b/crunevo/templates/personal_space/components/block_card.html
@@ -1,36 +1,16 @@
-<!-- Enhanced Block Card Component -->
-<div class="block-card {{ block.get_priority_color() }}-border" data-block-id="{{ block.id }}" data-order="{{ block.order_position }}" data-type="{{ block.block_type }}">
+<!-- Block Card Component simplified for Block model -->
+<div class="block-card {{ color }}-block" data-block-id="{{ block.id }}" data-order="{{ block.order_index }}" data-type="{{ block.type }}">
     <div class="block-header">
         <div class="block-info">
-            <div class="block-icon {{ block.color }}">
-                <i class="{{ block.icon }}"></i>
+            <div class="block-icon">
+                <i class="{{ icon }}"></i>
             </div>
             <div class="block-meta">
                 <h6 class="block-title">{{ block.title or 'Sin título' }}</h6>
-                <div class="block-badges">
-                    <span class="block-type-badge">{{ block.block_type|title }}</span>
-                    {% set status = block.get_status_badge() %}
-                    <span class="status-badge {{ status.color }}">{{ status.text }}</span>
-                </div>
+                <span class="block-type-badge">{{ block.type|title }}</span>
             </div>
         </div>
         <div class="block-actions">
-            {% if block.is_featured %}
-            <i class="featured-star bi bi-star-fill"></i>
-            {% endif %}
-            {% if block.get_due_days() is not none %}
-            <span class="due-indicator {% if block.get_due_days() < 0 %}overdue{% elif block.get_due_days() <= 1 %}urgent{% endif %}">
-                {% if block.get_due_days() < 0 %}
-                    <i class="bi bi-exclamation-triangle"></i>
-                {% elif block.get_due_days() == 0 %}
-                    Hoy
-                {% elif block.get_due_days() == 1 %}
-                    Mañana
-                {% else %}
-                    {{ block.get_due_days() }}d
-                {% endif %}
-            </span>
-            {% endif %}
             <button class="btn-ghost" onclick="editBlock({{ block.id }})" aria-label="Editar bloque">
                 <i class="bi bi-pencil"></i>
             </button>
@@ -39,28 +19,13 @@
             </button>
         </div>
     </div>
-
     <div class="block-content">
-        {% if block.block_type == 'nota' %}
+        {% if block.type == 'nota' %}
             {% include 'personal_space/blocks/nota_block.html' %}
-        {% elif block.block_type == 'kanban' %}
+        {% elif block.type == 'kanban' %}
             {% include 'personal_space/blocks/kanban_block.html' %}
-        {% elif block.block_type == 'objetivo' %}
+        {% elif block.type == 'objetivo' %}
             {% include 'personal_space/blocks/objetivo_block.html' %}
-        {% elif block.block_type == 'tarea' %}
-            {% include 'personal_space/blocks/tarea_block.html' %}
-        {% elif block.block_type == 'bloque' %}
-            {% include 'personal_space/blocks/bloque_block.html' %}
-        {% elif block.block_type == 'lista' %}
-            {% include 'personal_space/blocks/lista_block.html' %}
-        {% elif block.block_type == 'meta' %}
-            {% include 'personal_space/blocks/meta_block.html' %}
-        {% elif block.block_type == 'recordatorio' %}
-            {% include 'personal_space/blocks/recordatorio_block.html' %}
-        {% elif block.block_type == 'frase' %}
-            {% include 'personal_space/blocks/frase_block.html' %}
-        {% elif block.block_type == 'enlace' %}
-            {% include 'personal_space/blocks/enlace_block.html' %}
         {% endif %}
     </div>
 </div>

--- a/crunevo/templates/personal_space/components/macros.html
+++ b/crunevo/templates/personal_space/components/macros.html
@@ -1,0 +1,5 @@
+{% macro render_block_card(block, get_default_icon) %}
+    {% set color = block.get_metadata().get('color', 'indigo') %}
+    {% set icon = block.get_metadata().get('icon', get_default_icon(block.type)) %}
+    {% include 'personal_space/components/block_card.html' %}
+{% endmacro %}

--- a/crunevo/templates/personal_space/index.html
+++ b/crunevo/templates/personal_space/index.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% import 'personal_space/components/macros.html' as ps_macros %}
 {% block title %}Mi Espacio Personal{% endblock %}
 
 {% block head %}
@@ -77,7 +78,7 @@
         <div class="container-fluid">
             <div class="blocks-grid" id="blocksGrid">
                 {% for block in blocks %}
-                {% include 'personal_space/components/block_card.html' %}
+                {{ ps_macros.render_block_card(block, get_default_icon) }}
                 {% endfor %}
 
                 {% if blocks %}


### PR DESCRIPTION
## Summary
- query `Block` records on personal space index
- adjust block API endpoints for the new model
- render cards through a macro and update template markup
- update JS to convert API blocks, handle suggestions and drag & drop
- migrate personal space API tests to use `Block`
- document latest work in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687310f901b88325a5b88ca1c4d2c65d