### PR TITLE
Fix personal space button listeners

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -762,3 +762,4 @@
 - Added Block model, migration and /api/create-block endpoint with JS integration for suggestions (PR personal-space-db-blocks).
 - Personal space now loads blocks from the new Block model, rendering them dynamically with drag & drop and suggestions creating database records. (PR personal-space-blocks-ui)
 - Fully activated personal space blocks using the database: JS calls /api/create-block, block cards use data-block-type, PersonalBlock routes replaced with Block and helper for overdue items. (PR personal-space-full-fix)
+- Fixed personal space buttons: script loads via extra_js, listeners added for #createFirstBlock and smart suggestions using handleSuggestionAction. (PR personal-space-buttons-fix)

--- a/crunevo/static/css/personal-space.css
+++ b/crunevo/static/css/personal-space.css
@@ -100,7 +100,7 @@
     color: #a16207;
 }
 
-.suggestion-btn {
+.apply-suggestion-btn {
     white-space: nowrap;
 }
 

--- a/crunevo/static/js/personal-space.js
+++ b/crunevo/static/js/personal-space.js
@@ -1,5 +1,6 @@
 // Personal Space JavaScript
 document.addEventListener('DOMContentLoaded', function() {
+    console.log('personal-space.js cargado');
     initializePersonalSpace();
 });
 
@@ -76,7 +77,9 @@ function initializeEventListeners() {
     // Add block buttons
     document.getElementById('addBlockBtn')?.addEventListener('click', showAddBlockModal);
     document.getElementById('floatingAddBtn')?.addEventListener('click', showAddBlockModal);
-    document.getElementById('createFirstBlock')?.addEventListener('click', startPersonalSpace);
+    document.getElementById('createFirstBlock')?.addEventListener('click', () => {
+        createNewBlock('nota');
+    });
 
     // Control buttons
     document.getElementById('darkModeToggle')?.addEventListener('click', toggleDarkMode);
@@ -90,7 +93,13 @@ function initializeEventListeners() {
     document.getElementById('saveBlockBtn')?.addEventListener('click', saveCurrentBlock);
 
     // Suggestion events
-    document.addEventListener('click', handleSuggestionClick);
+    document.querySelectorAll('.apply-suggestion-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const card = btn.closest('.suggestion-card');
+            const action = card?.dataset.action;
+            handleSuggestionAction(action);
+        });
+    });
 
     // Block interaction events
     document.addEventListener('click', handleBlockInteractions);
@@ -1014,6 +1023,26 @@ function toggleFocusMode() {
     const newState = !isFocusMode;
     applyFocusMode(newState);
     localStorage.setItem('focus_mode', newState ? 'on' : 'off');
+}
+
+function handleSuggestionAction(action) {
+    switch (action) {
+        case 'create_nota_block':
+            createNewBlock('nota');
+            break;
+        case 'create_objetivo_block':
+            createNewBlock('objetivo');
+            break;
+        case 'create_kanban_block':
+            createNewBlock('kanban');
+            break;
+        case 'create_bloque_block':
+            createNewBlock('bloque');
+            break;
+        case 'show_overdue_items':
+            showNotification('Revisa tus tareas vencidas', 'info');
+            break;
+    }
 }
 
 // Suggestion Handling

--- a/crunevo/templates/personal_space/index.html
+++ b/crunevo/templates/personal_space/index.html
@@ -55,7 +55,7 @@
                         <h6>{{ suggestion.title }}</h6>
                         <p>{{ suggestion.message }}</p>
                     </div>
-                    <button class="btn btn-sm btn-outline-primary suggestion-btn" aria-label="Aplicar sugerencia" title="Aplicar sugerencia">
+                    <button class="btn btn-sm btn-outline-primary apply-suggestion-btn" aria-label="Aplicar sugerencia" title="Aplicar sugerencia">
                         Aplicar
                     </button>
                 </div>
@@ -288,6 +288,6 @@
 </div>
 {% endblock %}
 
-{% block scripts %}
+{% block extra_js %}
 <script src="{{ url_for('static', filename='js/personal-space.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- load personal space script using the `extra_js` block
- rename smart suggestion button class to `.apply-suggestion-btn`
- hook `#createFirstBlock` and smart suggestions with new event listeners
- implement `handleSuggestionAction`
- log when personal space JS loads
- document changes in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68732aa2a28c8325886131d6319f4702