### PR TITLE
Optimize Cloudinary image URLs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -790,3 +790,4 @@
 - Fixed account deletion by removing related records, added confirmation and flash message (PR delete-account-fix).
 - Tarjetas de apuntes modernizadas con sección de autor, etiquetas y menú de opciones; incluyen skeleton de carga y métricas inferiores (PR note-card-redesign).
 - Indicadores de verificación rediseñados: se quitan badges verdes, icono junto al nombre y efecto glow en tarjetas (PR notes-verified-ui).
+- Generado filtro `cl_url` y helper optimize_url para insertar `f_auto`, `q_auto` y tamaños al construir URLs de Cloudinary; se actualizaron avatares, galerías y tienda (PR cloudinary-optimizations).

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -134,9 +134,11 @@ def create_app():
         }
 
     from .utils.helpers import timesince, get_hall_membership, notes_count
+    from .utils.image_optimizer import optimize_url
     from .cache.link_preview import extract_first_url, get_preview
 
     app.jinja_env.filters["timesince"] = timesince
+    app.jinja_env.filters["cl_url"] = optimize_url
 
     def link_preview(text):
         url = extract_first_url(text)

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -42,7 +42,7 @@
           <div class="row align-items-center">
             <div class="col-auto">
               <div class="profile-avatar-container text-center position-relative" style="margin-top: -60px;">
-                <img src="{{ user.avatar_url or url_for('static', filename='img/default.png') }}"
+                <img src="{{ (user.avatar_url|cl_url(120,120,'thumb')) if user.avatar_url else url_for('static', filename='img/default.png') }}"
                      class="rounded-circle border border-white shadow avatar-img"
                      id="avatarPreview" width="120" height="120" alt="Avatar">
 
@@ -341,7 +341,7 @@
           <div class="card mb-3">
             <div class="row g-0">
               <div class="col-md-2 text-center">
-                <img loading="lazy" src="{{ compra.product.image_url or '/static/img/producto-default.png' }}" class="img-fluid rounded-start" alt="{{ compra.product.name }}">
+                <img loading="lazy" src="{{ (compra.product.image_url|cl_url(200,150,'fill')) if compra.product.image_url else '/static/img/producto-default.png' }}" class="img-fluid rounded-start" alt="{{ compra.product.name }}">
               </div>
               <div class="col-md-10">
                 <div class="card-body">

--- a/crunevo/templates/components/image_gallery.html
+++ b/crunevo/templates/components/image_gallery.html
@@ -7,7 +7,7 @@
   {% if count == 1 %}
     <!-- Single image - Full width -->
     <div class="facebook-gallery single-image">
-      <img src="{{ urls[0] }}" 
+      <img src="{{ urls[0]|cl_url(800,600,'fill') }}"
            alt="Imagen de la publicación" 
            onclick="openImageModal('{{ urls[0] }}', 0, '{{ post_id }}', event)" 
            loading="lazy" 
@@ -19,7 +19,7 @@
     <div class="facebook-gallery two-images">
       {% for url in urls[:2] %}
       <div class="gallery-item">
-        <img src="{{ url }}" 
+        <img src="{{ url|cl_url(800,600,'fill') }}"
              alt="Imagen {{ loop.index }} de {{ count }}" 
              onclick="openImageModal('{{ url }}', {{ loop.index0 }}, '{{ post_id }}', event)" 
              loading="lazy" 
@@ -32,7 +32,7 @@
     <!-- Three images - One large left, two stacked right -->
     <div class="facebook-gallery three-images">
       <div class="gallery-item main-item">
-        <img src="{{ urls[0] }}" 
+        <img src="{{ urls[0]|cl_url(800,600,'fill') }}"
              alt="Imagen 1 de {{ count }}" 
              onclick="openImageModal('{{ urls[0] }}', 0, '{{ post_id }}', event)" 
              loading="lazy" 
@@ -41,7 +41,7 @@
       <div class="gallery-side">
         {% for url in urls[1:3] %}
         <div class="gallery-item">
-          <img src="{{ url }}" 
+          <img src="{{ url|cl_url(800,600,'fill') }}"
                alt="Imagen {{ loop.index + 1 }} de {{ count }}" 
                onclick="openImageModal('{{ url }}', {{ loop.index }}, '{{ post_id }}', event)" 
                loading="lazy" 
@@ -56,7 +56,7 @@
     <div class="facebook-gallery four-images">
       {% for url in urls[:4] %}
       <div class="gallery-item">
-        <img src="{{ url }}" 
+        <img src="{{ url|cl_url(800,600,'fill') }}"
              alt="Imagen {{ loop.index }} de {{ count }}" 
              onclick="openImageModal('{{ url }}', {{ loop.index0 }}, '{{ post_id }}', event)" 
              loading="lazy" 
@@ -69,7 +69,7 @@
     <!-- Five or more images - Facebook style -->
     <div class="facebook-gallery five-plus-images">
       <div class="gallery-item main-item">
