### PR TITLE
Fix disappearing posts with scroll

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -777,3 +777,4 @@
 - Eliminación de apuntes y posts ahora borra votos/reacciones asociados y maneja IntegrityError para evitar fallos (PR delete-related-cleanup).
 - Corregido scroll infinito del feed: nueva ruta /feed/load con paginación, loader con mensajes y JS que evita peticiones duplicadas (PR feed-scroll-fix).
 - Posts cargados via scroll ya no desaparecen y se eliminó el texto "Cargando más..." dejando solo el spinner (PR feed-loader-text-remove).
+- Añadidos logs de depuración en loadFilteredFeed y loadMorePosts y condición para no limpiar el feed al recargar con el mismo filtro (PR feed-scroll-disappearing-fix).

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -778,10 +778,19 @@ class ModernFeedManager {
 
   // Load filtered feed
   async loadFilteredFeed(filter) {
+    console.log('loadFilteredFeed ACTIVADO');
+    console.log('[DEBUG]', {
+      currentPage: this.currentPage,
+      currentFilter: this.currentFilter,
+      isLoading: this.isLoading,
+      reachedEnd: this.reachedEnd
+    });
+
     const container = document.getElementById('feedContainer');
     if (!container) return;
 
-    if (filter === this.currentFilter) return;
+    const filterChanged = filter !== this.currentFilter;
+    if (!filterChanged && this.currentPage > 1) return;
 
     try {
       this.currentFilter = filter;
@@ -806,7 +815,9 @@ class ModernFeedManager {
       if (!data.html) {
         console.log('Empty HTML received for filter', filter);
       }
-      container.innerHTML = data.html || '';
+      if (filterChanged || this.currentPage === 1) {
+        container.innerHTML = data.html || '';
+      }
 
       // Reinitialize interactions
       this.initPostInteractions();
@@ -842,6 +853,12 @@ class ModernFeedManager {
 
   // Load more posts
   async loadMorePosts() {
+    console.log('[DEBUG]', {
+      currentPage: this.currentPage,
+      currentFilter: this.currentFilter,
+      isLoading: this.isLoading,
+      reachedEnd: this.reachedEnd
+    });
     if (this.isLoading || this.reachedEnd) return;
     this.isLoading = true;
     const loader = document.getElementById('feed-loader');


### PR DESCRIPTION
## Summary
- add debug logs in the feed to trace infinite scroll state
- prevent reload of same filter when page>1
- only clear feed container on first page or filter change
- document fix in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687427e9b3588325ad18e6d078813df3