### PR TITLE
Fix feed infinite scroll

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -775,3 +775,4 @@
 - Previsualización de imágenes en el chat, corrección de mensajes privados y diseño más compacto (PR chat-image-preview).
 - Eliminada votación y reacciones al borrar apuntes y publicaciones para evitar violación de claves foráneas (PR fix-cascade-delete).
 - Eliminación de apuntes y posts ahora borra votos/reacciones asociados y maneja IntegrityError para evitar fallos (PR delete-related-cleanup).
+- Corregido scroll infinito del feed: nueva ruta /feed/load con paginación, loader con mensajes y JS que evita peticiones duplicadas (PR feed-scroll-fix).

--- a/crunevo/templates/feed/feed.html
+++ b/crunevo/templates/feed/feed.html
@@ -173,8 +173,9 @@
 
         <!-- Load more trigger -->
         <div id="feedEnd" class="text-center py-4">
-          <div class="spinner-border text-primary" role="status">
-            <span class="visually-hidden">Cargando más...</span>
+          <div id="feed-loader">
+            <div class="spinner-border text-primary" role="status"></div>
+            <p class="text-muted mt-2 loader-text">Cargando más...</p>
           </div>
         </div>
       </div>

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -216,3 +216,10 @@ def test_eliminar_post_with_reactions(client, db_session, test_user, another_use
     assert Post.query.get(post.id) is None
     assert PostComment.query.filter_by(post_id=post.id).count() == 0
     assert PostReaction.query.filter_by(post_id=post.id).count() == 0
+
+
+def test_feed_load_empty_returns_blank(client, test_user):
+    login(client, test_user.username, "secret")
+    resp = client.get("/feed/load?page=99")
+    assert resp.status_code == 200
+    assert resp.data == b""


### PR DESCRIPTION
## Summary
- add `/feed/load` route using paginate
- improve infinite scroll logic with loader states and reachedEnd detection
- update feed template with loader element
- test infinite scroll endpoint
- document new changes in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6873686ad14083258576440fb45fcf3d