### PR TITLE
Fix like button icon persistence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -823,3 +823,4 @@
 - Added csrf macro import in store/_product_cards.html to fix UndefinedError in search_products (hotfix product-cards-csrf).
 - Fixed note upload failing with invalid integer when "reading_time" empty; route now parses it to int when provided (PR notes-reading-time-int).
 - Fixed notes filter buttons active color to white via .notes-filters .btn-outline-primary.active rule (PR notes-filters-contrast-fix).
+- Fixed like button icon disappearing; consistent structure with count in post card and modals, safe JS updates and global search check (PR like-button-fix).

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -425,7 +425,6 @@ class ModernFeedManager {
     if (btn.disabled) return;
 
     const icon = btn.querySelector('i');
-    const text = btn.querySelector('.action-text');
     const countSpan = btn.querySelector('.action-count');
 
     try {

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -330,7 +330,7 @@ function initGlobalSearch() {
   const noResults = document.getElementById('noResults');
   const suggestions = document.getElementById('searchSuggestions');
 
-  if (!searchInput || !searchResults) return;
+  if (!searchInput || !searchResults || !suggestions) return;
 
   let searchTimeout;
   let currentFilter = 'all';

--- a/crunevo/templates/components/comment_modal.html
+++ b/crunevo/templates/components/comment_modal.html
@@ -44,6 +44,7 @@
                       data-reaction="{{ user_reactions.get(post.id, '🔥') }}">
                 <i class="bi bi-fire{{ '-fill' if user_reactions.get(post.id) else '' }}"></i>
                 <span class="action-text">Me gusta</span>
+                <span class="action-count">{{ reaction_counts.get(post.id, {}).get('🔥', '') }}</span>
               </button>
               <div class="reaction-panel absolute bottom-full left-1/2 -translate-x-1/2 mb-2 flex flex-wrap gap-1 p-1 rounded-full shadow-lg bg-white dark:bg-zinc-800 d-none">
                 <button class="reaction-btn" data-reaction="🔥" title="Crunazo">🔥</button>

--- a/crunevo/templates/components/post_card.html
+++ b/crunevo/templates/components/post_card.html
@@ -150,7 +150,7 @@
       <button class="fb-action-btn like-btn {{ 'active' if user_reactions.get(post.id) }}"
               data-post-id="{{ post.id }}"
               data-reaction="{{ user_reactions.get(post.id, '🔥') }}">
-        <i class="bi bi-fire"></i>
+        <i class="bi bi-fire{{ '-fill' if user_reactions.get(post.id) else '' }}"></i>
         <span class="action-text">Me gusta</span>
         <span class="action-count">{{ reaction_counts.get(post.id, {}).get('🔥', '') }}</span>
       </button>

--- a/crunevo/templates/feed/_post_modal.html
+++ b/crunevo/templates/feed/_post_modal.html
@@ -54,6 +54,7 @@
                 data-reaction="{{ user_reaction or '🔥' }}">
           <i class="bi bi-fire{{ '-fill' if user_reaction else '' }}"></i>
           <span class="action-text">Me gusta</span>
+          <span class="action-count">{{ reaction_counts.get('🔥', '') }}</span>
         </button>
         <div class="reaction-panel absolute bottom-full left-1/2 -translate-x-1/2 mb-2 flex flex-wrap gap-1 p-1 rounded-full shadow-lg bg-white dark:bg-zinc-800 d-none">
           <button class="reaction-btn" data-reaction="🔥" title="Crunazo">🔥</button>


### PR DESCRIPTION
## Summary
- ensure like button keeps icon state in post card
- show reaction counts in comment and post modals
- clean up `handleLike` and guard global search initialization
- document changes in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68825e4648088325a65e54f863c8dffe