### PR TITLE
Add diagnostic facebook post CSS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -869,3 +869,4 @@
 - removeSkeletonPosts and deletePost now log the selectors of elements before applying fade-out or removal. Actual posts use the 'facebook-post' class; '.post-skeleton' is only for loading placeholders.
 - Verified post_card.html renders articles with class 'facebook-post' only; no 'post-skeleton' or 'fade-out' classes found in templates or server logic.
 - Searched repo for any rules hiding '.facebook-post' elements; none found beyond normal styles. Confirmed removeSkeletonPosts() only selects '.post-skeleton'. Documented findings for future reference.
+- Added diagnostic CSS borders for `.facebook-post` at end of feed.css to visualize opacity and fade-out behaviors during testing.

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -1452,3 +1452,8 @@ select:focus {
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
   gap: 1rem;
 }
+
+.facebook-post { border: 1px solid green; }
+.facebook-post[style*="opacity"] { border: 2px solid red !important; }
+.facebook-post.fade-out { border: 2px dashed orange !important; }
+


### PR DESCRIPTION
## Summary
- add temporary diagnostic borders in `feed.css` to highlight facebook posts
- document CSS diagnostics in `AGENTS.md`

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6885abbb1ef08325beceab5006ce344a