### PR TITLE
Fix feed scroll clearing posts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -778,3 +778,4 @@
 - Corregido scroll infinito del feed: nueva ruta /feed/load con paginación, loader con mensajes y JS que evita peticiones duplicadas (PR feed-scroll-fix).
 - Posts cargados via scroll ya no desaparecen y se eliminó el texto "Cargando más..." dejando solo el spinner (PR feed-loader-text-remove).
 - Añadidos logs de depuración en loadFilteredFeed y loadMorePosts y condición para no limpiar el feed al recargar con el mismo filtro (PR feed-scroll-disappearing-fix).
+- Ajustado loadFilteredFeed para respetar currentPage>1, proteger innerHTML y registrar actualización; loadMorePosts incluye timeout de seguridad y /feed/load muestra mensaje cuando no hay más publicaciones (PR feed-scroll-empty-fix).

--- a/crunevo/routes/feed_routes.py
+++ b/crunevo/routes/feed_routes.py
@@ -879,7 +879,7 @@ def load_feed():
     post_ids = [p.id for p in posts]
 
     if not posts:
-        return ""
+        return '<div class="no-more-posts text-center">No hay más publicaciones.</div>'
 
     reaction_map = PostReaction.counts_for_posts(post_ids)
     user_reactions = PostReaction.reactions_for_user_posts(current_user.id, post_ids)

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -789,8 +789,8 @@ class ModernFeedManager {
     const container = document.getElementById('feedContainer');
     if (!container) return;
 
+    if (filter === this.currentFilter && this.currentPage > 1) return;
     const filterChanged = filter !== this.currentFilter;
-    if (!filterChanged && this.currentPage > 1) return;
 
     try {
       this.currentFilter = filter;
@@ -815,7 +815,8 @@ class ModernFeedManager {
       if (!data.html) {
         console.log('Empty HTML received for filter', filter);
       }
-      if (filterChanged || this.currentPage === 1) {
+      if (this.currentPage === 1 || filterChanged) {
+        console.log('[FEED] Actualizando HTML del contenedor');
         container.innerHTML = data.html || '';
       }
 
@@ -861,6 +862,9 @@ class ModernFeedManager {
     });
     if (this.isLoading || this.reachedEnd) return;
     this.isLoading = true;
+    setTimeout(() => {
+      if (this.isLoading) this.isLoading = false;
+    }, 1000);
     const loader = document.getElementById('feed-loader');
     if (loader) {
       loader.style.display = '';

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from flask import url_for
 from crunevo.models import (
     FeedItem,
@@ -218,8 +219,8 @@ def test_eliminar_post_with_reactions(client, db_session, test_user, another_use
     assert PostReaction.query.filter_by(post_id=post.id).count() == 0
 
 
-def test_feed_load_empty_returns_blank(client, test_user):
+def test_feed_load_empty_returns_message(client, test_user):
     login(client, test_user.username, "secret")
     resp = client.get("/feed/load?page=99")
     assert resp.status_code == 200
-    assert resp.data == b""
+    assert "No hay más publicaciones." in resp.data.decode("utf-8")


### PR DESCRIPTION
## Summary
- avoid clearing feed when refreshing same filter on higher pages
- log when container HTML is updated
- ensure isLoading resets via timeout
- return a final message when /feed/load has no posts
- update test to match new behaviour
- document feed-scroll-empty-fix in AGENTS guidelines

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68742d9fec1c8325a82cf9fedf297ff6