### PR TITLE
Fix note preview rendering after dynamic load

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -799,3 +799,4 @@
 - notes.css ahora se carga globalmente desde base.html para mantener el diseño
   de note-card consistente en el feed (PR feed-note-card-css).
 - Estilos de note-card unificados en notes.css y eliminados de carrera.css; selectores fortalecidos con prefijo .note-card. (PR note-card-centralize)
+- Vistas previas de notas ahora se inicializan con `initNotePreviews`, llamado tras cargar contenido dinámico en el feed y otras páginas. (PR note-preview-reinit)

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -849,8 +849,8 @@ class ModernFeedManager {
       // Reinitialize interactions
       this.initPostInteractions();
       this.initCommentSystem();
-      if (typeof initPdfPreviews !== "undefined") {
-        initPdfPreviews();
+      if (typeof initNotePreviews !== "undefined") {
+        initNotePreviews();
       }
 
       this.showToast(`Filtro "${filter}" aplicado`, 'info');
@@ -928,6 +928,9 @@ class ModernFeedManager {
           container.appendChild(el);
         }
       });
+      if (typeof initNotePreviews !== "undefined") {
+        initNotePreviews();
+      }
 
     } catch (error) {
       console.error('Error loading more posts:', error);

--- a/crunevo/templates/feed/user_notes.html
+++ b/crunevo/templates/feed/user_notes.html
@@ -38,7 +38,7 @@
 <script src="{{ url_for('static', filename='pdfjs/pdf.min.js') }}"></script>
 <script>
   pdfjsLib.GlobalWorkerOptions.workerSrc = "{{ url_for('static', filename='pdfjs/pdf.worker.min.js') }}";
-  initPdfPreviews();
+  initNotePreviews();
 </script>
 {% endblock %}
 

--- a/crunevo/templates/notes/list.html
+++ b/crunevo/templates/notes/list.html
@@ -49,7 +49,7 @@ document.getElementById('noteSearch').addEventListener('input', function(e){
       data.forEach(n => {
         list.appendChild(createNoteCard(n));
       });
-      initPdfPreviews();
+      initNotePreviews();
     });
 });
 
@@ -125,6 +125,6 @@ function createNoteCard(n) {
 <script src="{{ url_for('static', filename='js/viewer.js') }}"></script>
 <script>
   pdfjsLib.GlobalWorkerOptions.workerSrc = "{{ url_for('static', filename='pdfjs/pdf.worker.min.js') }}";
-  initPdfPreviews();
+  initNotePreviews();
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- ensure note previews initialize lazily via `initNotePreviews`
- call `initNotePreviews` on feed updates and in notes templates
- document change in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687dc3e460408325b12f43fc0e78f14b