### PR TITLE
Fix loadMorePosts end detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -857,3 +857,4 @@
 - Reemplazado botón "Editar perfil" por "Detalles personales" solo visible en el perfil propio; ajustada redirección a /perfil en lugar de configuración (PR perfil-detalles-fix).
 - Fixed Jinja if/else in perfil_publico.html to avoid TemplateSyntaxError and show actions for other users (hotfix perfil-conditional-fix).
 - Se implementó sistema de errores para admins en /admin/errores. Captura automática, vista filtrable y botón de resolución.
+- Detecta 'no-more-posts' en feed.js para detener el infinite scroll y ocultar el loader (PR feed-load-end).

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -1040,14 +1040,20 @@ class ModernFeedManager {
       const temp = document.createElement('div');
       temp.innerHTML = data;
 
-      if (data.trim() === '') {
+      if (data.trim() === '' || data.includes('no-more-posts')) {
         console.log('No more posts to load');
-        loader?.querySelector('.spinner-border')?.classList.add('d-none');
+        if (loader) {
+          loader.style.display = 'none';
+        }
         if (!this.reachedEnd) {
           this.infiniteObserver?.unobserve(document.getElementById('feedEnd'));
         }
         this.reachedEnd = true;
-        container.insertAdjacentHTML('beforeend', '<div class="text-center text-muted">No se encontraron más publicaciones.</div>');
+        if (data.trim()) {
+          container.insertAdjacentHTML('beforeend', data);
+        } else {
+          container.insertAdjacentHTML('beforeend', '<div class="text-center text-muted">No se encontraron más publicaciones.</div>');
+        }
         return;
       }
 


### PR DESCRIPTION
## Summary
- handle `no-more-posts` string returned by `/feed/load`
- stop observing `#feedEnd`, hide loader and set `reachedEnd`
- note change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68853eed9c6c8325b340ff2c4b4eddc2