### PR TITLE
Fix fire icon visibility on like

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -851,3 +851,4 @@
 - Release command sets random SECRET_KEY to avoid missing env error (PR release-secret-fix).
 - Added comment deletion endpoint `/feed/comment/delete/<id>` with author/moderator authorization (PR comment-delete-endpoint).
 - Consolidated openCommentsModal, submitModalComment and addCommentToModalUI into comment.js; feed.js references them and main.js calls initCommentModals once (PR comment-modal-refactor).
+- Defined .bi-fire-fill in fix-bootstrap.css to keep the fire icon visible when liking posts (PR like-fire-icon-fix)

--- a/crunevo/static/css/fix-bootstrap.css
+++ b/crunevo/static/css/fix-bootstrap.css
@@ -6,3 +6,5 @@
   --bs-body-bg: #121212;
   --bs-body-color: #f8f9fa;
 }
+
+.bi-fire-fill::before { content: "\f7f6"; }


### PR DESCRIPTION
## Summary
- define `.bi-fire-fill` in fix-bootstrap.css so Bootstrap Icons can display a filled fire
- document the update in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68846c0983688325a19d613608d2072c