### PR TITLE
Add feed fade-out instrumentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -870,3 +870,4 @@
 - Verified post_card.html renders articles with class 'facebook-post' only; no 'post-skeleton' or 'fade-out' classes found in templates or server logic.
 - Searched repo for any rules hiding '.facebook-post' elements; none found beyond normal styles. Confirmed removeSkeletonPosts() only selects '.post-skeleton'. Documented findings for future reference.
 - Added diagnostic CSS borders for `.facebook-post` at end of feed.css to visualize opacity and fade-out behaviors during testing.
+- Added console logs after applying fade-out to elements in feed.js for instrumentation (PR feed-fade-out-log).

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -84,6 +84,7 @@ class ModernFeedManager {
     document.querySelectorAll(selector).forEach(skeleton => {
       console.log('[FEED] removeSkeletonPosts selector', selector, 'element', skeleton);
       skeleton.classList.add('fade-out');
+      console.log('⚠️ fade-out aplicado a:', skeleton);
       setTimeout(() => skeleton.remove(), 300);
     });
   }
@@ -244,6 +245,7 @@ class ModernFeedManager {
       }
     } else {
       commentsSection.classList.add('fade-out');
+      console.log('⚠️ fade-out aplicado a:', commentsSection);
       setTimeout(() => {
         commentsSection.style.display = 'none';
         commentsSection.classList.remove('fade-out');
@@ -1204,6 +1206,7 @@ class ModernFeedManager {
     // Auto-remove after delay
     setTimeout(() => {
       toast.classList.add('fade-out');
+      console.log('⚠️ fade-out aplicado a:', toast);
       setTimeout(() => toast.remove(), 300);
     }, type === 'error' ? 5000 : 3000);
   }
@@ -1461,6 +1464,7 @@ function deletePost(postId) {
       if (postElement) {
         console.log('[FEED] deletePost selector', selector, 'element', postElement);
         postElement.classList.add('fade-out');
+        console.log('⚠️ fade-out aplicado a:', postElement);
         setTimeout(() => postElement.remove(), 300);
       }
       window.modernFeedManager?.showToast('Publicación eliminada', 'success');


### PR DESCRIPTION
## Summary
- log the element when adding fade-out animation in feed.js
- document instrumentation in AGENTS guidelines

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6885c0cc8310832597cadb36fe550ce2