### PR TITLE
Improve personal space navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -769,3 +769,4 @@
 - Added SortableJS script via extra_js block to ensure drag-and-drop works (PR personal-space-sortablejs-fix).
 - Block model regained progress calculation and overdue check to prevent template errors (PR block-methods-fix).
 - Corregido visor de fotos: las flechas actualizan la imagen usando #modalImage y el panel lateral evita overflow con comentarios scrollables (PR photo-modal-navigation-fix).
+- Added generic block viewer with placeholder page and Kanban view; cards now feature an 'Entrar' button and double-click navigation (PR personal-space-access-improvements).

--- a/crunevo/routes/personal_space_routes.py
+++ b/crunevo/routes/personal_space_routes.py
@@ -13,6 +13,7 @@ from flask_login import login_required, current_user
 from crunevo.extensions import db
 from crunevo.models.block import Block
 from crunevo.utils.helpers import activated_required
+from jinja2 import TemplateNotFound
 from datetime import datetime
 import json  # noqa: F401
 
@@ -434,3 +435,27 @@ def create_kanban():
         return redirect(url_for("personal_space.index"))
 
     return render_template("personal_space/forms/create_kanban.html")
+
+
+@personal_space_bp.route("/kanban/<int:block_id>")
+@login_required
+@activated_required
+def view_kanban(block_id):
+    """Display a kanban board"""
+    block = Block.query.filter_by(id=block_id, user_id=current_user.id).first_or_404()
+    return render_template("personal_space/views/kanban_view.html", block=block)
+
+
+@personal_space_bp.route("/bloque/<int:block_id>")
+@login_required
+@activated_required
+def view_block(block_id):
+    """Generic viewer for personal blocks"""
+    block = Block.query.filter_by(id=block_id, user_id=current_user.id).first_or_404()
+    template_name = f"personal_space/views/{block.type}_view.html"
+    try:
+        return render_template(template_name, block=block)
+    except TemplateNotFound:
+        return render_template(
+            "personal_space/views/under_construction.html", block=block
+        )

--- a/crunevo/static/js/personal-space.js
+++ b/crunevo/static/js/personal-space.js
@@ -196,6 +196,8 @@ function createBlockElement(block) {
 
     div.innerHTML = generateBlockHTML(block);
 
+    div.addEventListener('dblclick', () => openBlock(block.id));
+
     return div;
 }
 
@@ -236,11 +238,14 @@ function generateBlockHTML(block) {
         <div class="block-content">
             ${generateBlockContent(block)}
         </div>
-        <div class="block-footer">
+        <div class="block-footer d-flex justify-content-between align-items-center">
             <small class="text-muted">
                 Actualizado ${formatDate(block.updated_at)}
             </small>
-            ${block.progress > 0 ? `<div class="progress-badge">${block.progress}%</div>` : ''}
+            <div class="d-flex align-items-center">
+                ${block.progress > 0 ? `<span class="progress-badge me-2">${block.progress}%</span>` : ''}
+                <button class="btn btn-link btn-sm enter-block" data-id="${block.id}">Entrar</button>
+            </div>
         </div>
     `;
 }
@@ -495,6 +500,9 @@ function handleBlockInteractions(e) {
     } else if (e.target.closest('.toggle-featured')) {
         e.preventDefault();
         toggleBlockFeatured(blockId);
+    } else if (e.target.closest('.enter-block')) {
+        e.preventDefault();
+        openBlock(blockId);
     } else if (e.target.closest('.block-content') && !e.target.closest('.dropdown')) {
         showEditBlockModal(blockId);
     }
@@ -1449,6 +1457,10 @@ function toggleTask(blockId) {
 function openKanban(blockId) {
     // Open kanban management modal
     window.location.href = `/espacio-personal/kanban/${blockId}`;
+}
+
+function openBlock(blockId) {
+    window.location.href = `/espacio-personal/bloque/${blockId}`;
 }
 
 function manageBloque(blockId) {

--- a/crunevo/templates/personal_space/views/kanban_view.html
+++ b/crunevo/templates/personal_space/views/kanban_view.html
@@ -1,0 +1,33 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container py-4">
+  <h2 class="mb-4">{{ block.title or 'Tablero Kanban' }}</h2>
+  {% set columns = block.get_metadata().get('columns', {}) %}
+  <div class="row" id="kanbanBoard">
+    {% for column, tasks in columns.items() %}
+    <div class="col-md-4 mb-3">
+      <div class="card">
+        <div class="card-header d-flex justify-content-between align-items-center">
+          <strong>{{ column }}</strong>
+          <span class="badge bg-secondary">{{ tasks|length }}</span>
+        </div>
+        <ul class="list-group list-group-flush" data-column="{{ column }}">
+          {% for task in tasks %}
+          <li class="list-group-item">{{ task.title }}</li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+  <a href="{{ url_for('personal_space.index') }}" class="btn btn-secondary mt-3">Volver</a>
+</div>
+{% endblock %}
+{% block extra_js %}
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
+<script>
+  document.querySelectorAll('#kanbanBoard [data-column]').forEach(col => {
+    Sortable.create(col, { group: 'kanban', animation: 150 });
+  });
+</script>
+{% endblock %}

--- a/crunevo/templates/personal_space/views/under_construction.html
+++ b/crunevo/templates/personal_space/views/under_construction.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container py-5 text-center">
+  <h2 class="mb-3">{{ block.title or 'Herramienta en desarrollo' }}</h2>
+  <p>Esta función estará disponible pronto.</p>
+  <a href="{{ url_for('personal_space.index') }}" class="btn btn-primary mt-3">Volver</a>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add kanban and generic block view routes
- show placeholder view for unfinished tools
- add "Entrar" button and double click to open blocks

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68734ae0835083258db70dd34ca6b41a