### PR TITLE
Fix profile details button visibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -854,3 +854,4 @@
 - Defined .bi-fire-fill in fix-bootstrap.css to keep the fire icon visible when liking posts (PR like-fire-icon-fix)
 - Perfil público ahora reutiliza el banner y el formulario de publicaciones; enlaces de perfil en navbar, sidebar y navegación móvil usan profile_by_username (PR public-profile-banner-modal).
 - Replaced "Editar perfil" button with "Detalles personales" fixed inside the profile header and ensured achievements section spacing and mobile grid (PR profile-details-btn).
+- Reemplazado botón "Editar perfil" por "Detalles personales" solo visible en el perfil propio; ajustada redirección a /perfil en lugar de configuración (PR perfil-detalles-fix).

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -92,13 +92,6 @@
             {% endif %}
           </div>
 
-          {% if current_user.id == user.id %}
-          <a href="{{ url_for('settings.index') }}#personal"
-             class="btn btn-primary btn-sm shadow-sm position-absolute end-0 bottom-0 m-3">
-            <i class="bi bi-person-lines-fill"></i> Detalles personales
-          </a>
-          {% endif %}
-
           <!-- Mobile profile info -->
           <div class="d-lg-none mt-3">
             <div class="d-flex justify-content-start align-items-center mb-2 px-3">

--- a/crunevo/templates/perfil_publico.html
+++ b/crunevo/templates/perfil_publico.html
@@ -23,7 +23,7 @@
         {% endif %}
       </div>
     </div>
-    <div class="card-body p-4" style="margin-top: -60px;">
+    <div class="card-body position-relative p-4" style="margin-top: -60px;">
       <div class="row align-items-center">
         <div class="col-auto">
           <div class="profile-avatar-container text-center position-relative" style="margin-top: -60px;">
@@ -58,6 +58,11 @@
           </div>
         </div>
       </div>
+      {% if current_user.is_authenticated and current_user.id == user.id %}
+      <a href="{{ url_for('auth.perfil') }}" class="btn btn-outline-primary btn-sm shadow-sm position-absolute end-0 bottom-0 m-3">
+        <i class="bi bi-person-lines-fill"></i> Detalles personales
+      </a>
+      {% endif %}
 
       <!-- Mobile profile info -->
       <div class="d-lg-none mt-3">
@@ -82,10 +87,6 @@
     </div>
   </div>
 
-  {% if current_user.is_authenticated and current_user.id == user.id %}
-  <div class="text-end mb-4">
-    <a href="{{ url_for('auth.perfil') }}" class="btn btn-outline-primary btn-sm">Editar perfil</a>
-  </div>
   {% elif current_user.is_authenticated %}
   <div class="text-center mb-4">
     <form method="post" action="{{ url_for('auth.agradecer', user_id=user.id) }}" class="d-inline">


### PR DESCRIPTION
## Summary
- remove details button from personal profile page
- show a "Detalles personales" button on public profile only when viewing own profile
- document change in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68847ff9bbf08325953bb81f01fd0d0c