### PR TITLE
Add token-based API package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -830,3 +830,4 @@
 - Feed routes split into subpackage crunevo/routes/feed with views.py and api.py; feed_routes.py now re-exports for compatibility (PR feed-subpackage).
 - Guarded streak claim button event listener to prevent errors when element is missing (PR feed-missing-element-guard).
 - Guarded reaction button initialization to prevent TypeError on pages without .btn-reaction (PR feed-reaction-null-check).
+- Created api package with JWT-authenticated endpoints and updated README with usage instructions (PR feed-api-blueprint).

--- a/README.md
+++ b/README.md
@@ -229,3 +229,21 @@ Desde el commit `Load PDF.js locally`, CRUNEVO utiliza una versión local de PDF
 Ubicación:
 - `static/pdfjs/pdf.min.js`
 - `static/pdfjs/pdf.worker.min.js`
+
+
+## API Usage
+
+To access the JSON API you must first obtain a token:
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+     -d '{"username": "USER", "password": "PASS"}' \
+     http://localhost:5000/api/token
+```
+
+Use the returned token in the `Authorization` header to call endpoints:
+
+```bash
+curl -H "Authorization: Bearer <TOKEN>" \
+     http://localhost:5000/api/feed?page=1
+```

--- a/crunevo/api/__init__.py
+++ b/crunevo/api/__init__.py
@@ -1,0 +1,9 @@
+from .feed import feed_api_bp
+from .notes import notes_api_bp
+from .users import users_api_bp
+
+
+def init_api(app):
+    app.register_blueprint(feed_api_bp)
+    app.register_blueprint(notes_api_bp)
+    app.register_blueprint(users_api_bp)

--- a/crunevo/api/feed.py
+++ b/crunevo/api/feed.py
@@ -1,0 +1,22 @@
+from flask import Blueprint, jsonify, request
+
+from crunevo.models.post import Post
+from crunevo.utils.jwt_utils import jwt_required
+
+feed_api_bp = Blueprint("feed_api", __name__, url_prefix="/api")
+
+
+@feed_api_bp.route("/feed")
+@jwt_required
+def get_feed():
+    """Return paginated posts as JSON."""
+    page = int(request.args.get("page", 1))
+    per_page = 10
+    pagination = Post.query.order_by(Post.created_at.desc()).paginate(
+        page=page, per_page=per_page, error_out=False
+    )
+    posts = [
+        {"id": p.id, "content": p.content, "created_at": p.created_at.isoformat()}
+        for p in pagination.items
+    ]
+    return jsonify({"page": page, "total": pagination.total, "posts": posts})

--- a/crunevo/api/notes.py
+++ b/crunevo/api/notes.py
@@ -1,0 +1,21 @@
+from flask import Blueprint, jsonify, request
+
+from crunevo.models.note import Note
+from crunevo.utils.jwt_utils import jwt_required
+
+notes_api_bp = Blueprint("notes_api", __name__, url_prefix="/api")
+
+
+@notes_api_bp.route("/notes")
+@jwt_required
+def list_notes():
+    page = int(request.args.get("page", 1))
+    per_page = 10
+    pagination = Note.query.order_by(Note.created_at.desc()).paginate(
+        page=page, per_page=per_page, error_out=False
+    )
+    notes = [
+        {"id": n.id, "title": n.title, "created_at": n.created_at.isoformat()}
+        for n in pagination.items
+    ]
+    return jsonify({"page": page, "total": pagination.total, "notes": notes})

--- a/crunevo/api/users.py
+++ b/crunevo/api/users.py
@@ -1,0 +1,26 @@
+from flask import Blueprint, jsonify, request, g
+
+from crunevo.models.user import User
+from crunevo.utils.jwt_utils import generate_token, jwt_required
+
+users_api_bp = Blueprint("users_api", __name__, url_prefix="/api")
+
+
+@users_api_bp.route("/token", methods=["POST"])
+def issue_token():
+    data = request.get_json() or {}
+    username = data.get("username")
+    password = data.get("password", "")
+    if not username or not password:
+        return jsonify({"error": "Missing credentials"}), 400
+    user = User.query.filter_by(username=username).first()
+    if not user or not user.check_password(password):
+        return jsonify({"error": "Invalid credentials"}), 401
+    return jsonify({"token": generate_token(user)})
+
+
+@users_api_bp.route("/user")
+@jwt_required
+def current_user_info():
+    user = g.current_user
+    return jsonify({"id": user.id, "username": user.username})

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -331,7 +331,10 @@ def create_app():
     from .routes.main_routes import main_bp
     from .routes.story_routes import stories_bp
     from .routes.developer_routes import developer_bp
+    from .routes.backpack_routes import backpack_bp
     from .routes.personal_space_routes import personal_space_bp
+
+    from .api import init_api as init_api_blueprints
 
     is_admin = os.environ.get("ADMIN_INSTANCE") == "1"
     app.config["ADMIN_INSTANCE"] = is_admin
@@ -463,10 +466,10 @@ def create_app():
         app.register_blueprint(dashboard_bp)
         app.register_blueprint(settings_bp)
         app.register_blueprint(personal_space_bp)
+        init_api_blueprints(app)
 
         from .routes.carrera_routes import carrera_bp
         from .routes.league_routes import league_bp
-        from .routes.backpack_routes import backpack_bp
         from .routes.challenges_routes import challenges_bp
         from .routes.hall_routes import hall_bp
         from .routes.poll_routes import poll_bp

--- a/crunevo/utils/jwt_utils.py
+++ b/crunevo/utils/jwt_utils.py
@@ -1,0 +1,41 @@
+from datetime import datetime, timedelta
+from functools import wraps
+
+import jwt
+from flask import current_app, request, jsonify, g
+
+from crunevo.models.user import User
+
+
+def generate_token(user, expires_in: int = 3600) -> str:
+    payload = {
+        "user_id": user.id,
+        "exp": datetime.utcnow() + timedelta(seconds=expires_in),
+    }
+    return jwt.encode(payload, current_app.config["SECRET_KEY"], algorithm="HS256")
+
+
+def jwt_required(f):
+    """Simple JWT auth decorator."""
+
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        auth = request.headers.get("Authorization", "")
+        if not auth.startswith("Bearer "):
+            return jsonify({"error": "Missing token"}), 401
+        token = auth.split(" ", 1)[1]
+        try:
+            payload = jwt.decode(
+                token,
+                current_app.config["SECRET_KEY"],
+                algorithms=["HS256"],
+            )
+        except jwt.PyJWTError:
+            return jsonify({"error": "Invalid token"}), 401
+        user = User.query.get(payload.get("user_id"))
+        if not user:
+            return jsonify({"error": "Invalid token"}), 401
+        g.current_user = user
+        return f(*args, **kwargs)
+
+    return wrapper

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,3 +43,4 @@ sentry-sdk==2.32.0
 Authlib==1.2.1
 bleach==6.1.0
 flask
+PyJWT==2.8.0


### PR DESCRIPTION
## Summary
- implement `/api` package with blueprints for feed, notes and users
- provide `/api/feed` endpoint with JWT auth
- add helper for generating and verifying JWT tokens
- document API usage in README
- log this work in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6883df3b75dc832592b9690c9387580d