### PR TITLE
Fix notifications reload

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -861,3 +861,4 @@
 - loadFilteredFeed muestra mensaje si data.html está vacío sin limpiar el contenedor y reinicia reachedEnd/currentPage (hotfix quickfeed-empty)
 - loadMorePosts y loadFilteredFeed ahora ocultan el loader y muestran un alert si ocurre un error; registran el status HTTP y respuesta para depuración (PR feed-error-handling).
 - Removed unused global comment modal in feed.html; each post modal now uniquely references commentsModal-<post.id> (PR comment-modal-id-cleanup).
+- Improved notifications dropdown reload: shows error toast when request fails, keeps previous entries when empty with message 'No hay notificaciones nuevas' and refreshes only if tab visible (PR notifications-error-toast).

--- a/crunevo/static/js/notifications.js
+++ b/crunevo/static/js/notifications.js
@@ -21,6 +21,11 @@ class NotificationManager {
             this.renderNotifications(data.notifications);
         } catch (error) {
             console.error('Error loading notifications:', error);
+            if (window.CRUNEVO_UI && window.CRUNEVO_UI.showErrorToast) {
+                window.CRUNEVO_UI.showErrorToast('Error al cargar notificaciones');
+            } else if (typeof showToast === 'function') {
+                showToast('Error al cargar notificaciones');
+            }
         }
     }
 
@@ -34,8 +39,19 @@ class NotificationManager {
     renderNotifications(notifications) {
         if (!this.container) return;
         
+        // Remove previous "no new" message if present
+        const noNew = this.container.querySelector('.no-new-notifs');
+        if (noNew) noNew.remove();
+
         if (notifications.length === 0) {
-            this.container.innerHTML = '<div class="text-center text-muted p-3">No hay notificaciones</div>';
+            if (this.container.querySelectorAll('.notification-item').length === 0) {
+                this.container.innerHTML = '<div class="text-center text-muted p-3">No hay notificaciones</div>';
+            } else {
+                const msg = document.createElement('div');
+                msg.className = 'text-center text-muted p-3 no-new-notifs';
+                msg.textContent = 'No hay notificaciones nuevas';
+                this.container.appendChild(msg);
+            }
             return;
         }
 
@@ -70,7 +86,11 @@ class NotificationManager {
     }
 
     setupAutoRefresh() {
-        setInterval(() => this.loadNotifications(), 30000); // Cada 30 segundos
+        setInterval(() => {
+            if (!document.hidden) {
+                this.loadNotifications();
+            }
+        }, 30000); // Cada 30 segundos si la pestaña está activa
     }
 }
 


### PR DESCRIPTION
## Summary
- show a toast on notification load failure
- keep existing notifications when there are none and show a message
- avoid reloading notifications when the tab isn't visible
- document changes in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688545e2a8f08325bae6b3256ea2266d