### PR TITLE
Fix disappearing posts on infinite scroll

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -776,3 +776,4 @@
 - Eliminada votación y reacciones al borrar apuntes y publicaciones para evitar violación de claves foráneas (PR fix-cascade-delete).
 - Eliminación de apuntes y posts ahora borra votos/reacciones asociados y maneja IntegrityError para evitar fallos (PR delete-related-cleanup).
 - Corregido scroll infinito del feed: nueva ruta /feed/load con paginación, loader con mensajes y JS que evita peticiones duplicadas (PR feed-scroll-fix).
+- Posts cargados via scroll ya no desaparecen y se eliminó el texto "Cargando más..." dejando solo el spinner (PR feed-loader-text-remove).

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -781,6 +781,8 @@ class ModernFeedManager {
     const container = document.getElementById('feedContainer');
     if (!container) return;
 
+    if (filter === this.currentFilter) return;
+
     try {
       this.currentFilter = filter;
       this.currentPage = 1;
@@ -788,8 +790,6 @@ class ModernFeedManager {
       const loader = document.getElementById('feed-loader');
       if (loader) {
         loader.querySelector('.spinner-border')?.classList.remove('d-none');
-        const txt = loader.querySelector('.loader-text');
-        if (txt) txt.textContent = 'Cargando más...';
         loader.style.display = '';
       }
 
@@ -803,6 +803,9 @@ class ModernFeedManager {
       this.removeSkeletonPosts();
 
       // Update content
+      if (!data.html) {
+        console.log('Empty HTML received for filter', filter);
+      }
       container.innerHTML = data.html || '';
 
       // Reinitialize interactions
@@ -845,8 +848,6 @@ class ModernFeedManager {
     if (loader) {
       loader.style.display = '';
       loader.querySelector('.spinner-border')?.classList.remove('d-none');
-      const txt = loader.querySelector('.loader-text');
-      if (txt) txt.textContent = 'Cargando más...';
     }
 
     try {
@@ -855,11 +856,12 @@ class ModernFeedManager {
       const data = await response.text();
 
       if (data.trim() === '') {
-        const txt = loader?.querySelector('.loader-text');
+        console.log('No more posts to load');
         loader?.querySelector('.spinner-border')?.classList.add('d-none');
-        if (txt) txt.textContent = 'No hay más publicaciones.';
+        if (!this.reachedEnd) {
+          this.infiniteObserver?.unobserve(document.getElementById('feedEnd'));
+        }
         this.reachedEnd = true;
-        this.infiniteObserver?.unobserve(document.getElementById('feedEnd'));
         return;
       }
 
@@ -880,11 +882,11 @@ class ModernFeedManager {
     } catch (error) {
       console.error('Error loading more posts:', error);
       this.showToast('Error al cargar más publicaciones', 'error');
-      const txt = loader?.querySelector('.loader-text');
       loader?.querySelector('.spinner-border')?.classList.add('d-none');
-      if (txt) txt.textContent = 'Error al cargar.';
+      if (!this.reachedEnd) {
+        this.infiniteObserver?.unobserve(document.getElementById('feedEnd'));
+      }
       this.reachedEnd = true;
-      this.infiniteObserver?.unobserve(document.getElementById('feedEnd'));
     } finally {
       this.isLoading = false;
     }

--- a/crunevo/templates/feed/feed.html
+++ b/crunevo/templates/feed/feed.html
@@ -175,7 +175,6 @@
         <div id="feedEnd" class="text-center py-4">
           <div id="feed-loader">
             <div class="spinner-border text-primary" role="status"></div>
-            <p class="text-muted mt-2 loader-text">Cargando más...</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- clean up loader UI on feed
- prevent duplicate loads and disappearing posts
- log when filter fetches empty HTML
- document changes in AGENTS

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68736d0f20e0832594e5aaab3ef09133