### PR TITLE
Restrict incomplete pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -785,3 +785,4 @@
 - Fixed publish product modal using category groups via categories_dict (QA store-category-dict-fix).
 - Fixed Filters button in /store: sidebar toggles correctly with rotating icon and mobile IDs renamed to avoid duplicates (PR store-filters-btn-fix).
 - Mobile navbar: removed 'Carrera', moved 'Perfil' to the rightmost slot and added accessibility/headers fixes (PR mobile-nav-carrera-remove).
+- Enlaces a Liga, Desafíos y Mi Carrera ocultos para usuarios normales y rutas redirigen al feed si el rol no es admin (PR restrict-incomplete-pages).

--- a/crunevo/routes/carrera_routes.py
+++ b/crunevo/routes/carrera_routes.py
@@ -20,6 +20,10 @@ carrera_bp = Blueprint("carrera", __name__, url_prefix="/mi-carrera")
 @activated_required
 def index():
     """Main career center dashboard"""
+
+    if current_user.role != "admin":
+        flash("Acceso restringido", "warning")
+        return redirect(url_for("feed.feed_home"))
     # Check if user has career assigned
     if not current_user.career:
         flash("Debes asignar una carrera para acceder a Mi Carrera", "warning")

--- a/crunevo/routes/challenges_routes.py
+++ b/crunevo/routes/challenges_routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template, request, jsonify, flash
+from flask import Blueprint, render_template, request, jsonify, flash, redirect, url_for
 from flask_login import login_required, current_user
 from crunevo.extensions import db
 from crunevo.models.challenges import (
@@ -21,6 +21,10 @@ challenges_bp = Blueprint("challenges", __name__, url_prefix="/desafios")
 @activated_required
 def ghost_mentor():
     """Ghost Mentor Challenge page"""
+
+    if current_user.role != "admin":
+        flash("Acceso restringido", "warning")
+        return redirect(url_for("feed.feed_home"))
     if not table_exists("ghost_mentor_challenge"):
         flash("Función no disponible", "warning")
         return render_template(

--- a/crunevo/routes/league_routes.py
+++ b/crunevo/routes/league_routes.py
@@ -3,6 +3,7 @@ from flask_login import login_required, current_user
 from crunevo.extensions import db
 from crunevo.models.league import AcademicTeam, TeamMember, LeagueMonth, TeamAction
 from crunevo.utils.helpers import activated_required, table_exists
+
 from datetime import datetime
 from sqlalchemy import desc
 
@@ -14,6 +15,10 @@ league_bp = Blueprint("league", __name__, url_prefix="/liga")
 @activated_required
 def index():
     """Academic League main page"""
+
+    if current_user.role != "admin":
+        flash("Acceso restringido", "warning")
+        return redirect(url_for("feed.feed_home"))
 
     if not table_exists("team_member"):
         flash("Función no disponible", "warning")

--- a/crunevo/templates/components/launcher_menu.html
+++ b/crunevo/templates/components/launcher_menu.html
@@ -16,6 +16,7 @@
         <i class="bi bi-stars fs-3 text-warning"></i>
         <span class="small mt-1">Misiones</span>
       </a>
+      {% if current_user.is_authenticated and current_user.role == 'admin' %}
       <a href="{{ url_for('league.index') if 'league.index' in url_for.__globals__.get('current_app', {}).view_functions else '/liga' }}" class="launcher-item">
         <i class="bi bi-award fs-3 text-success"></i>
         <span class="small mt-1">Liga</span>
@@ -24,6 +25,7 @@
         <i class="bi bi-lightning fs-3 text-danger"></i>
         <span class="small mt-1">Desafíos</span>
       </a>
+      {% endif %}
     </div>
   </div>
 </li>

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -44,9 +44,11 @@
         <a class="nav-link" href="{{ url_for('forum.list_questions') if 'forum.list_questions' in url_for.__globals__.get('current_app', {}).view_functions else '/foro' }}"><i class="bi bi-chat-left-quote me-1"></i>Foro</a>
         <a class="nav-link" href="{{ url_for('store.store_index') if 'store.store_index' in url_for.__globals__.get('current_app', {}).view_functions else '/store' }}"><i class="bi bi-shop me-1"></i>Tienda</a>
         <a class="nav-link" href="{{ url_for('courses.list_courses') if 'courses.list_courses' in url_for.__globals__.get('current_app', {}).view_functions else '/cursos' }}"><i class="bi bi-play-circle-fill me-1"></i>Cursos</a>
+        {% if current_user.is_authenticated and current_user.role == 'admin' %}
         <a class="nav-link" href="{{ url_for('carrera.index') if 'carrera.index' in url_for.__globals__.get('current_app', {}).view_functions else '/micarrera' }}">
           <i class="bi bi-mortarboard"></i> Mi Carrera
         </a>
+        {% endif %}
       </div>
 
       <ul class="navbar-nav ms-auto align-items-center gap-2">

--- a/crunevo/templates/components/sidebar_left_feed.html
+++ b/crunevo/templates/components/sidebar_left_feed.html
@@ -121,6 +121,7 @@
           </a>
         </li>
 
+        {% if current_user.is_authenticated and current_user.role == 'admin' %}
         <li>
           <a href="{{ url_for('carrera.index') if 'carrera.index' in url_for.__globals__.get('current_app', {}).view_functions else '/micarrera' }}" class="nav-link {{ 'active' if request.endpoint == 'carrera.index' }}">
             <i class="bi bi-mortarboard"></i>
@@ -139,6 +140,7 @@
             <span class="fw-semibold">Desafíos</span>
           </a>
         </li>
+        {% endif %}
         {% if current_user.is_authenticated %}
           {% set hall_member = get_hall_membership(current_user) %}
           {% if hall_member or (current_user.credits >= 1000) %}


### PR DESCRIPTION
## Summary
- limit `/liga`, `/desafios/mentor-fantasma` and `/mi-carrera` to admin users
- hide links to these pages from navbar, sidebar and launcher
- log change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6876d4c778a48325a022ccc72e08137e