### PR TITLE
Redesign verification style for notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -789,3 +789,4 @@
 - Vista /notes redise\u00f1ada como galer\u00eda A4: alias /apuntes, tarjetas verticales con t\u00edtulo arriba, sidebar removido y responsive (PR notes-a4-gallery).
 - Fixed account deletion by removing related records, added confirmation and flash message (PR delete-account-fix).
 - Tarjetas de apuntes modernizadas con sección de autor, etiquetas y menú de opciones; incluyen skeleton de carga y métricas inferiores (PR note-card-redesign).
+- Indicadores de verificación rediseñados: se quitan badges verdes, icono junto al nombre y efecto glow en tarjetas (PR notes-verified-ui).

--- a/crunevo/static/css/notes.css
+++ b/crunevo/static/css/notes.css
@@ -17,6 +17,11 @@
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
 }
 
+.note-card--verified {
+  box-shadow: 0 0 12px rgba(108, 99, 255, 0.5), 0 8px 24px rgba(0, 0, 0, 0.08);
+  border-left: 3px solid #6c63ff;
+}
+
 .note-preview {
   position: relative;
   height: 180px;

--- a/crunevo/templates/components/note_card.html
+++ b/crunevo/templates/components/note_card.html
@@ -3,11 +3,9 @@
 {% set ext = note.filename.split('?')[0].rsplit('.', 1)[-1].lower() %}
 {% set author = note.author %}
 
-<article class="note-card card shadow-sm rounded-4 h-100 position-relative">
+<article class="note-card card shadow-sm rounded-4 h-100 position-relative {% if note.verified %}note-card--verified{% endif %}">
   {% if note.views > 100 %}
   <span class="badge text-bg-danger position-absolute top-0 start-0 m-2">Popular 🔥</span>
-  {% elif author and author.verification_level >= 2 %}
-  <span class="badge text-bg-success position-absolute top-0 start-0 m-2">Verificado ✅</span>
   {% endif %}
 
   <div class="dropdown position-absolute top-0 end-0 m-2">
@@ -43,6 +41,11 @@
       <img src="{{ author.avatar_url if author else url_for('static', filename='img/default.png') }}" alt="{{ author.username if author else 'Usuario' }}">
       {% if author %}
       <a href="{{ url_for('auth.profile_by_username', username=author.username) }}" class="text-decoration-none">{{ author.username }}</a>
+      {% if author and author.verification_level >= 2 %}
+      <span class="ms-1" style="color: var(--bs-primary);" data-bs-toggle="tooltip" title="Usuario Verificado">
+        <i class="bi bi-patch-check-fill"></i>
+      </span>
+      {% endif %}
       {% else %}
       <span class="text-muted">Usuario eliminado</span>
       {% endif %}


### PR DESCRIPTION
## Summary
- rework note verification UI
- add `.note-card--verified` class with glow effect
- place verification icon after author name
- document change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68783bf5a92c832593767b0b18c57593