### PR TITLE
Require SECRET_KEY env var

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -839,3 +839,5 @@
 - Session cookies default to `SESSION_COOKIE_SECURE=True` and `SESSION_COOKIE_SAMESITE='Lax'` in `config.py`. Production sets `SESSION_COOKIE_HTTPONLY=true` in `fly.toml` and `fly-admin.toml` (PR session-cookie-security).
 - Enabled Dependabot weekly updates for pip packages and added CI workflow running 'make test' on PRs (PR dependabot-ci).
 - CI workflow runs 'make fmt' and 'make test' on every push (PR workflow-fmt-test).
+- SECRET_KEY now required from environment; config warns in debug and errors in
+  production (PR secret-key-env).

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ database hosted on Fly.io:
 ```bash
 fly postgres create ...           # crea cluster
 fly postgres attach ...           # genera DATABASE_URL
-fly secrets set SECRET_KEY=...    # etc.
+fly secrets set SECRET_KEY=...    # requerido, la app falla sin esta variable
 ```
 
 When connecting from another Fly app, use the internal hostname
@@ -210,6 +210,8 @@ pre-commit install
 ## Configuración
 
 La clave CSRF (`FLASK_WTF_SECRET_KEY`) suele ser la misma que `SECRET_KEY`.
+Debes definir `SECRET_KEY` como variable de entorno. No existe valor por
+defecto y el servidor se detendrá si falta en producción.
 La variable `ENABLE_CSRF` está siempre activa en producción y no deberías deshabilitarla.
 En producción la protección CSRF está siempre habilitada.
 

--- a/crunevo/config.py
+++ b/crunevo/config.py
@@ -7,9 +7,19 @@ load_dotenv()
 
 
 class Config:
-    SECRET_KEY = os.getenv("SECRET_KEY", "devkey")
-
     DEBUG = os.getenv("FLASK_DEBUG", "0").lower() in ("1", "true", "yes")
+
+    SECRET_KEY = os.getenv("SECRET_KEY")
+    if not SECRET_KEY:
+        if DEBUG:
+            SECRET_KEY = "devkey"
+            logging.getLogger(__name__).warning(
+                "SECRET_KEY not set; using insecure default in debug mode"
+            )
+        else:
+            raise RuntimeError(
+                "SECRET_KEY environment variable is required in production"
+            )
 
     # Secure session cookies in all environments
     SESSION_COOKIE_SECURE = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,8 @@
+# ruff: noqa: E402
 import os
+
+os.environ.setdefault("SECRET_KEY", "test-secret")
+
 import sys
 import pytest
 


### PR DESCRIPTION
## Summary
- ensure `SECRET_KEY` only comes from environment and fail without it in production
- document env requirement in README
- set test SECRET_KEY via conftest
- note change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68842d655b088325b22a3a33fa27b720