### PR TITLE
Improve health check with DB query

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -810,3 +810,4 @@
 - min_machines_running set to 1 in fly.toml to keep one machine running (PR fly-autostop-fix).
 - Added dedicated /healthz endpoint returning 'ok' and updated fly.toml health check path (PR healthz-endpoint).
 - Modernized notes list with purple filter buttons, Bootstrap icons and DOMContentLoaded wrappers for initNotePreviews (PR notes-ui-refresh).
+- Improved healthz endpoint to validate DB connection and increased timeout to 15s (PR health-check-db-timeout).

--- a/crunevo/routes/health_routes.py
+++ b/crunevo/routes/health_routes.py
@@ -1,5 +1,7 @@
-from flask import Blueprint
-from crunevo.extensions import talisman
+from flask import Blueprint, current_app
+from sqlalchemy import text
+
+from crunevo.extensions import db, talisman
 
 health_bp = Blueprint("health", __name__)
 
@@ -7,7 +9,12 @@ health_bp = Blueprint("health", __name__)
 @health_bp.route("/healthz")
 @talisman(force_https=False)
 def healthz():
-    return "ok"
+    try:
+        db.session.execute(text("SELECT 1"))
+        return "ok", 200
+    except Exception:
+        current_app.logger.exception("Health check failed")
+        return "error", 500
 
 
 @health_bp.route("/ping")

--- a/fly.toml
+++ b/fly.toml
@@ -27,7 +27,7 @@ primary_region = 'gru'
     grace_period = '15s'
     interval = '15s'
     method = 'GET'
-    timeout = '5s'
+    timeout = '15s'
     path = "/healthz"
 
 [[vm]]


### PR DESCRIPTION
## Summary
- include DB status in healthz endpoint
- extend Fly health check timeout to 15s
- document change in AGENTS guidance

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68818e45e6888325ab341dedbff0cb2c