### PR TITLE
Fix like icon regression and safe listener

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -824,3 +824,4 @@
 - Fixed note upload failing with invalid integer when "reading_time" empty; route now parses it to int when provided (PR notes-reading-time-int).
 - Fixed notes filter buttons active color to white via .notes-filters .btn-outline-primary.active rule (PR notes-filters-contrast-fix).
 - Fixed like button icon disappearing; consistent structure with count in post card and modals, safe JS updates and global search check (PR like-button-fix).
+- Restored fire icon in like buttons and guarded legacy search click handler (PR like-icon-restore)

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -596,7 +596,8 @@ function initNavbarSearchLegacy() {
     });
 
     document.addEventListener('click', (e) => {
-      if (!globalSearch.contains(e.target) && !searchDropdown.contains(e.target)) {
+      const clickedDropdown = searchDropdown && searchDropdown.contains(e.target);
+      if (!globalSearch.contains(e.target) && !clickedDropdown) {
         hide();
       }
     });

--- a/crunevo/templates/components/comment_modal.html
+++ b/crunevo/templates/components/comment_modal.html
@@ -39,9 +39,7 @@
         <div class="modal-post-actions px-4 py-2 border-top border-bottom">
           <div class="d-flex justify-content-around">
             <div class="relative reaction-container" data-post-id="{{ post.id }}" data-my-reaction="{{ user_reactions.get(post.id, '') }}">
-              <button class="modal-action-btn like-btn {{ 'active' if user_reactions.get(post.id) }}"
-                      data-post-id="{{ post.id }}"
-                      data-reaction="{{ user_reactions.get(post.id, '🔥') }}">
+              <button class="modal-action-btn like-btn {{ 'active' if user_reactions.get(post.id) }}" data-post-id="{{ post.id }}">
                 <i class="bi bi-fire{{ '-fill' if user_reactions.get(post.id) else '' }}"></i>
                 <span class="action-text">Me gusta</span>
                 <span class="action-count">{{ reaction_counts.get(post.id, {}).get('🔥', '') }}</span>

--- a/crunevo/templates/components/post_card.html
+++ b/crunevo/templates/components/post_card.html
@@ -147,9 +147,7 @@
   <!-- Post Actions -->
   <div class="post-actions">
     <div class="relative reaction-container" data-post-id="{{ post.id }}" data-my-reaction="{{ user_reactions.get(post.id, '') }}">
-      <button class="fb-action-btn like-btn {{ 'active' if user_reactions.get(post.id) }}"
-              data-post-id="{{ post.id }}"
-              data-reaction="{{ user_reactions.get(post.id, '🔥') }}">
+      <button class="fb-action-btn like-btn {{ 'active' if user_reactions.get(post.id) }}" data-post-id="{{ post.id }}">
         <i class="bi bi-fire{{ '-fill' if user_reactions.get(post.id) else '' }}"></i>
         <span class="action-text">Me gusta</span>
         <span class="action-count">{{ reaction_counts.get(post.id, {}).get('🔥', '') }}</span>

--- a/crunevo/templates/feed/_post_modal.html
+++ b/crunevo/templates/feed/_post_modal.html
@@ -49,9 +49,7 @@
   <div class="modal-info-footer">
     <div class="modal-post-actions">
       <div class="relative reaction-container" data-post-id="{{ post.id }}" data-my-reaction="{{ user_reaction or '' }}">
-        <button class="modal-action-btn like-btn {{ 'active' if user_reaction else '' }}"
-                data-post-id="{{ post.id }}"
-                data-reaction="{{ user_reaction or '🔥' }}">
+        <button class="modal-action-btn like-btn {{ 'active' if user_reaction else '' }}" data-post-id="{{ post.id }}">
           <i class="bi bi-fire{{ '-fill' if user_reaction else '' }}"></i>
           <span class="action-text">Me gusta</span>
           <span class="action-count">{{ reaction_counts.get('🔥', '') }}</span>


### PR DESCRIPTION
## Summary
- restore fire icon structure in post card and modals
- guard navbar search click handler to avoid TypeError
- log changes in `AGENTS.md`

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6882641770588325a267f15dbf6c9839