### PR TITLE
Fix notes filters active color

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -822,3 +822,4 @@
 - Fase 3: panel de reacciones con long press flotante, scroll horizontal y contador clickeable.
 - Added csrf macro import in store/_product_cards.html to fix UndefinedError in search_products (hotfix product-cards-csrf).
 - Fixed note upload failing with invalid integer when "reading_time" empty; route now parses it to int when provided (PR notes-reading-time-int).
+- Fixed notes filter buttons active color to white via .notes-filters .btn-outline-primary.active rule (PR notes-filters-contrast-fix).

--- a/crunevo/static/css/notes.css
+++ b/crunevo/static/css/notes.css
@@ -97,6 +97,13 @@
   border-color: var(--primary);
 }
 
+/* Ensure outline variant keeps good contrast when active */
+.notes-filters .btn-outline-primary.active {
+  color: #fff !important;
+  background-color: var(--primary) !important;
+  border-color: var(--primary) !important;
+}
+
 .notes-filters .btn:not(.active):hover {
   color: #fff;
   background-color: var(--primary);


### PR DESCRIPTION
## Summary
- improve notes filter button contrast by overriding .btn-outline-primary.active
- document fix in AGENTS log

## Testing
- `make fmt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881e5052f288325b494cc908cae5685