### PR TITLE
Fix health check DB query

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -810,3 +810,4 @@
 - min_machines_running set to 1 in fly.toml to keep one machine running (PR fly-autostop-fix).
 - Added dedicated /healthz endpoint returning 'ok' and updated fly.toml health check path (PR healthz-endpoint).
 - Modernized notes list with purple filter buttons, Bootstrap icons and DOMContentLoaded wrappers for initNotePreviews (PR notes-ui-refresh).
+- Health check waits longer and verifies DB connection; timeout increased to 15s and /healthz checks database (PR healthz-db-check).

--- a/crunevo/routes/health_routes.py
+++ b/crunevo/routes/health_routes.py
@@ -1,5 +1,6 @@
-from flask import Blueprint
-from crunevo.extensions import talisman
+from flask import Blueprint, current_app
+from sqlalchemy import text
+from crunevo.extensions import talisman, db
 
 health_bp = Blueprint("health", __name__)
 
@@ -7,7 +8,12 @@ health_bp = Blueprint("health", __name__)
 @health_bp.route("/healthz")
 @talisman(force_https=False)
 def healthz():
-    return "ok"
+    try:
+        db.session.execute(text("SELECT 1"))
+        return "ok", 200
+    except Exception as e:  # pragma: no cover - avoid failing tests on DB down
+        current_app.logger.error(f"Health check failed: {e}")
+        return "error", 500
 
 
 @health_bp.route("/ping")

--- a/fly.toml
+++ b/fly.toml
@@ -27,7 +27,7 @@ primary_region = 'gru'
     grace_period = '15s'
     interval = '15s'
     method = 'GET'
-    timeout = '5s'
+    timeout = '15s'
     path = "/healthz"
 
 [[vm]]


### PR DESCRIPTION
## Summary
- probe DB in health check and log failures
- allow more time for Fly.io health check
- record update in AGENTS instructions

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68818e45e6888325ab341dedbff0cb2c