-        <img src="{{ urls[0] }}" 
+        <img src="{{ urls[0]|cl_url(800,600,'fill') }}"
              alt="Imagen 1 de {{ count }}" 
              onclick="openImageModal('{{ urls[0] }}', 0, '{{ post_id }}', event)" 
              loading="lazy" 
@@ -78,7 +78,7 @@
       <div class="gallery-grid">
         {% for url in urls[1:5] %}
         <div class="gallery-item {% if loop.index == 4 and count > 5 %}has-overlay{% endif %}">
-          <img src="{{ url }}" 
+          <img src="{{ url|cl_url(800,600,'fill') }}"
                alt="Imagen {{ loop.index + 1 }} de {{ count }}" 
                onclick="openImageModal('{{ url }}', {{ loop.index }}, '{{ post_id }}', event)" 
                loading="lazy" 

--- a/crunevo/templates/components/post_card.html
+++ b/crunevo/templates/components/post_card.html
@@ -10,7 +10,7 @@
   <!-- Post Header -->
   <div class="post-header">
     <div class="post-avatar">
-      <img src="{{ author.avatar_url if author else url_for('static', filename='img/default.png') }}"
+      <img src="{{ (author.avatar_url|cl_url(40,40,'thumb')) if author else url_for('static', filename='img/default.png') }}"
            alt="{{ author.username if author else 'Usuario eliminado' }}"
            class="avatar-img">
     </div>

--- a/crunevo/templates/store/_product_cards.html
+++ b/crunevo/templates/store/_product_cards.html
@@ -1,7 +1,7 @@
 {% for product in products %}
 <div class="product-card" data-category="{{ product.category }}" data-price="{{ product.price }}" data-credits="{{ product.price_credits or 0 }}">
   <div class="product-image-container">
-    <img src="{{ product.first_image or url_for('static', filename='img/default_product.png') }}"
+    <img src="{{ (product.first_image|cl_url(400,300,'fill')) if product.first_image else url_for('static', filename='img/default_product.png') }}"
          alt="{{ product.name }}"
          class="product-image"
          loading="lazy">

--- a/crunevo/templates/store/carrito.html
+++ b/crunevo/templates/store/carrito.html
@@ -25,7 +25,7 @@
           <tr>
             <td>
               <div class="d-flex align-items-center">
-                <img loading="lazy" src="{{ item.product.first_image or '/static/img/producto-default.png' }}" alt="{{ item.product.name }}" class="me-3 rounded" width="60">
+                <img loading="lazy" src="{{ (item.product.first_image|cl_url(60,60,'thumb')) if item.product.first_image else '/static/img/producto-default.png' }}" alt="{{ item.product.name }}" class="me-3 rounded" width="60">
                 <div>
                   <strong>{{ item.product.name }}</strong><br>
                   <small class="text-muted">{{ item.product.description[:60] }}</small>

--- a/crunevo/templates/store/compras.html
+++ b/crunevo/templates/store/compras.html
@@ -12,7 +12,7 @@
     <div class="card mb-3">
       <div class="row g-0">
         <div class="col-md-2 text-center">
-          <img loading="lazy" src="{{ compra.product.image_url or '/static/img/producto-default.png' }}" class="img-fluid rounded-start" alt="{{ compra.product.name }}">
+          <img loading="lazy" src="{{ (compra.product.image_url|cl_url(200,150,'fill')) if compra.product.image_url else '/static/img/producto-default.png' }}" class="img-fluid rounded-start" alt="{{ compra.product.name }}">
         </div>
         <div class="col-md-10">
           <div class="card-body">

--- a/crunevo/templates/store/favorites.html
+++ b/crunevo/templates/store/favorites.html
@@ -43,7 +43,7 @@
             {% for product in products %}
               <div class="col">
                 <div class="card product-card position-relative h-100 border border-primary p-2">
-                  <img loading="lazy" src="{{ product.image_url or '/static/img/producto-default.png' }}" class="card-img-top rounded mb-2" alt="{{ product.name }}">
+                  <img loading="lazy" src="{{ (product.image_url|cl_url(400,300,'fill')) if product.image_url else '/static/img/producto-default.png' }}" class="card-img-top rounded mb-2" alt="{{ product.name }}">
                   <form method="post" action="{{ url_for('store.toggle_favorite', product_id=product.id) }}" class="position-absolute top-0 end-0 m-2">
                     {{ csrf.csrf_field() }}
                     <button class="btn btn-sm btn-light border-0" type="submit">

--- a/crunevo/templates/store/product_card.html
+++ b/crunevo/templates/store/product_card.html
@@ -2,7 +2,7 @@
 {% import 'components/csrf.html' as csrf %}
 <div class="card h-100 border border-primary p-2 position-relative">
   <a href="{{ url_for('store.view_product', product_id=product.id) }}">
