### PR TITLE
Improve notes gallery layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -789,3 +789,4 @@
 - Vista /notes redise\u00f1ada como galer\u00eda A4: alias /apuntes, tarjetas verticales con t\u00edtulo arriba, sidebar removido y responsive (PR notes-a4-gallery).
 - Fixed account deletion by removing related records, added confirmation and flash message (PR delete-account-fix).
 - Tarjetas de apuntes modernizadas con sección de autor, etiquetas y menú de opciones; incluyen skeleton de carga y métricas inferiores (PR note-card-redesign).
+- Layout de /notes ajustado con grid responsive Bootstrap y tarjetas flex-column que empujan acciones al fondo (PR notes-gallery-responsive).

--- a/crunevo/static/css/notes.css
+++ b/crunevo/static/css/notes.css
@@ -10,6 +10,9 @@
 .note-card {
   border: none;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
 
 .note-card:hover {
@@ -67,7 +70,7 @@
 }
 
 .note-actions {
-  margin-top: 0.5rem;
+  margin-top: auto;
 }
 
 @media (max-width: 575.98px) {

--- a/crunevo/templates/components/note_card.html
+++ b/crunevo/templates/components/note_card.html
@@ -3,7 +3,7 @@
 {% set ext = note.filename.split('?')[0].rsplit('.', 1)[-1].lower() %}
 {% set author = note.author %}
 
-<article class="note-card card shadow-sm rounded-4 h-100 position-relative">
+<article class="note-card card shadow-sm rounded-4 h-100 position-relative d-flex flex-column">
   {% if note.views > 100 %}
   <span class="badge text-bg-danger position-absolute top-0 start-0 m-2">Popular 🔥</span>
   {% elif author and author.verification_level >= 2 %}
@@ -72,7 +72,7 @@
   </div>
   {% endif %}
 
-  <div class="px-3 note-actions pb-3">
+  <div class="px-3 note-actions pb-3 mt-auto">
     <div class="note-stats mb-2">
       <span><i class="bi bi-eye me-1"></i>{{ note.views }}</span>
       <span><i class="bi bi-heart me-1"></i>{{ note.likes or 0 }}</span>

--- a/crunevo/templates/notes/list.html
+++ b/crunevo/templates/notes/list.html
@@ -31,9 +31,9 @@
         <a href="{{ url_for('notes.upload_note') }}" class="btn btn-success">Subir apunte</a>
       </div>
     </div>
-    <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-5 row-cols-xl-6 row-cols-xxl-7 g-3" id="notesList">
+    <div class="row g-4" id="notesList">
 {% for note in notes %}
-  <div class="col">
+  <div class="col-12 col-md-6 col-lg-4 col-xxl-3">
     {% set show_quick_view = True %}
     {% include 'components/note_card.html' %}
   </div>
@@ -55,10 +55,10 @@ document.getElementById('noteSearch').addEventListener('input', function(e){
 
 function createNoteCard(n) {
   const col = document.createElement('div');
-  col.className = 'col';
+  col.className = 'col-12 col-md-6 col-lg-4 col-xxl-3';
 
   const card = document.createElement('article');
-  card.className = 'note-card card shadow-sm rounded-4 h-100 position-relative';
+  card.className = 'note-card card shadow-sm rounded-4 h-100 position-relative d-flex flex-column';
 
   const header = document.createElement('div');
   header.className = 'p-3 pb-0';
@@ -101,7 +101,7 @@ function createNoteCard(n) {
   }
 
   const actions = document.createElement('div');
-  actions.className = 'px-3 note-actions pb-3';
+  actions.className = 'px-3 note-actions pb-3 mt-auto';
   actions.innerHTML = `
     <div class="note-stats mb-2">
       <span><i class="bi bi-eye me-1"></i>${n.views || 0}</span>


### PR DESCRIPTION
## Summary
- implement responsive grid for the notes list
- ensure note cards stretch to full column height
- push note actions to the bottom of each card
- document changes in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687832c911f0832582dddd44b7807006