### PR TITLE
Add debug logs for comments and toast

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -871,3 +871,4 @@
 - Searched repo for any rules hiding '.facebook-post' elements; none found beyond normal styles. Confirmed removeSkeletonPosts() only selects '.post-skeleton'. Documented findings for future reference.
 - Added diagnostic CSS borders for `.facebook-post` at end of feed.css to visualize opacity and fade-out behaviors during testing.
 - Inserted diagnostic borders after `.facebook-post` styles in feed.css to debug hidden posts.
+- toggleComments now logs the element being hidden before applying the `fade-out` class and showToast logs the toast element before fade-out for easier debugging.

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -243,6 +243,7 @@ class ModernFeedManager {
         setTimeout(() => commentInput.focus(), 100);
       }
     } else {
+      console.log('[FEED] toggleComments hide element', commentsSection);
       commentsSection.classList.add('fade-out');
       setTimeout(() => {
         commentsSection.style.display = 'none';
@@ -1203,6 +1204,7 @@ class ModernFeedManager {
 
     // Auto-remove after delay
     setTimeout(() => {
+      console.log('[FEED] showToast auto-remove', toast);
       toast.classList.add('fade-out');
       setTimeout(() => toast.remove(), 300);
     }, type === 'error' ? 5000 : 3000);


### PR DESCRIPTION
## Summary
- log comments section before fade-out in toggleComments
- log toast elements before fading out in showToast
- document new logs in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6885c2777400832592dddff1295ed5f2