### PR TITLE
Fix image modal navigation and layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -768,3 +768,4 @@
 - Personal space layout refreshed with compact cards, top metrics and disappearing suggestions. startPersonalSpace waits for API responses (PR personal-space-ui-refresh).
 - Added SortableJS script via extra_js block to ensure drag-and-drop works (PR personal-space-sortablejs-fix).
 - Block model regained progress calculation and overdue check to prevent template errors (PR block-methods-fix).
+- Corregido visor de fotos: las flechas actualizan la imagen usando #modalImage y el panel lateral evita overflow con comentarios scrollables (PR photo-modal-navigation-fix).

--- a/crunevo/static/css/photo-modal.css
+++ b/crunevo/static/css/photo-modal.css
@@ -154,7 +154,8 @@
   background: white;
   display: flex;
   flex-direction: column;
-  overflow-y: auto;
+  max-height: 100vh;
+  overflow: hidden;
   border-left: 1px solid #E4E6EA;
 }
 
@@ -259,7 +260,7 @@
 
 /* Comments Section */
 .modal-comments-section {
-  flex: 1;
+  flex-grow: 1;
   padding: 20px;
   overflow-y: auto;
 }
@@ -353,6 +354,7 @@
     max-height: 40vh;
     border-left: none;
     border-top: 1px solid #E4E6EA;
+    overflow: hidden;
   }
   
   [data-bs-theme="dark"] .modal-info-section {

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -597,7 +597,7 @@ class ModernFeedManager {
     const modal = document.getElementById('imageModal');
     if (!modal) return;
 
-    const img = modal.querySelector('.modal-image');
+    const img = modal.querySelector('#modalImage');
     const counter = modal.querySelector('.modal-counter');
     const prevBtn = modal.querySelector('.modal-nav.prev');
     const nextBtn = modal.querySelector('.modal-nav.next');

--- a/crunevo/templates/feed/_post_modal.html
+++ b/crunevo/templates/feed/_post_modal.html
@@ -224,10 +224,9 @@
 }
 
 .modal-comments-section {
-  flex: 1;
+  flex-grow: 1;
   padding: 20px;
   overflow-y: auto;
-  max-height: 400px;
 }
 
 .comment-item {


### PR DESCRIPTION
## Summary
- fix navigation in image modal by selecting `#modalImage`
- limit modal info section overflow and allow scrolling comments only
- update gallery comment section styles
- document in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6873466e2b748325b39fcac1f17ffc42