### PR TITLE
Fix instance dir initialization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -806,3 +806,4 @@
 - Updated fly.toml with http_service health check grace period and performance VM to avoid startup 503 errors (PR fly-health-vm).
 - Reverted Gunicorn to synchronous worker for reliable startup (PR gunicorn-sync-worker).
 - Simplified fly.toml and Dockerfile to use a single gunicorn command with 3 workers and no services block (PR fly-config-cleanup).
+- os.makedirs("instance") now uses exist_ok=True to avoid startup error (PR db-instance-exist-ok).

--- a/crunevo/utils/db_init.py
+++ b/crunevo/utils/db_init.py
@@ -26,7 +26,7 @@ def ensure_database_ready():
     """Ensure database is ready and has all required tables."""
     try:
         if not os.path.exists("instance"):
-            os.makedirs("instance")
+            os.makedirs("instance", exist_ok=True)
         init_database()
         return True
     except Exception as e:


### PR DESCRIPTION
## Summary
- ensure the app can start when `instance` directory exists by using `exist_ok=True`
- document the change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688065a3c00c8325bde00675493e7652