### PR TITLE
Fix header menu init crash on feed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -826,3 +826,4 @@
 - Fixed like button icon disappearing; consistent structure with count in post card and modals, safe JS updates and global search check (PR like-button-fix).
 - Restored fire icon in like buttons and guarded legacy search click handler (PR like-icon-restore)
 - Consolidated DOMContentLoaded handlers from comment.js, forum_editor.js, enhanced-ui.js, store.js, league.js and feed.js into main.js; modules expose init functions (PR domcontent-modules-consolidation).
+- Guarded streak claim button event listener to prevent errors when element is missing (PR feed-missing-element-guard).

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -823,6 +823,11 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  const streakBtn = document.getElementById('claimStreakBtn');
+  if (streakBtn) {
+    streakBtn.addEventListener('click', claimStreak);
+  }
+
   if (typeof initFeedManager === 'function') {
     initFeedManager();
   }


### PR DESCRIPTION
## Summary
- protect streak claim button event binding from missing element
- document the fix in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6883d86930448325b6edd675b2b9c2ca