-    <img loading="lazy" src="{{ product.first_image or '/static/img/producto-default.png' }}" class="card-img-top rounded mb-2 img-fluid" style="max-height: 180px; object-fit: cover;" alt="imagen">
+    <img loading="lazy" src="{{ (product.first_image|cl_url(400,300,'fill')) if product.first_image else '/static/img/producto-default.png' }}" class="card-img-top rounded mb-2 img-fluid" style="max-height: 180px; object-fit: cover;" alt="imagen">
   </a>
   <div class="position-absolute top-0 start-0 m-2 tw-space-x-1">
     {% if product.category %}<span class="badge bg-info text-body">{{ product.category }}</span>{% endif %}

--- a/crunevo/templates/store/producto.html
+++ b/crunevo/templates/store/producto.html
@@ -16,8 +16,8 @@
       <div class="col-lg-6">
         <div class="product-gallery">
           <div class="main-image-container">
-            <img id="mainProductImage" 
-                 src="{{ product.image_url or url_for('static', filename='img/default_product.png') }}" 
+            <img id="mainProductImage"
+                 src="{{ (product.image_url|cl_url(800,600,'fill')) if product.image_url else url_for('static', filename='img/default_product.png') }}"
                  alt="{{ product.name }}"
                  class="main-product-image"
                  onclick="openProductImageModal(this.src)">
@@ -32,7 +32,7 @@
           <div class="thumbnail-gallery">
             {% for image_url in product.image_urls %}
             <div class="thumbnail-item {{ 'active' if loop.first }}">
-              <img src="{{ image_url }}" 
+              <img src="{{ image_url|cl_url(200,200,'thumb') }}"
                    alt="{{ product.name }} - Imagen {{ loop.index }}"
                    class="thumbnail-image"
                    onclick="changeMainImage(this.src)">

--- a/crunevo/templates/store/store.html
+++ b/crunevo/templates/store/store.html
@@ -204,11 +204,11 @@
                data-popular="{{ 'true' if product.is_popular else 'false' }}"
                data-new="{{ 'true' if product.is_new else 'false' }}">
             
-            <div class="product-image-container">
-              <img src="{{ product.first_image or url_for('static', filename='img/default_product.png') }}" 
-                   alt="{{ product.name }}" 
-                   class="product-image"
-                   loading="lazy">
+              <div class="product-image-container">
+                <img src="{{ (product.first_image|cl_url(400,300,'fill')) if product.first_image else url_for('static', filename='img/default_product.png') }}"
+                     alt="{{ product.name }}"
+                     class="product-image"
+                     loading="lazy">
 
               <!-- Product Badges -->
               <div class="product-badges">

--- a/crunevo/templates/store/view_product.html
+++ b/crunevo/templates/store/view_product.html
@@ -34,8 +34,8 @@
       <!-- Product Images -->
       <div class="product-images">
         <div class="main-image-container">
-          <img src="{{ product.first_image or url_for('static', filename='img/default_product.png') }}" 
-               alt="{{ product.name }}" 
+          <img src="{{ (product.first_image|cl_url(800,600,'fill')) if product.first_image else url_for('static', filename='img/default_product.png') }}"
+               alt="{{ product.name }}"
                class="main-image"
                id="mainImage">
 
@@ -68,8 +68,8 @@
         {% if product.image_urls and product.image_urls|length > 1 %}
         <div class="thumbnail-gallery">
           {% for image_url in product.image_urls %}
-          <img src="{{ image_url }}" 
-               alt="{{ product.name }}" 
+          <img src="{{ image_url|cl_url(200,200,'thumb') }}"
+               alt="{{ product.name }}"
                class="thumbnail {{ 'active' if loop.first else '' }}"
                onclick="changeMainImage('{{ image_url }}')">
           {% endfor %}

--- a/crunevo/utils/image_optimizer.py
+++ b/crunevo/utils/image_optimizer.py
@@ -3,6 +3,31 @@ from PIL import Image
 import io
 import cloudinary.uploader
 
+
+def optimize_url(
+    url: str, width: int | None = None, height: int | None = None, crop: str = "fill"
+) -> str:
+    """Return an optimized Cloudinary URL using f_auto, q_auto and size."""
+    if not url or "res.cloudinary.com" not in url:
+        return url
+
+    try:
+        base, rest = url.split("/upload/", 1)
+    except ValueError:
+        return url
+
+    parts = ["f_auto", "q_auto"]
+    if width:
+        parts.append(f"w_{width}")
+    if height:
+        parts.append(f"h_{height}")
+    if crop:
+        parts.append(f"c_{crop}")
+
+    transform = ",".join(parts)
+    return f"{base}/upload/{transform}/{rest}"
+
+
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Summary
- add `optimize_url` helper for Cloudinary URLs
- register `cl_url` jinja filter
- use `cl_url` for avatars, galleries and store images
- document change in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687a62dd06c88325bd38918877bf73fd