### PR TITLE
Add Dependabot and CI workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run tests
+        run: make test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
 - All `<form method="post">` must import `components/csrf.html` and call
   `csrf_field()` immediately after the `<form>` tag.
 - Nunca hacer CREATE TYPE sin comprobar si el tipo ya existe; usa IF NOT EXISTS o checkfirst=True.
+- Dependabot PRs should only be merged after CI passes (`make test`) and prefer squash merges.
 - Se corrigió la barra de navegación fija añadiendo padding global y mejorando el menú móvil (PR navbar fixes).
 - Se ajustó el padding global mediante CSS en el body y se agregó z-index al navbar para evitar que tape el contenido.
 - Se mejoró el cierre del menú móvil y se fijó la altura del navbar (PR navbar fixes 2).
@@ -836,3 +837,4 @@
 - Build the SPA separately with `docker build -t crunevo-frontend -f frontend/Dockerfile frontend`.
 - Deploy frontend and backend containers independently; the SPA communicates with the Flask API via HTTP.
 - Session cookies default to `SESSION_COOKIE_SECURE=True` and `SESSION_COOKIE_SAMESITE='Lax'` in `config.py`. Production sets `SESSION_COOKIE_HTTPONLY=true` in `fly.toml` and `fly-admin.toml` (PR session-cookie-security).
+- Enabled Dependabot weekly updates for pip packages and added CI workflow running 'make test' on PRs (PR dependabot-ci).


### PR DESCRIPTION
## Summary
- configure Dependabot for pip packages
- add CI workflow running `make test`
- document automation PR policy in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68841f509ed88325961a33bc655ce3ca