### PR TITLE
Fix store category loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -781,3 +781,4 @@
 - Ajustado loadFilteredFeed para respetar currentPage>1, proteger innerHTML y registrar actualización; loadMorePosts incluye timeout de seguridad y /feed/load muestra mensaje cuando no hay más publicaciones (PR feed-scroll-empty-fix).
 - Añadidos console logs en loadMorePosts para depurar HTML y elementos, se inserta cuando falta data-post-id y se muestra mensaje cuando no hay más publicaciones (PR feed-scroll-debug-fix).
 - Marketplace filters toggle: sidebar oculto por defecto y categorías completas en modal con Tom Select (PR store-filters-toggle)
+- Fixed publish product modal using category groups via categories_dict (QA store-category-dict-fix).

--- a/crunevo/routes/store_routes.py
+++ b/crunevo/routes/store_routes.py
@@ -103,6 +103,7 @@ def store_index():
     from crunevo.constants import STORE_CATEGORIES
 
     categories = [cat for group in STORE_CATEGORIES.values() for cat in group]
+    categories_dict = STORE_CATEGORIES
     favorites = FavoriteProduct.query.filter_by(user_id=current_user.id).all()
     favorite_ids = [fav.product_id for fav in favorites]
     purchased = Purchase.query.filter_by(user_id=current_user.id).all()
@@ -131,6 +132,7 @@ def store_index():
         favorite_ids=favorite_ids,
         purchased_ids=purchased_ids,
         categories=categories,
+        categories_dict=categories_dict,
         categoria=categoria,
         precio_max=precio_max,
         ratings=ratings,

--- a/crunevo/templates/store/store.html
+++ b/crunevo/templates/store/store.html
@@ -435,7 +435,7 @@
             <label for="publishCategory" class="form-label">Categoría</label>
             <select class="form-select" id="publishCategory" name="category" data-placeholder="Seleccionar categoría">
               <option value=""></option>
-              {% for group, cats in categories.items() %}
+              {% for group, cats in categories_dict.items() %}
               <optgroup label="{{ group }}">
                 {% for cat in cats %}
                 <option value="{{ cat }}">{{ cat }}</option>


### PR DESCRIPTION
## Summary
- prevent crash by passing STORE_CATEGORIES as `categories_dict`
- render publish product category options grouped by category
- document fix in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68743f3ac0c8832582f5d813e0394418