### PR TITLE
Fix reading_time parsing for note upload

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -821,3 +821,4 @@
 - Fase 2: reconstruido botón Me Gusta con conteo estable, handleLike actualiza solo el contador y color activo igual a Guardar.
 - Fase 3: panel de reacciones con long press flotante, scroll horizontal y contador clickeable.
 - Added csrf macro import in store/_product_cards.html to fix UndefinedError in search_products (hotfix product-cards-csrf).
+- Fixed note upload failing with invalid integer when "reading_time" empty; route now parses it to int when provided (PR notes-reading-time-int).

--- a/crunevo/routes/notes_routes.py
+++ b/crunevo/routes/notes_routes.py
@@ -298,6 +298,9 @@ def upload_note():
             if suggested:
                 category = suggested[0]
 
+        rt_val = request.form.get("reading_time", "").strip()
+        rt = int(rt_val) if rt_val else None
+
         note = Note(
             title=title,
             description=description,
@@ -307,7 +310,7 @@ def upload_note():
             tags=request.form.get("tags"),
             category=category,
             language=request.form.get("language"),
-            reading_time=request.form.get("reading_time"),
+            reading_time=rt,
             content_type=request.form.get("content_type"),
             summary=request.form.get("summary"),
             course=request.form.get("course"),


### PR DESCRIPTION
## Summary
- handle empty `reading_time` when uploading notes
- document change in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6881deb7204c832593ee50d0e47b6c5e