### PR TITLE
Improve comment error handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -846,3 +846,4 @@
 - Comment modal logic consolidated into feed.js; comment.js reduced to a stub and main.js initializes the unified code (PR comment-module-unify).
 - Added reactions list modal with /feed/api/reactions/<post_id> endpoint and JS handler (PR reactions-list-modal).
 - Comment and photo modals now include ARIA labelling and keyboard focus for improved accessibility (PR modals-aria-accessibility).
+- Comment submission now inspects fetch errors and shows friendly messages; buttons re-enable on failure (PR comment-error-messages).

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -244,3 +244,14 @@ def test_comments_api_pagination(client, db_session, test_user):
     assert resp2.status_code == 200
     assert len(resp1.get_json()) == 10
     assert len(resp2.get_json()) == 5
+
+
+def test_comment_disabled_returns_403(client, db_session, test_user, another_user):
+    post = Post(content="x", author=test_user, comment_permission="none")
+    db_session.add(post)
+    db_session.commit()
+
+    login(client, another_user.username, "secret")
+    resp = client.post(f"/feed/comment/{post.id}", data={"body": "hello"})
+    assert resp.status_code == 403
+    assert resp.get_json()["error"] == "Comentarios deshabilitados"


### PR DESCRIPTION
## Summary
- show server error messages when comment fetch fails in feed.js
- re-enable buttons consistently
- add regression test for comment disabled
- document changes in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688442176fb48325baeaf719aba309fb