### PR TITLE
Update templates to use csrf macro

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -847,3 +847,4 @@
 - Added reactions list modal with /feed/api/reactions/<post_id> endpoint and JS handler (PR reactions-list-modal).
 - Comment and photo modals now include ARIA labelling and keyboard focus for improved accessibility (PR modals-aria-accessibility).
 - Comment submission now inspects fetch errors and shows friendly messages; buttons re-enable on failure (PR comment-error-messages).
+- Replaced manual CSRF inputs with `csrf_field()` and imported csrf macro in comment and post modals (PR csrf-template-fix).

--- a/crunevo/templates/components/comment_modal.html
+++ b/crunevo/templates/components/comment_modal.html
@@ -1,4 +1,5 @@
 {% import 'components/image_gallery.html' as gallery %}
+{% import 'components/csrf.html' as csrf %}
 {% set saved_posts = saved_posts if saved_posts is defined else {} %}
 <!-- Modal de Comentarios con Galería Completa -->
 <div class="modal fade" id="commentsModal-{{ post.id }}" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="commentsModalLabel-{{ post.id }}" aria-hidden="true">
@@ -106,7 +107,8 @@
           <!-- Formulario para Agregar Comentario -->
           <div class="add-comment-form mt-3">
             <form class="comment-form d-flex align-items-center" data-post-id="{{ post.id }}" onsubmit="submitModalComment(event, '{{ post.id }}')">
-              <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" 
+              {{ csrf.csrf_field() }}
+              <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}"
                    alt="{{ current_user.username }}"
                    class="rounded-circle me-2" 
                    style="width: 32px; height: 32px; object-fit: cover;">
@@ -123,7 +125,6 @@
                   <i class="bi bi-send-fill"></i>
                 </button>
               </div>
-              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             </form>
           </div>
         </div>

--- a/crunevo/templates/feed/_post_modal.html
+++ b/crunevo/templates/feed/_post_modal.html
@@ -1,4 +1,5 @@
 
+{% import 'components/csrf.html' as csrf %}
 {% set saved_posts = saved_posts if saved_posts is defined else {} %}
 
 <div class="modal-post-container">
@@ -104,6 +105,7 @@
       {% if current_user.is_authenticated %}
       <form class="comment-form d-flex align-items-center" data-post-id="{{ post.id }}"
             onsubmit="submitModalComment(event, '{{ post.id }}')">
+        {{ csrf.csrf_field() }}
         <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}"
              alt="{{ current_user.username }}"
              class="rounded-circle me-2" style="width:32px;height:32px;object-fit:cover;">
@@ -113,7 +115,6 @@
             <i class="bi bi-send-fill"></i>
           </button>
         </div>
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       </form>
       {% else %}
       <p class="text-center"><a href="{{ url_for('auth.login') }}" class="btn btn-primary">Inicia sesi&oacute;n para comentar</a></p>


### PR DESCRIPTION
## Summary
- import `components/csrf.html` in comment_modal and feed post modal
- replace manual CSRF inputs with `csrf_field()`
- document update in AGENTS guidelines

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68844510b484832580dcf139a52786b1