### PR TITLE
Ensure Fly keeps one machine active

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -807,3 +807,4 @@
 - Reverted Gunicorn to synchronous worker for reliable startup (PR gunicorn-sync-worker).
 - Simplified fly.toml and Dockerfile to use a single gunicorn command with 3 workers and no services block (PR fly-config-cleanup).
 - os.makedirs("instance") now uses exist_ok=True to avoid startup error (PR db-instance-exist-ok).
+- min_machines_running set to 1 in fly.toml to keep one machine running (PR fly-autostop-fix).

--- a/fly.toml
+++ b/fly.toml
@@ -21,7 +21,7 @@ primary_region = 'bog'
   force_https = true
   auto_stop_machines = true
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
 
   [[http_service.checks]]
     grace_period = '15s'


### PR DESCRIPTION
## Summary
- configure Fly to maintain at least one machine running
- log this change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68806981067c832597dbbe64c6dfdf00