### PR TITLE
Add admin error log viewer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -856,3 +856,4 @@
 - Replaced "Editar perfil" button with "Detalles personales" fixed inside the profile header and ensured achievements section spacing and mobile grid (PR profile-details-btn).
 - Reemplazado botón "Editar perfil" por "Detalles personales" solo visible en el perfil propio; ajustada redirección a /perfil en lugar de configuración (PR perfil-detalles-fix).
 - Fixed Jinja if/else in perfil_publico.html to avoid TemplateSyntaxError and show actions for other users (hotfix perfil-conditional-fix).
+- Se implementó sistema de errores para admins en /admin/errores. Captura automática, vista filtrable y botón de resolución.

--- a/crunevo/models/__init__.py
+++ b/crunevo/models/__init__.py
@@ -60,5 +60,7 @@ from .hall_1000 import RaffleParticipant  # noqa: F401
 from .print_request import PrintRequest  # noqa: F401
 from .api_key import APIKey  # noqa: F401
 
+from .system_error_log import SystemErrorLog  # noqa: F401
+
 from .internship import Internship, InternshipApplication  # noqa: F401
 from .product_request import ProductRequest  # noqa: F401

--- a/crunevo/models/system_error_log.py
+++ b/crunevo/models/system_error_log.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+from crunevo.extensions import db
+
+
+class SystemErrorLog(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    ruta = db.Column(db.String(255))
+    mensaje = db.Column(db.Text)
+    status_code = db.Column(db.Integer)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
+    resuelto = db.Column(db.Boolean, default=False)
+
+    user = db.relationship("User")

--- a/crunevo/templates/admin/dashboard.html
+++ b/crunevo/templates/admin/dashboard.html
@@ -127,6 +127,24 @@
     </div>
   </div>
 
+  <div class="row g-4 mb-4">
+    <div class="col-md-6 col-xl-4">
+      <div class="card bg-gradient-danger text-white h-100 border-0 rounded-4">
+        <div class="card-body d-flex justify-content-between align-items-center">
+          <div>
+            <div class="text-white-75 small fw-bold">Errores recientes</div>
+            <div class="display-6 fw-bold">{{ unresolved_errors }}</div>
+            <div class="small">sin resolver</div>
+          </div>
+          <i class="bi bi-bug-fill display-4 text-white-50"></i>
+        </div>
+        <a href="{{ url_for('admin.ver_errores') }}" class="card-footer bg-white bg-opacity-10 d-flex align-items-center justify-content-between text-white text-decoration-none">
+          Ver errores <i class="bi bi-arrow-right"></i>
+        </a>
+      </div>
+    </div>
+  </div>
+
   <!-- Charts and Analytics -->
   <div class="row g-4 mb-4">
     <div class="col-xl-8">

--- a/crunevo/templates/admin/errores.html
+++ b/crunevo/templates/admin/errores.html
@@ -1,0 +1,59 @@
+{% extends 'admin/base_admin.html' %}
+{% from 'components/csrf.html' import csrf_field %}
+{% block admin_content %}
+<h2 class="page-title mb-4">Errores de sistema</h2>
+<form class="row g-3 mb-3" method="get">
+  <div class="col-md-4">
+    <input type="text" class="form-control" name="ruta" placeholder="Ruta" value="{{ filtro_ruta }}">
+  </div>
+  <div class="col-md-3">
+    <input type="number" class="form-control" name="user" placeholder="ID usuario" value="{{ filtro_user or '' }}">
+  </div>
+  <div class="col-md-3">
+    <select class="form-select" name="estado">
+      <option value="" {% if not filtro_estado %}selected{% endif %}>Todos</option>
+      <option value="pendiente" {% if filtro_estado=='pendiente' %}selected{% endif %}>Pendiente</option>
+      <option value="resuelto" {% if filtro_estado=='resuelto' %}selected{% endif %}>Resuelto</option>
+    </select>
+  </div>
+  <div class="col-md-2">
+    <button class="btn btn-primary w-100" type="submit">Filtrar</button>
+  </div>
+</form>
+<div class="card shadow-sm">
+  <div class="card-body p-0">
+    <div class="table-responsive">
+      <table class="table table-vcenter card-table" data-datatable>
+        <thead>
+          <tr>
+            <th>ID</th><th>Ruta</th><th>Mensaje</th><th>Código</th><th>Usuario</th><th>Fecha</th><th></th>
+          </tr>
+        </thead>
+        <tbody>
+        {% for err in errores %}
+        <tr class="{% if not err.resuelto %}table-danger{% endif %}">
+          <td>{{ err.id }}</td>
+          <td class="text-truncate" style="max-width:150px">{{ err.ruta }}</td>
+          <td class="text-truncate" style="max-width:250px">{{ err.mensaje[:120] }}</td>
+          <td>{{ err.status_code }}</td>
+          <td>{{ err.user_id or '-' }}</td>
+          <td>{{ err.timestamp.strftime('%Y-%m-%d %H:%M') }}</td>
+          <td>
+            {% if not err.resuelto %}
+            <form method="post" action="{{ url_for('admin.resolver_error', error_id=err.id) }}" class="d-inline">
+              {{ csrf_field() }}
+              <button class="btn btn-sm btn-success" data-bs-toggle="tooltip" title="Marcar resuelto">
+                <i class="ti ti-check"></i>
+              </button>
+            </form>
+            {% else %}<span class="badge bg-success">Resuelto</span>{% endif %}
+          </td>
+        </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+<script>document.addEventListener('DOMContentLoaded', initDataTables);</script>
+{% endblock %}

--- a/crunevo/templates/admin/partials/sidebar.html
+++ b/crunevo/templates/admin/partials/sidebar.html
@@ -57,5 +57,9 @@
   <a class="nav-link disabled"><i class="ti ti-calendar-event me-2"></i> Eventos</a>
 
   <span class="text-muted fw-bold small mt-4 mb-2">⚙️ Sistema</span>
+  <a class="nav-link {% if request.endpoint == 'admin.ver_errores' %}active{% endif %}" href="{{ url_for('admin.ver_errores') }}">
+    <i class="ti ti-bug me-2"></i> Errores
+    {% if UNRESOLVED_ERRORS %}<span class="badge bg-danger ms-1">{{ UNRESOLVED_ERRORS }}</span>{% endif %}
+  </a>
   <a class="nav-link disabled"><i class="ti ti-settings me-2"></i> Configuración</a>
 </div>

--- a/migrations/versions/add_system_error_log.py
+++ b/migrations/versions/add_system_error_log.py
@@ -1,0 +1,43 @@
+"""create system error log table
+
+Revision ID: add_system_error_log
+Revises: user_block_attachment
+Create Date: 2025-07-30 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "add_system_error_log"
+down_revision = "add_block_model"
+branch_labels = None
+depends_on = None
+
+
+def has_table(name: str, conn) -> bool:
+    inspector = sa.inspect(conn)
+    return name in inspector.get_table_names()
+
+
+def upgrade():
+    conn = op.get_bind()
+    if not has_table("system_error_log", conn):
+        op.create_table(
+            "system_error_log",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("timestamp", sa.DateTime(), nullable=True),
+            sa.Column("ruta", sa.String(length=255), nullable=True),
+            sa.Column("mensaje", sa.Text(), nullable=True),
+            sa.Column("status_code", sa.Integer(), nullable=True),
+            sa.Column("user_id", sa.Integer(), sa.ForeignKey("user.id"), nullable=True),
+            sa.Column(
+                "resuelto", sa.Boolean(), nullable=True, server_default=sa.text("false")
+            ),
+            if_not_exists=True,
+        )
+
+
+def downgrade():
+    op.drop_table("system_error_log", if_exists=True)

--- a/tests/test_error_logs.py
+++ b/tests/test_error_logs.py
@@ -1,0 +1,28 @@
+from crunevo.models import User, SystemErrorLog
+
+
+def test_error_logging_and_resolve(client, db_session):
+    admin = User(
+        username="adm",
+        email="adm@example.com",
+        role="admin",
+        activated=True,
+        avatar_url="a",
+    )
+    admin.set_password("pass")
+    db_session.add(admin)
+    db_session.commit()
+
+    @client.application.route("/boom")
+    def boom():
+        raise RuntimeError("boom")
+
+    resp = client.get("/boom")
+    assert resp.status_code == 500
+    log = SystemErrorLog.query.first()
+    assert log and log.ruta == "/boom"
+
+    client.post("/login", data={"username": "adm", "password": "pass"})
+    resp = client.post(f"/admin/errores/{log.id}/resolver")
+    assert resp.status_code == 302
+    assert SystemErrorLog.query.get(log.id).resuelto is True


### PR DESCRIPTION
## Summary
- log HTTP exceptions in `SystemErrorLog`
- expose error count via context processor
- add `/admin/errores` route with filter and resolve button
- show unresolved error badge in sidebar and dashboard
- include migration and tests

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68852a8c7a148325ac1a5f5df7e5e2fa