### PR TITLE
Fix marketplace filters toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -800,3 +800,4 @@
   de note-card consistente en el feed (PR feed-note-card-css).
 - Estilos de note-card unificados en notes.css y eliminados de carrera.css; selectores fortalecidos con prefijo .note-card. (PR note-card-centralize)
 - Vistas previas de notas ahora se inicializan con `initNotePreviews`, llamado tras cargar contenido dinámico en el feed y otras páginas. (PR note-preview-reinit)
+- Toggle filters sidebar via filter-toggle-btn and CSS transform (PR marketplace-filters-fix).

--- a/crunevo/static/css/store.css
+++ b/crunevo/static/css/store.css
@@ -135,10 +135,21 @@
   top: 2rem;
   max-height: calc(100vh - 4rem);
   overflow-y: auto;
+  transform: translateX(0);
+  transition: transform 0.3s ease-in-out;
+}
+
+
+#filter-sidebar {
+  transition: transform 0.3s ease-in-out;
+}
+
+body.filter-sidebar-is-open #filter-sidebar {
+  transform: translateX(0);
 }
 
 .store-sidebar.collapsed {
-  display: none;
+  transform: translateX(-100%);
 }
 
 .filters-container {
@@ -1108,6 +1119,11 @@
   visibility: visible;
 }
 
+body.filter-sidebar-is-open #sidebar-overlay {
+  opacity: 1;
+  visibility: visible;
+}
+
 .offcanvas-filters {
   position: fixed;
   top: 0;
@@ -1429,14 +1445,14 @@
   border: 0;
 }
 
-#toggleSidebarBtn i {
+#filter-toggle-btn i {
   transition: transform 0.3s ease;
 }
 
-#toggleSidebarBtn.sidebar-open .label-text {
+#filter-toggle-btn.sidebar-open .label-text {
   display: none;
 }
 
-#toggleSidebarBtn.sidebar-open i.rotating {
+#filter-toggle-btn.sidebar-open i.rotating {
   transform: rotate(90deg);
 }

--- a/crunevo/static/js/store.js
+++ b/crunevo/static/js/store.js
@@ -117,9 +117,16 @@ class CrunevoStore {
             });
         }
 
-        const sidebarToggle = document.getElementById('toggleSidebarBtn');
+        const sidebarToggle = document.getElementById('filter-toggle-btn');
         if (sidebarToggle) {
             sidebarToggle.addEventListener('click', () => {
+                this.toggleSidebar();
+            });
+        }
+
+        const sidebarOverlay = document.getElementById('sidebar-overlay');
+        if (sidebarOverlay) {
+            sidebarOverlay.addEventListener('click', () => {
                 this.toggleSidebar();
             });
         }
@@ -624,10 +631,10 @@ class CrunevoStore {
     }
 
     toggleSidebar() {
-        const sidebar = document.querySelector('.store-sidebar');
+        const sidebar = document.getElementById('filter-sidebar') || document.querySelector('.store-sidebar');
         const layout = document.querySelector('.store-layout');
-        const btn = document.getElementById('toggleSidebarBtn');
-        const overlay = document.getElementById('sidebarOverlay');
+        const btn = document.getElementById('filter-toggle-btn');
+        const overlay = document.getElementById('sidebar-overlay');
 
         if (sidebar && layout && btn) {
             const willOpen = sidebar.classList.contains('collapsed');
@@ -638,6 +645,8 @@ class CrunevoStore {
             btn.classList.toggle('sidebar-open', willOpen);
             const icon = btn.querySelector('i');
             icon?.classList.toggle('rotating');
+
+            document.body.classList.toggle('filter-sidebar-is-open', willOpen);
         }
     }
 

--- a/crunevo/templates/store/store.html
+++ b/crunevo/templates/store/store.html
@@ -16,7 +16,7 @@
     <div class="store-header d-flex flex-column flex-lg-row align-items-start align-items-lg-center justify-content-between ms-3 mt-3 gap-2">
       <div class="d-flex align-items-center gap-2">
         <h2 class="mb-3 mb-lg-0">Marketplace</h2>
-        <button type="button" id="toggleSidebarBtn" onclick="toggleSidebar()" class="btn btn-light d-none d-lg-inline-flex align-items-center">
+        <button type="button" id="filter-toggle-btn" onclick="toggleSidebar()" class="btn btn-light d-none d-lg-inline-flex align-items-center">
           <i class="bi bi-sliders"></i>
           <span class="label-text ms-1">Filtros</span>
         </button>
@@ -31,7 +31,7 @@
     </div>
     <div class="store-layout sidebar-collapsed">
       <!-- Sidebar Filters -->
-      <aside class="store-sidebar collapsed">
+      <aside id="filter-sidebar" class="store-sidebar collapsed">
         <div class="filters-container">
           <div class="filters-header">
             <h3 class="filters-title">🔍 Filtros</h3>
@@ -406,7 +406,7 @@
       <span class="cart-badge" id="floatingCartCount">0</span>
     </a>
   </div>
-  <div class="sidebar-overlay" id="sidebarOverlay" onclick="toggleSidebar()" role="button" tabindex="0"></div>
+  <div class="sidebar-overlay" id="sidebar-overlay" onclick="toggleSidebar()" role="button" tabindex="0"></div>
 </div>
 
 


### PR DESCRIPTION
## Summary
- let users open the store filters sidebar using `filter-toggle-btn`
- show/hide sidebar by adding `filter-sidebar-is-open` class and CSS transform
- sync overlay visibility with the sidebar
- document change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687dc7be843483258bea83b211831319