### PR TITLE
Centralize note-card styles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -798,3 +798,4 @@
   `feed-as-grid` y estilos grid en CSS (PR feed-notes-grid).
 - notes.css ahora se carga globalmente desde base.html para mantener el diseño
   de note-card consistente en el feed (PR feed-note-card-css).
+- Estilos de note-card unificados en notes.css y eliminados de carrera.css; selectores fortalecidos con prefijo .note-card. (PR note-card-centralize)

--- a/crunevo/static/css/carrera.css
+++ b/crunevo/static/css/carrera.css
@@ -96,23 +96,6 @@
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.12);
 }
 
-/* Note Card */
-.note-card {
-  border: none;
-  border-radius: 12px;
-  overflow: hidden;
-  transition: all 0.3s ease;
-}
-
-.note-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.1);
-}
-
-.note-card .card-header {
-  background: linear-gradient(135deg, #EFF6FF 0%, #F0FDF4 100%);
-  border-bottom: 1px solid #E2E8F0;
-}
 
 /* Course Card */
 .course-card {

--- a/crunevo/static/css/notes.css
+++ b/crunevo/static/css/notes.css
@@ -1,17 +1,11 @@
-.note-title {
-  font-size: 0.95rem;
-  font-weight: 600;
-  margin-bottom: 0.25rem;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
 
 .note-card {
-  border: none;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
   display: flex;
   flex-direction: column;
+  border: none;
+  border-radius: 12px;
+  overflow: hidden;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .note-card .card-body {
@@ -30,61 +24,62 @@
   border-left: 3px solid #6c63ff;
 }
 
-.note-preview {
+.note-card .note-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.note-card .note-preview {
   position: relative;
   height: 180px;
   overflow: hidden;
   background-color: var(--bs-light-bg-subtle, #f8f9fa);
 }
-
-.note-preview img,
-.note-preview canvas {
+.note-card .note-preview img,
+.note-card .note-preview canvas {
   width: 100%;
   height: 100%;
   object-fit: cover;
   display: block;
 }
-
-.note-preview .loading-shimmer {
+.note-card .note-preview .loading-shimmer {
   position: absolute;
   inset: 0;
 }
-
-.note-author {
+.note-card .note-author {
   display: flex;
   align-items: center;
   gap: 0.25rem;
   font-size: 0.8rem;
   margin-bottom: 0.25rem;
 }
-
-.note-author img {
+.note-card .note-author img {
   width: 24px;
   height: 24px;
   border-radius: 50%;
   object-fit: cover;
 }
-
-.note-tags {
+.note-card .note-tags {
   margin-top: 0.25rem;
 }
-
-.note-tags .badge {
+.note-card .note-tags .badge {
   margin-right: 0.25rem;
 }
-
-.note-stats {
+.note-card .note-stats {
   display: flex;
   justify-content: space-between;
   font-size: 0.8rem;
 }
-
-.note-actions {
+.note-card .note-actions {
   margin-top: auto;
 }
 
 @media (max-width: 575.98px) {
-  .note-title {
+  .note-card .note-title {
     font-size: 0.85rem;
   }
 }


### PR DESCRIPTION
## Summary
- consolidate note-card CSS in `notes.css`
- drop old note-card styling from `carrera.css`
- record the move in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687dbe93c7788325a0b894d87338a682