### PR TITLE
Implement fake Crunebot mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -771,3 +771,4 @@
 - Corregido visor de fotos: las flechas actualizan la imagen usando #modalImage y el panel lateral evita overflow con comentarios scrollables (PR photo-modal-navigation-fix).
 - Added generic block viewer with placeholder page and Kanban view; cards now feature an 'Entrar' button and double-click navigation (PR personal-space-access-improvements).
 - Upload form now uses Tom Select with expanded categories and academic levels (PR notes-category-select).
+- Added IA_ENABLED config flag, disabled OpenAI calls when off and provided static quick responses with status badge (PR crunebot-fake-mode).

--- a/crunevo/config.py
+++ b/crunevo/config.py
@@ -41,6 +41,7 @@ class Config:
 
     RESEND_API_KEY = os.getenv("RESEND_API_KEY")
     OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+    IA_ENABLED = os.getenv("IA_ENABLED", "False").lower() in ("1", "true", "yes")
     OPENWEATHER_API_KEY = os.getenv("OPENWEATHER_API_KEY")
     MAIL_PROVIDER = os.getenv("MAIL_PROVIDER", "smtp")
     USE_RESEND = MAIL_PROVIDER == "resend" or RESEND_API_KEY is not None

--- a/crunevo/routes/ia_routes.py
+++ b/crunevo/routes/ia_routes.py
@@ -1,8 +1,16 @@
 from flask import Blueprint, render_template, request, jsonify, current_app
 import openai
 from openai import RateLimitError
-
 from crunevo.utils.helpers import activated_required
+
+QUICK_RESPONSES = {
+    "¿Cómo funciona CRUNEVO?": "CRUNEVO es una comunidad educativa donde puedes subir apuntes, ganar Crolars, participar en misiones y mucho más. ¡Explora todas sus secciones desde el menú superior!",
+    "¿Cómo ganar Crolars?": "Puedes ganar Crolars subiendo apuntes útiles, comentando, ayudando en el foro y completando misiones académicas.",
+    "Explícame los clubes académicos": "Los clubes académicos son grupos de estudio y colaboración en los que podrás compartir recursos y participar en eventos.",
+    "¿Cómo subir apuntes?": "Dirígete a la sección 'Apuntes' y haz clic en 'Subir apunte' para compartir tus materiales.",
+    "¿Qué es CRUNEVO+?": "CRUNEVO+ es la suscripción premium que ofrece beneficios adicionales y contenido exclusivo.",
+    "¿Dónde están los cursos?": "Los cursos están disponibles en la sección 'Cursos' del menú superior. Allí encontrarás contenidos en video, PDF o enlaces educativos.",
+}
 
 ia_bp = Blueprint("ia", __name__, url_prefix="/ia")
 
@@ -10,16 +18,30 @@ ia_bp = Blueprint("ia", __name__, url_prefix="/ia")
 @ia_bp.route("/")
 @activated_required
 def ia_chat():
-    return render_template("ia/chat.html")
+    ia_enabled = current_app.config.get("IA_ENABLED") and current_app.config.get(
+        "OPENAI_API_KEY"
+    )
+    return render_template("ia/chat.html", ia_enabled=ia_enabled)
 
 
 @ia_bp.route("/ask", methods=["POST"])
 @activated_required
 def ia_ask():
     data = request.get_json() or {}
-    prompt = data.get("message", "")
+    prompt = (data.get("message", "") or "").strip()
     if not prompt:
         return jsonify({"error": "empty"}), 400
+
+    ia_enabled = current_app.config.get("IA_ENABLED") and current_app.config.get(
+        "OPENAI_API_KEY"
+    )
+    if not ia_enabled:
+        answer = QUICK_RESPONSES.get(
+            prompt,
+            "Por ahora Crunebot está desactivado. Solo puedes usar las opciones rápidas del menú lateral mientras completamos la configuración.",
+        )
+        return jsonify({"answer": answer})
+
     try:
         openai.api_key = current_app.config.get("OPENAI_API_KEY")
         completion = openai.chat.completions.create(

--- a/crunevo/templates/ia/chat.html
+++ b/crunevo/templates/ia/chat.html
@@ -74,13 +74,13 @@
                 <div class="avatar-circle bg-primary d-flex align-items-center justify-content-center">
                   <i class="bi bi-robot text-white fs-4"></i>
                 </div>
-                <div class="status-indicator bg-success"></div>
+                <div class="status-indicator {{ 'bg-success' if ia_enabled else 'bg-danger' }}"></div>
               </div>
               <div>
                 <h6 class="fw-bold mb-0">Crunebot</h6>
-                <p class="text-success small mb-0">
-                  <i class="bi bi-circle-fill" style="font-size: 6px;"></i> Conectado
-                </p>
+                <span class="badge rounded-pill {{ 'text-bg-success' if ia_enabled else 'text-bg-danger' }}">
+                  {{ 'Conectado' if ia_enabled else 'Desactivado' }}
+                </span>
               </div>
             </div>
             
@@ -96,7 +96,7 @@
         </div>
 
         <!-- Chat Messages -->
-        <div class="chat-messages flex-grow-1 p-4 pb-24" id="chat-messages" data-user-avatar="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}">
+        <div class="chat-messages flex-grow-1 p-4 pb-24" id="chat-messages" data-user-avatar="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" data-ia-enabled="{{ 'true' if ia_enabled else 'false' }}">
           <!-- Welcome Message -->
           <div class="message-container mb-4">
             <div class="message received">

--- a/tests/test_ia.py
+++ b/tests/test_ia.py
@@ -18,3 +18,10 @@ def test_notes_populares_redirect(client, test_user):
     login(client, test_user.username)
     resp = client.get("/notes/populares")
     assert resp.status_code == 302
+
+
+def test_ia_ask_disabled(client, test_user):
+    login(client, test_user.username)
+    resp = client.post("/ia/ask", json={"message": "¿Cómo ganar Crolars?"})
+    data = resp.get_json()
+    assert "Crolars" in data["answer"]


### PR DESCRIPTION
## Summary
- add `IA_ENABLED` config flag to toggle Crunebot
- return canned answers in `ia_routes` when the bot is disabled
- show red "Desactivado" badge in chat header when AI is off
- handle quick actions locally and prevent double init in JS
- test default answer when IA is disabled
- document changes in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6873560a23388325a7d8972f0b0f04db