### PR TITLE
Fix gunicorn startup with sync worker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -804,3 +804,4 @@
 - Marketplace sidebar now fixed-position with overlay; button toggles body class for smooth slide (PR marketplace-sidebar-bugfix).
 - Refactored post modal layout with fixed header and footer so comment input stays visible and comments scroll separately (PR post-modal-layout-fix).
 - Updated fly.toml with http_service health check grace period and performance VM to avoid startup 503 errors (PR fly-health-vm).
+- Reverted Gunicorn to synchronous worker for reliable startup (PR gunicorn-sync-worker).

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,5 @@ COPY migrations/versions /app/migrations/versions
 # Run gunicorn using the FLASK_APP environment variable. Default to the
 # public instance if FLASK_APP is not set (e.g. during local builds).
 # Ejecuta la app usando el valor de FLASK_APP o usa wsgi:app por defecto
-# Use eventlet worker for WebSocket support
-CMD ["sh", "-c", "exec gunicorn --timeout 120 -k eventlet -b 0.0.0.0:8080 ${FLASK_APP:-crunevo.wsgi:app}"]
+# Run a single synchronous worker for stability
+CMD ["sh", "-c", "exec gunicorn --timeout 120 --workers 1 -b 0.0.0.0:8080 ${FLASK_APP:-crunevo.wsgi:app}"]


### PR DESCRIPTION
## Summary
- run gunicorn with a single synchronous worker
- document the change

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68804c9a49f083259cbed259d9914853