### PR TITLE
Improve infinite scroll debugging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -779,3 +779,4 @@
 - Posts cargados via scroll ya no desaparecen y se eliminó el texto "Cargando más..." dejando solo el spinner (PR feed-loader-text-remove).
 - Añadidos logs de depuración en loadFilteredFeed y loadMorePosts y condición para no limpiar el feed al recargar con el mismo filtro (PR feed-scroll-disappearing-fix).
 - Ajustado loadFilteredFeed para respetar currentPage>1, proteger innerHTML y registrar actualización; loadMorePosts incluye timeout de seguridad y /feed/load muestra mensaje cuando no hay más publicaciones (PR feed-scroll-empty-fix).
+- Añadidos console logs en loadMorePosts para depurar HTML y elementos, se inserta cuando falta data-post-id y se muestra mensaje cuando no hay más publicaciones (PR feed-scroll-debug-fix).

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -875,6 +875,10 @@ class ModernFeedManager {
       this.currentPage++;
       const response = await fetch(`/feed/load?page=${this.currentPage}&categoria=${this.currentFilter}`);
       const data = await response.text();
+      console.log('[DEBUG] HTML recibido:', data);
+      const container = document.getElementById('feedContainer');
+      const temp = document.createElement('div');
+      temp.innerHTML = data;
 
       if (data.trim() === '') {
         console.log('No more posts to load');
@@ -883,21 +887,17 @@ class ModernFeedManager {
           this.infiniteObserver?.unobserve(document.getElementById('feedEnd'));
         }
         this.reachedEnd = true;
+        container.insertAdjacentHTML('beforeend', '<div class="text-center text-muted">No se encontraron más publicaciones.</div>');
         return;
       }
 
-      const container = document.getElementById('feedContainer');
-      const temp = document.createElement('div');
-      temp.innerHTML = data;
-
       Array.from(temp.children).forEach(el => {
+        console.log('[DEBUG] Elemento analizado:', el.outerHTML);
         const postId = el.getAttribute('data-post-id');
-        if (postId) {
-          const exists = container.querySelector(`[data-post-id="${postId}"]`);
-          if (exists) return;
+        if (!postId || !container.querySelector(`[data-post-id="${postId}"]`)) {
+          el.classList.add('fade-in');
+          container.appendChild(el);
         }
-        el.classList.add('fade-in');
-        container.appendChild(el);
       });
 
     } catch (error) {


### PR DESCRIPTION
## Summary
- add debug logs when loading more feed items
- insert posts even without data-post-id, log each element
- show message when no posts remaining
- document debug fix in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6874328193708325b95bf6f913be6027