### PR TITLE
Fix notes filter grid in feed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -794,3 +794,5 @@
 - Fixed comment null errors and share modal duplicates, styled inactive feed buttons, improved note-card layout with flexbox and added optimistic save (PR feed-bugfixes-ui).
 - Scoped comment event delegation to #feedContainer to avoid modal conflicts (PR comment-events-scope).
 - Fixed comment rendering in gallery modal: API now returns avatar and JS uses valid selector for modal inputs (PR gallery-modal-comment-fix).
+- Filtro "Apuntes" en /feed muestra tarjetas en cuadrícula añadiendo la clase
+  `feed-as-grid` y estilos grid en CSS (PR feed-notes-grid).

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -1540,3 +1540,10 @@ select:focus {
   opacity: 1;
   pointer-events: auto;
 }
+
+/* Grid layout for notes */
+.feed-as-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1rem;
+}

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -809,6 +809,11 @@ class ModernFeedManager {
 
     const container = document.getElementById('feedContainer');
     if (!container) return;
+    if (filter === "apuntes") {
+      container.classList.add("feed-as-grid");
+    } else {
+      container.classList.remove("feed-as-grid");
+    }
 
     if (filter === this.currentFilter && this.currentPage > 1) return;
     const filterChanged = filter !== this.currentFilter;
@@ -844,6 +849,9 @@ class ModernFeedManager {
       // Reinitialize interactions
       this.initPostInteractions();
       this.initCommentSystem();
+      if (typeof initPdfPreviews !== "undefined") {
+        initPdfPreviews();
+      }
 
       this.showToast(`Filtro "${filter}" aplicado`, 'info');
     } catch (error) {


### PR DESCRIPTION
## Summary
- show grid layout for notes when selecting the "Apuntes" filter
- add CSS class `.feed-as-grid` for responsive gallery
- document feature in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687d8d1bb74c8325aa170f7959d3298b