### PR TITLE
Fix note card styling in feed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -796,3 +796,5 @@
 - Fixed comment rendering in gallery modal: API now returns avatar and JS uses valid selector for modal inputs (PR gallery-modal-comment-fix).
 - Filtro "Apuntes" en /feed muestra tarjetas en cuadrícula añadiendo la clase
   `feed-as-grid` y estilos grid en CSS (PR feed-notes-grid).
+- notes.css ahora se carga globalmente desde base.html para mantener el diseño
+  de note-card consistente en el feed (PR feed-note-card-css).

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -54,6 +54,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/modern-components.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/feed.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/notes.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/photo-modal.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/personal-space.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/carrera.css') }}">


### PR DESCRIPTION
## Summary
- include `notes.css` globally from `base.html` so note cards keep the correct layout
- document the change in AGENTS guidelines

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687d9805ccb0832586ec2b94c8176260