### PR TITLE
Update profile header button

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -853,3 +853,4 @@
 - Consolidated openCommentsModal, submitModalComment and addCommentToModalUI into comment.js; feed.js references them and main.js calls initCommentModals once (PR comment-modal-refactor).
 - Defined .bi-fire-fill in fix-bootstrap.css to keep the fire icon visible when liking posts (PR like-fire-icon-fix)
 - Perfil público ahora reutiliza el banner y el formulario de publicaciones; enlaces de perfil en navbar, sidebar y navegación móvil usan profile_by_username (PR public-profile-banner-modal).
+- Replaced "Editar perfil" button with "Detalles personales" fixed inside the profile header and ensured achievements section spacing and mobile grid (PR profile-details-btn).

--- a/crunevo/static/css/perfil.css
+++ b/crunevo/static/css/perfil.css
@@ -100,7 +100,8 @@
   margin-top: 4px;
 }
 
-.achievements-section {
+.achievements-section,
+.logros-section {
   margin-bottom: 2rem;
 }
 
@@ -108,6 +109,12 @@
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 1rem;
+}
+
+@media (max-width: 768px) {
+  .achievements-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
 @media (min-width: 768px) {

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -37,7 +37,7 @@
   {% endif %}
 </div>
         </div>
-        <div class="card-body p-4" style="margin-top: -60px;">
+        <div class="card-body position-relative p-4" style="margin-top: -60px;">
 
           <div class="row align-items-center">
             <div class="col-auto">
@@ -84,16 +84,20 @@
               {% if is_own_profile %}
               <div class="col-auto">
                 <div class="btn-group-vertical">
-                  <button class="btn btn-primary btn-sm">
-                    <i class="bi bi-pencil"></i> Editar Perfil
-                </button>
-                <button class="btn btn-outline-primary btn-sm">
-                  <i class="bi bi-eye"></i> Ver como Público
-                </button>
-              </div>
+                  <button class="btn btn-outline-primary btn-sm">
+                    <i class="bi bi-eye"></i> Ver como Público
+                  </button>
+                </div>
             </div>
             {% endif %}
           </div>
+
+          {% if current_user.id == user.id %}
+          <a href="{{ url_for('settings.index') }}#personal"
+             class="btn btn-primary btn-sm shadow-sm position-absolute end-0 bottom-0 m-3">
+            <i class="bi bi-person-lines-fill"></i> Detalles personales
+          </a>
+          {% endif %}
 
           <!-- Mobile profile info -->
           <div class="d-lg-none mt-3">


### PR DESCRIPTION
## Summary
- adjust profile header layout to position a new personal details button
- tweak achievement grid spacing and responsiveness
- log the change in AGENTS guidelines

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6884773092b883258d1c169ab446bdbd