### PR TITLE
Remove leftover global comment modal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -860,3 +860,4 @@
 - Detecta 'no-more-posts' en feed.js para detener el infinite scroll y ocultar el loader (PR feed-load-end).
 - loadFilteredFeed muestra mensaje si data.html está vacío sin limpiar el contenedor y reinicia reachedEnd/currentPage (hotfix quickfeed-empty)
 - loadMorePosts y loadFilteredFeed ahora ocultan el loader y muestran un alert si ocurre un error; registran el status HTTP y respuesta para depuración (PR feed-error-handling).
+- Removed unused global comment modal in feed.html; each post modal now uniquely references commentsModal-<post.id> (PR comment-modal-id-cleanup).

--- a/crunevo/templates/feed/feed.html
+++ b/crunevo/templates/feed/feed.html
@@ -113,20 +113,6 @@
   </div>
 </div>
 
-<!-- Comment Modal -->
-<div class="modal fade" id="commentModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered modal-lg">
-    <div class="modal-content border-0 rounded-4">
-      <div class="modal-header border-0 pb-0">
-        <h5 class="modal-title">💬 Comentarios</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
-      </div>
-      <div id="commentModalBody" class="modal-body p-0">
-        <!-- Post detail will load here -->
-      </div>
-    </div>
-  </div>
-</div>
 
 <!-- Edit Post Modal -->
 <div class="modal fade" id="editPostModal" tabindex="-1" aria-hidden="true">


### PR DESCRIPTION
## Summary
- drop obsolete global `#commentModal` from feed template
- document modal-id cleanup in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68854388732083258cea2e1670d22da0