### PR TITLE
Secure session cookie defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -835,3 +835,4 @@
 - FeedPage under `frontend/app/feed/page.tsx` consumes `/api/feed` using `fetch`.
 - Build the SPA separately with `docker build -t crunevo-frontend -f frontend/Dockerfile frontend`.
 - Deploy frontend and backend containers independently; the SPA communicates with the Flask API via HTTP.
+- Session cookies default to `SESSION_COOKIE_SECURE=True` and `SESSION_COOKIE_SAMESITE='Lax'` in `config.py`. Production sets `SESSION_COOKIE_HTTPONLY=true` in `fly.toml` and `fly-admin.toml` (PR session-cookie-security).

--- a/crunevo/config.py
+++ b/crunevo/config.py
@@ -11,6 +11,10 @@ class Config:
 
     DEBUG = os.getenv("FLASK_DEBUG", "0").lower() in ("1", "true", "yes")
 
+    # Secure session cookies in all environments
+    SESSION_COOKIE_SECURE = True
+    SESSION_COOKIE_SAMESITE = "Lax"
+
     SQLALCHEMY_DATABASE_URI = os.getenv("DATABASE_URL", "sqlite:///data.db").replace(
         "postgres://", "postgresql://"
     )

--- a/fly-admin.toml
+++ b/fly-admin.toml
@@ -13,6 +13,7 @@ primary_region = "bog"
   ADMIN_INSTANCE = "1"
   MAINTENANCE_MODE = "0"
   PORT = "8080"
+  SESSION_COOKIE_HTTPONLY = "true"
 
 [experimental]
   auto_rollback = true

--- a/fly.toml
+++ b/fly.toml
@@ -12,6 +12,7 @@ primary_region = 'gru'
   FLASK_APP = 'crunevo.wsgi:app'
   FLASK_ENV = 'production'
   PORT = "8080"
+  SESSION_COOKIE_HTTPONLY = "true"
 
 [experimental]
   auto_rollback = true


### PR DESCRIPTION
## Summary
- secure session cookies by default
- set SESSION_COOKIE_HTTPONLY in production configs
- record cookie defaults in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68841bcadcc48325a9c55186f04cd9e7