### PR TITLE
Fix chat image routing and preview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -772,3 +772,4 @@
 - Added generic block viewer with placeholder page and Kanban view; cards now feature an 'Entrar' button and double-click navigation (PR personal-space-access-improvements).
 - Upload form now uses Tom Select with expanded categories and academic levels (PR notes-category-select).
 - Added IA_ENABLED config flag, disabled OpenAI calls when off and provided static quick responses with status badge (PR crunebot-fake-mode).
+- Previsualización de imágenes en el chat, corrección de mensajes privados y diseño más compacto (PR chat-image-preview).

--- a/crunevo/routes/chat_routes.py
+++ b/crunevo/routes/chat_routes.py
@@ -142,7 +142,8 @@ def send_message():
     attachment = request.files.get("file")
     content = sanitize_message(data.get("content", "").strip())
     receiver_id = data.get("receiver_id")
-    is_global = data.get("is_global", False)
+    is_global_raw = data.get("is_global")
+    is_global = str(is_global_raw).lower() == "true"
 
     audio_url = None
     attachment_url = None

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -1571,9 +1571,39 @@ function initPrivateChat() {
   const audioBtn = document.getElementById('audioBtn');
   const fileInput = document.getElementById('fileInput');
   const fileBtn = document.getElementById('fileBtn');
+  const filePreview = document.getElementById('filePreview');
   container.scrollTop = container.scrollHeight;
   audioBtn?.addEventListener('click', () => audioInput?.click());
   fileBtn?.addEventListener('click', () => fileInput?.click());
+
+  fileInput?.addEventListener('change', () => {
+    const f = fileInput.files[0];
+    if (!f) {
+      filePreview?.classList.add('d-none');
+      return;
+    }
+    const cancel = document.createElement('button');
+    cancel.type = 'button';
+    cancel.className = 'btn-close';
+    cancel.addEventListener('click', () => {
+      fileInput.value = '';
+      filePreview.classList.add('d-none');
+    });
+    filePreview.innerHTML = '';
+    if (f.type.startsWith('image/')) {
+      const img = document.createElement('img');
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        img.src = e.target.result;
+      };
+      reader.readAsDataURL(f);
+      filePreview.appendChild(img);
+    } else {
+      filePreview.textContent = f.name;
+    }
+    filePreview.appendChild(cancel);
+    filePreview.classList.remove('d-none');
+  });
   form?.addEventListener('submit', (e) => {
     e.preventDefault();
     const content = input.value.trim();
@@ -1593,6 +1623,7 @@ function initPrivateChat() {
           input.value = '';
           audioInput.value = '';
           if (fileInput) fileInput.value = '';
+          if (filePreview) filePreview.classList.add('d-none');
           addMessage(data.message, true);
           lastId = data.message.id;
         }
@@ -1724,10 +1755,40 @@ function initGlobalChat() {
   const audioBtn = document.getElementById('audioBtn');
   const fileInput = document.getElementById('fileInput');
   const fileBtn = document.getElementById('fileBtn');
+  const filePreview = document.getElementById('filePreview');
   let lastId = parseInt(container.dataset.lastId || '0', 10);
   container.scrollTop = container.scrollHeight;
   audioBtn?.addEventListener('click', () => audioInput?.click());
   fileBtn?.addEventListener('click', () => fileInput?.click());
+
+  fileInput?.addEventListener('change', () => {
+    const f = fileInput.files[0];
+    if (!f) {
+      filePreview?.classList.add('d-none');
+      return;
+    }
+    const cancel = document.createElement('button');
+    cancel.type = 'button';
+    cancel.className = 'btn-close';
+    cancel.addEventListener('click', () => {
+      fileInput.value = '';
+      filePreview.classList.add('d-none');
+    });
+    filePreview.innerHTML = '';
+    if (f.type.startsWith('image/')) {
+      const img = document.createElement('img');
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        img.src = e.target.result;
+      };
+      reader.readAsDataURL(f);
+      filePreview.appendChild(img);
+    } else {
+      filePreview.textContent = f.name;
+    }
+    filePreview.appendChild(cancel);
+    filePreview.classList.remove('d-none');
+  });
 
   form?.addEventListener('submit', (e) => {
     e.preventDefault();
@@ -1747,6 +1808,7 @@ function initGlobalChat() {
           input.value = '';
           audioInput.value = '';
           if (fileInput) fileInput.value = '';
+          if (filePreview) filePreview.classList.add('d-none');
           addMessage(data.message);
           lastId = data.message.id;
         }

--- a/crunevo/templates/chat/global.html
+++ b/crunevo/templates/chat/global.html
@@ -10,14 +10,14 @@
   border: 1px solid #dee2e6;
   border-radius: 12px;
   background: rgba(255,255,255,0.05);
-  padding: 1rem 1rem 120px;
+  padding: 0.5rem 0.75rem 80px;
 }
 
 .message-item {
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
   display: flex;
   align-items: flex-start;
-  gap: 0.75rem;
+  gap: 0.5rem;
 }
 
 .message-item.own {
@@ -26,7 +26,7 @@
 
 .message-content {
   max-width: 70%;
-  padding: 0.75rem 1rem;
+  padding: 0.5rem 0.75rem;
   border-radius: 18px;
   background: rgba(233, 236, 239, 0.9);
   word-wrap: break-word;
@@ -84,8 +84,25 @@
   position: sticky;
   bottom: 0;
   background: white;
-  padding: 1rem;
+  padding: 0.5rem;
   border-top: 1px solid #dee2e6;
+}
+
+.message-content img {
+  max-width: 60%;
+  max-height: 200px;
+}
+
+#filePreview {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+#filePreview img {
+  width: 40px;
+  height: 40px;
+  object-fit: cover;
+  border-radius: 4px;
 }
 </style>
 {% endblock %}
@@ -132,7 +149,8 @@
         </div>
         
         <div class="chat-input">
-          <form id="messageForm" class="d-flex gap-2" enctype="multipart/form-data">
+          <form id="messageForm" class="d-flex flex-wrap gap-2 align-items-center" enctype="multipart/form-data">
+            <div id="filePreview" class="d-none small"></div>
             <input type="text" id="messageInput" class="form-control rounded-pill"
                    placeholder="Escribe un mensaje..." maxlength="1000">
             <input type="file" id="audioInput" accept=".mp3,.ogg" class="form-control d-none">

--- a/crunevo/templates/chat/private_chat.html
+++ b/crunevo/templates/chat/private_chat.html
@@ -14,13 +14,13 @@
 .chat-messages {
   height: 400px;
   overflow-y: auto;
-  padding: 1rem 1rem 120px;
+  padding: 0.5rem 0.75rem 80px;
   background: rgba(255,255,255,0.02);
 }
 
 .message-bubble {
   max-width: 80%;
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
   display: flex;
   flex-direction: column;
 }
@@ -36,7 +36,7 @@
 }
 
 .bubble-content {
-  padding: 0.75rem 1rem;
+  padding: 0.5rem 0.75rem;
   border-radius: 18px;
   word-wrap: break-word;
 }
@@ -55,6 +55,23 @@
   font-size: 0.75rem;
   opacity: 0.7;
   margin-top: 0.25rem;
+}
+
+.bubble-content img {
+  max-width: 60%;
+  max-height: 200px;
+}
+
+#filePreview {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+#filePreview img {
+  width: 40px;
+  height: 40px;
+  object-fit: cover;
+  border-radius: 4px;
 }
 </style>
 {% endblock %}
@@ -103,7 +120,8 @@
         </div>
         
         <div class="card-footer">
-          <form id="messageForm" class="d-flex gap-2" enctype="multipart/form-data">
+          <form id="messageForm" class="d-flex flex-wrap gap-2 align-items-center" enctype="multipart/form-data">
+            <div id="filePreview" class="d-none small"></div>
             <input type="text" id="messageInput" class="form-control"
                    placeholder="Escribe un mensaje..." maxlength="1000">
             <input type="file" id="audioInput" accept=".mp3,.ogg" class="form-control d-none">


### PR DESCRIPTION
## Summary
- improve chat layout with compact spacing
- show selected image preview with remove button in chat forms
- fix boolean logic so private images don't leak to global chat
- limit image sizes in messages
- document change in AGENTS guidelines

## Testing
- `make fmt`
- `make test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68735b42995c8325bc5b2690c591f9a2