### PR TITLE
Implement long press reactions UX

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -819,3 +819,4 @@
 - Adopted Option 2: eventlet worker with healthz and min_machines_running improvements (PR eventlet-option2)
 - Removed dynamic share option overlay and related CSS; share buttons now use built-in navigator.share only (PR share-options-remove).
 - Fase 2: reconstruido botón Me Gusta con conteo estable, handleLike actualiza solo el contador y color activo igual a Guardar.
+- Fase 3: panel de reacciones con long press flotante, scroll horizontal y contador clickeable.

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -349,6 +349,14 @@
   min-width: 20px;
 }
 
+/* Reaction panel */
+.reaction-panel {
+  overflow-x: auto;
+  white-space: nowrap;
+  max-width: 300px;
+  flex-wrap: nowrap;
+}
+
 /* Comments section */
 .comments-section {
   border-top: 1px solid var(--border-color);

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -353,22 +353,6 @@ class ModernFeedManager {
       }
     });
 
-    // Hover to show reactions
-    document.addEventListener('mouseenter', (e) => {
-      if (e.target.matches('.like-btn')) {
-        const btn = e.target;
-        btn._hoverTimer = setTimeout(() => {
-          this.showReactionPanel(btn);
-        }, 300);
-      }
-    }, true);
-
-    document.addEventListener('mouseleave', (e) => {
-      if (e.target.matches('.like-btn')) {
-        clearTimeout(e.target._hoverTimer);
-      }
-    }, true);
-
     // Long press for mobile/desktop
     document.addEventListener('touchstart', (e) => {
       const btn = e.target.closest('.like-btn');
@@ -421,6 +405,14 @@ class ModernFeedManager {
       if (e.target.matches('.save-btn') || e.target.closest('.save-btn')) {
         const btn = e.target.closest('.save-btn');
         this.handleSave(btn);
+      }
+    });
+
+    // Click on reactions count
+    document.addEventListener('click', (e) => {
+      const target = e.target.closest('.post-reactions-count');
+      if (target) {
+        console.log('TODO: Abrir modal para ver quién reaccionó');
       }
     });
   }


### PR DESCRIPTION
## Summary
- stop showing reactions on hover
- add horizontal scrolling reaction panel
- log message when clicking on reaction count
- note task history in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6881cef2019883258e54eba66498df80