### PR TITLE
Add debug logs for feed and notifications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -865,3 +865,4 @@
 - Updated notifications.js to query #notificationsDropdown and #notifications-list; replaced .notification-container selector (PR notifications-dropdown-selector).
 - Removed legacy initNotifications from main.js; dropdown updates now rely on initNotificationManager (PR remove-initNotifications).
 - loadFilteredFeed ahora verifica response.ok, registra errores y conserva el contenido previo en caso de fallo; solo actualiza el contenedor cuando data.html no está vacío (hotfix feed-filter-ok-check).
+- removeSkeletonPosts ahora registra los skeleton eliminados; loadFilteredFeed y loadMorePosts muestran el HTML recibido y solo limpian el contenedor si cambia el filtro. notifications.js registra conteos y si el dropdown se actualiza o se conserva (PR feed-notif-logging).

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -81,6 +81,7 @@ class ModernFeedManager {
 
   removeSkeletonPosts() {
     document.querySelectorAll('.post-skeleton').forEach(skeleton => {
+      console.log('[FEED] Removing skeleton post:', skeleton);
       skeleton.classList.add('fade-out');
       setTimeout(() => skeleton.remove(), 300);
     });
@@ -947,6 +948,10 @@ class ModernFeedManager {
     }
 
     const filterChanged = filter !== this.currentFilter;
+    if (filterChanged) {
+      console.log('[FEED] Clearing container for new filter:', filter);
+      container.innerHTML = '';
+    }
 
     try {
       this.currentFilter = filter;
@@ -970,15 +975,18 @@ class ModernFeedManager {
         throw new Error('Network response was not ok');
       }
       const data = JSON.parse(text);
+      console.log('[FEED] HTML received:', data.html);
 
       // Hide skeletons
       this.removeSkeletonPosts();
 
       // Update content only when HTML is not empty
       if (typeof data.html === 'string' && data.html.trim() !== '') {
-        if (this.currentPage === 1 || filterChanged) {
-          console.log('[FEED] Actualizando HTML del contenedor');
+        if (filterChanged) {
+          console.log('[FEED] Updating container with new filter');
           container.innerHTML = data.html;
+        } else {
+          console.log('[FEED] Filter unchanged - feed preserved');
         }
 
         // Reinitialize interactions
@@ -1056,6 +1064,7 @@ class ModernFeedManager {
       const data = await response.text();
       console.log('[DEBUG] HTTP status:', response.status);
       console.log('[DEBUG] Response text:', data);
+      console.log('[FEED] HTML received in loadMorePosts:', data);
       const container = document.getElementById('feedContainer');
       const temp = document.createElement('div');
       temp.innerHTML = data;

--- a/crunevo/static/js/notifications.js
+++ b/crunevo/static/js/notifications.js
@@ -17,8 +17,14 @@ class NotificationManager {
         try {
             const response = await fetch('/api/notifications');
             const data = await response.json();
+            const currentFirst = this.container?.querySelector('.notification-item')?.dataset.id;
+            const newFirst = data.notifications[0]?.id?.toString();
+            const updated = currentFirst !== newFirst;
+            console.log('[NOTIF] unread:', data.unread_count, 'total:', data.notifications.length, updated ? '- updating dropdown' : '- preserving dropdown');
             this.updateBadge(data.unread_count);
-            this.renderNotifications(data.notifications);
+            if (updated) {
+                this.renderNotifications(data.notifications);
+            }
         } catch (error) {
             console.error('Error loading notifications:', error);
             if (window.CRUNEVO_UI && window.CRUNEVO_UI.showErrorToast) {


### PR DESCRIPTION
## Summary
- log when skeleton posts are removed
- add debug logs for filter load and pagination HTML
- only clear feed when filter changes
- log notification counts and dropdown updates
- document changes in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6885587040e483259697bf506fb6b87b