### PR TITLE
Redesigned note card UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -788,3 +788,4 @@
 - Enlaces a Liga, Desafíos y Mi Carrera ocultos para usuarios normales y rutas redirigen al feed si el rol no es admin (PR restrict-incomplete-pages).
 - Vista /notes redise\u00f1ada como galer\u00eda A4: alias /apuntes, tarjetas verticales con t\u00edtulo arriba, sidebar removido y responsive (PR notes-a4-gallery).
 - Fixed account deletion by removing related records, added confirmation and flash message (PR delete-account-fix).
+- Tarjetas de apuntes modernizadas con sección de autor, etiquetas y menú de opciones; incluyen skeleton de carga y métricas inferiores (PR note-card-redesign).

--- a/crunevo/static/css/notes.css
+++ b/crunevo/static/css/notes.css
@@ -1,23 +1,73 @@
 .note-title {
-  font-size: 0.9rem;
+  font-size: 0.95rem;
   font-weight: 600;
   margin-bottom: 0.25rem;
-  text-align: center;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.note-card .note-preview {
+.note-card {
+  border: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.note-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+}
+
+.note-preview {
+  position: relative;
+  height: 180px;
+  overflow: hidden;
   background-color: var(--bs-light-bg-subtle, #f8f9fa);
 }
 
-.note-card .ratio-a4 {
-  --bs-aspect-ratio: 141%;
+.note-preview img,
+.note-preview canvas {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
 }
 
-.note-card .btn-group {
+.note-preview .loading-shimmer {
+  position: absolute;
+  inset: 0;
+}
+
+.note-author {
+  display: flex;
+  align-items: center;
   gap: 0.25rem;
+  font-size: 0.8rem;
+  margin-bottom: 0.25rem;
+}
+
+.note-author img {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.note-tags {
+  margin-top: 0.25rem;
+}
+
+.note-tags .badge {
+  margin-right: 0.25rem;
+}
+
+.note-stats {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+}
+
+.note-actions {
+  margin-top: 0.5rem;
 }
 
 @media (max-width: 575.98px) {

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -281,7 +281,15 @@ function initPdfPreviews() {
         const viewport = page.getViewport({ scale: 0.5 });
         canvas.height = viewport.height;
         canvas.width = viewport.width;
-        page.render({ canvasContext: canvas.getContext('2d'), viewport });
+        return page
+          .render({ canvasContext: canvas.getContext('2d'), viewport })
+          .promise;
+      })
+      .then(() => {
+        canvas.classList.remove('d-none');
+        canvas.closest('.note-preview')
+          ?.querySelector('.loading-shimmer')
+          ?.remove();
       })
       .catch(() => {
         const div = document.createElement('div');
@@ -289,6 +297,23 @@ function initPdfPreviews() {
         div.textContent = 'Vista previa no disponible';
         canvas.replaceWith(div);
       });
+  });
+
+  document.querySelectorAll('img.note-img').forEach((img) => {
+    if (img.complete) {
+      img.classList.remove('d-none');
+      img.closest('.note-preview')?.querySelector('.loading-shimmer')?.remove();
+    } else {
+      img.addEventListener('load', () => {
+        img.classList.remove('d-none');
+        img.closest('.note-preview')
+          ?.querySelector('.loading-shimmer')
+          ?.remove();
+      });
+      img.addEventListener('error', () => {
+        img.closest('.note-preview')?.querySelector('.loading-shimmer')?.remove();
+      });
+    }
   });
 }
 

--- a/crunevo/templates/components/note_card.html
+++ b/crunevo/templates/components/note_card.html
@@ -1,42 +1,87 @@
 {% import 'components/csrf.html' as csrf %}
 {% set show_quick = show_quick_view if show_quick_view is defined else False %}
 {% set ext = note.filename.split('?')[0].rsplit('.', 1)[-1].lower() %}
-<div class="note-item">
-  <p class="note-title">{{ note.title }}</p>
-  <article class="card note-card shadow-sm rounded-4 h-100">
-    <div class="note-preview ratio ratio-a4 bg-light-subtle text-center">
-      {% if ext == 'pdf' %}
-        <canvas class="pdf-thumb w-100 h-100" data-pdf="{{ note.filename }}"></canvas>
-      {% elif ext in ['jpg','jpeg','png','webp'] %}
-        <img src="{{ note.filename }}" class="img-fluid rounded w-100 h-100" style="object-fit: cover;" alt="preview">
-      {% else %}
-        <div class="text-muted d-flex flex-column justify-content-center h-100">
-          <i class="bi bi-file-earmark fs-1"></i>
-          <small>Vista previa no disponible</small>
-        </div>
+{% set author = note.author %}
+
+<article class="note-card card shadow-sm rounded-4 h-100 position-relative">
+  {% if note.views > 100 %}
+  <span class="badge text-bg-danger position-absolute top-0 start-0 m-2">Popular 🔥</span>
+  {% elif author and author.verification_level >= 2 %}
+  <span class="badge text-bg-success position-absolute top-0 start-0 m-2">Verificado ✅</span>
+  {% endif %}
+
+  <div class="dropdown position-absolute top-0 end-0 m-2">
+    <button class="options-btn" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+      <i class="bi bi-three-dots"></i>
+    </button>
+    <ul class="dropdown-menu dropdown-menu-end">
+      {% if current_user.is_authenticated and note.user_id == current_user.id %}
+      <li>
+        <a class="dropdown-item" href="{{ url_for('notes.edit_note', note_id=note.id) }}">
+          <i class="bi bi-pencil"></i> Editar
+        </a>
+      </li>
       {% endif %}
-    </div>
-    <div class="card-body d-flex flex-column justify-content-between pt-2">
-      <div class="d-flex justify-content-between align-items-center small text-muted mb-2">
-        <span><i class="bi bi-eye me-1"></i> {{ note.views }}</span>
-        <span><i class="bi bi-hand-thumbs-up me-1"></i> {{ note.likes or 0 }}</span>
-      </div>
-      <div class="btn-group mt-auto">
-        <a href="{{ url_for('notes.view_note', id=note.id) }}" class="btn btn-outline-primary btn-sm">Ver detalle</a>
-        {% if current_user.is_authenticated and note.user_id == current_user.id %}
-        <a href="{{ url_for('notes.edit_note', note_id=note.id) }}" class="btn btn-outline-secondary btn-sm">Editar</a>
-        {% else %}
-        <button type="button" class="btn btn-outline-warning btn-sm" data-bs-toggle="modal" data-bs-target="#reportNote{{ note.id }}">Reportar</button>
-        {% endif %}
-        {% if show_quick and ext in ['pdf','png'] %}
-        <button class="btn btn-outline-info btn-sm" onclick="openQuickView('{{ note.filename }}')">
-          <i class="bi bi-eye"></i>
+      {% if current_user.is_authenticated %}
+      <li>
+        <a class="dropdown-item" href="#" onclick="toggleSave('note', {{ note.id }}, this); return false;">
+          <i class="bi bi-bookmark"></i> Guardar
+        </a>
+      </li>
+      {% endif %}
+      <li>
+        <button class="dropdown-item" data-bs-toggle="modal" data-bs-target="#reportNote{{ note.id }}">
+          <i class="bi bi-flag"></i> Reportar
         </button>
-        {% endif %}
-      </div>
+      </li>
+    </ul>
+  </div>
+
+  <div class="p-3 pb-0">
+    <p class="note-title mb-1">{{ note.title }}</p>
+    <div class="note-author">
+      <img src="{{ author.avatar_url if author else url_for('static', filename='img/default.png') }}" alt="{{ author.username if author else 'Usuario' }}">
+      {% if author %}
+      <a href="{{ url_for('auth.profile_by_username', username=author.username) }}" class="text-decoration-none">{{ author.username }}</a>
+      {% else %}
+      <span class="text-muted">Usuario eliminado</span>
+      {% endif %}
+      <span class="text-muted ms-auto">{{ note.created_at|timesince }}</span>
     </div>
-  </article>
-</div>
+  </div>
+
+  <div class="note-preview">
+    <div class="loading-shimmer"></div>
+    {% if ext == 'pdf' %}
+      <canvas class="pdf-thumb d-none" data-pdf="{{ note.filename }}"></canvas>
+    {% elif ext in ['jpg','jpeg','png','webp'] %}
+      <img src="{{ note.filename }}" class="note-img d-none" alt="preview">
+    {% else %}
+      <div class="text-muted d-flex flex-column justify-content-center align-items-center h-100">
+        <i class="bi bi-file-earmark fs-1"></i>
+        <small>Vista previa no disponible</small>
+      </div>
+    {% endif %}
+  </div>
+
+  {% if note.tags %}
+  <div class="note-tags px-3">
+    {% for tag in note.tags.split(',')[:3] %}
+    <span class="badge bg-light text-dark">{{ tag.strip() }}</span>
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  <div class="px-3 note-actions pb-3">
+    <div class="note-stats mb-2">
+      <span><i class="bi bi-eye me-1"></i>{{ note.views }}</span>
+      <span><i class="bi bi-heart me-1"></i>{{ note.likes or 0 }}</span>
+      <span><i class="bi bi-download me-1"></i>{{ note.downloads or 0 }}</span>
+    </div>
+    <a href="{{ url_for('notes.view_note', id=note.id) }}" class="btn btn-primary btn-sm w-100">Ver Detalle</a>
+  </div>
+</article>
+
 {% if current_user.is_authenticated and note.user_id != current_user.id %}
 <div class="modal fade" id="reportNote{{ note.id }}" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog">

--- a/crunevo/templates/notes/list.html
+++ b/crunevo/templates/notes/list.html
@@ -57,72 +57,61 @@ function createNoteCard(n) {
   const col = document.createElement('div');
   col.className = 'col';
 
-  const wrapper = document.createElement('div');
-  wrapper.className = 'note-item';
-
-  const title = document.createElement('p');
-  title.className = 'note-title';
-  title.textContent = n.title;
-  wrapper.appendChild(title);
-
   const card = document.createElement('article');
-  card.className = 'card note-card shadow-sm rounded-4 h-100';
+  card.className = 'note-card card shadow-sm rounded-4 h-100 position-relative';
+
+  const header = document.createElement('div');
+  header.className = 'p-3 pb-0';
+  header.innerHTML = `<p class="note-title mb-1">${n.title}</p>`;
+  card.appendChild(header);
 
   const preview = document.createElement('div');
-  preview.className = 'note-preview ratio ratio-a4 bg-light-subtle text-center';
+  preview.className = 'note-preview';
+  preview.innerHTML = '<div class="loading-shimmer"></div>';
 
   const ext = n.filename.split('?')[0].split('.').pop().toLowerCase();
   if (ext === 'pdf') {
     const canvas = document.createElement('canvas');
-    canvas.className = 'pdf-thumb w-100 h-100';
+    canvas.className = 'pdf-thumb d-none';
     canvas.dataset.pdf = n.filename;
     preview.appendChild(canvas);
   } else if (['jpg','jpeg','png','webp'].includes(ext)) {
     const img = document.createElement('img');
     img.src = n.filename;
-    img.className = 'img-fluid rounded w-100 h-100';
-    img.style.objectFit = 'cover';
+    img.className = 'note-img d-none';
     preview.appendChild(img);
   } else {
     const div = document.createElement('div');
-    div.className = 'text-muted d-flex flex-column justify-content-center h-100';
-    div.style.flexDirection = 'column';
+    div.className = 'text-muted d-flex flex-column justify-content-center align-items-center h-100';
     div.innerHTML = '<i class="bi bi-file-earmark fs-1"></i><small>Vista previa no disponible</small>';
     preview.appendChild(div);
   }
+  card.appendChild(preview);
 
-  const body = document.createElement('div');
-  body.className = 'card-body d-flex flex-column justify-content-between pt-2';
-
-
-  const stats = document.createElement('div');
-  stats.className = 'd-flex justify-content-between align-items-center small text-muted';
-  stats.innerHTML = `<span><i class="bi bi-eye me-1"></i> ${n.views || 0}</span><span><i class="bi bi-hand-thumbs-up me-1"></i> ${n.likes || 0}</span>`;
-
-  const btnGroup = document.createElement('div');
-  btnGroup.className = 'btn-group mt-auto';
-
-  const link = document.createElement('a');
-  link.className = 'btn btn-outline-primary btn-sm';
-  link.href = `/notes/${n.id}`;
-  link.textContent = 'Ver detalle';
-  btnGroup.appendChild(link);
-
-  if (['pdf','png'].includes(ext)) {
-    const qbtn = document.createElement('button');
-    qbtn.className = 'btn btn-outline-info btn-sm';
-    qbtn.innerHTML = '<i class="bi bi-eye"></i>';
-    qbtn.addEventListener('click', () => openQuickView(n.filename));
-    btnGroup.appendChild(qbtn);
+  if (n.tags) {
+    const tags = document.createElement('div');
+    tags.className = 'note-tags px-3';
+    n.tags.split(',').slice(0,3).forEach(t => {
+      const span = document.createElement('span');
+      span.className = 'badge bg-light text-dark';
+      span.textContent = t.trim();
+      tags.appendChild(span);
+    });
+    card.appendChild(tags);
   }
 
-  body.appendChild(stats);
-  body.appendChild(btnGroup);
+  const actions = document.createElement('div');
+  actions.className = 'px-3 note-actions pb-3';
+  actions.innerHTML = `
+    <div class="note-stats mb-2">
+      <span><i class="bi bi-eye me-1"></i>${n.views || 0}</span>
+      <span><i class="bi bi-heart me-1"></i>${n.likes || 0}</span>
+    </div>
+    <a href="/notes/${n.id}" class="btn btn-primary btn-sm w-100">Ver Detalle</a>
+  `;
 
-  card.appendChild(preview);
-  card.appendChild(body);
-  wrapper.appendChild(card);
-  col.appendChild(wrapper);
+  card.appendChild(actions);
+  col.appendChild(card);
   return col;
 }
 </script>


### PR DESCRIPTION
## Summary
- refresh note card design with author section, dropdown actions and bottom stats
- add CSS styles for new hover effect, skeleton loader and tags
- support skeleton removal in `initPdfPreviews`
- document redesign in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6877848c89688325bc66655eed8fd2da