### PR TITLE
Modern floating reactions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -879,3 +879,5 @@
 - Removed debugging borders and logs from feed.js; fade-in/out animations now use
   `forwards` fill mode and loader hides after successful load to fix invisible
   posts issue.
+- Updated reaction panel with floating overlay and modern emojis; adjusted templates and JS.
+- Restored CRUNEVO emojis in floating reaction panel; kept overlay JS improvements (PR modern-floating-reactions-fix).

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -99,7 +99,7 @@ function applyGalleryOrientation() {
 
 function showReactions(btn) {
   const container = btn.closest('.reaction-container');
-  const options = container.querySelector('.reaction-options');
+  const options = container.querySelector('.reaction-panel');
   if (!options) return;
   const current = container.dataset.myReaction;
   if (current) {
@@ -142,7 +142,7 @@ function initReactions() {
   document.querySelectorAll('.reaction-container').forEach((container) => {
     const mainBtn = container.querySelector('.btn-reaction');
     if (!mainBtn) return;
-    const options = container.querySelector('.reaction-options');
+    const options = container.querySelector('.reaction-panel');
     const span = container.querySelector('.count');
     const countsDiv = container.querySelector('.reaction-counts');
     const postId = container.dataset.postId;

--- a/crunevo/templates/components/reactions.html
+++ b/crunevo/templates/components/reactions.html
@@ -5,7 +5,7 @@
   <button class="btn btn-reaction">
     <span class="main-emoji">{{ main }}</span> <span class="count">{{ post.likes or 0 }}</span>
   </button>
-  <div class="reaction-options d-none position-absolute">
+  <div class="reaction-panel absolute bottom-full left-1/2 -translate-x-1/2 mb-2 flex flex-wrap gap-1 p-1 rounded-full shadow-lg bg-white dark:bg-zinc-800 d-none">
     <button class="reaction-btn" data-reaction="🔥" title="Crunazo">🔥</button>
     <button class="reaction-btn" data-reaction="🧠" title="Neuro">🧠</button>
     <button class="reaction-btn" data-reaction="💔" title="Roto">💔</button>
@@ -14,6 +14,10 @@
     <button class="reaction-btn" data-reaction="😂" title="Vacilón">😂</button>
     <button class="reaction-btn" data-reaction="🤡" title="Cringe">🤡</button>
     <button class="reaction-btn" data-reaction="😲" title="Asu">😲</button>
+    <button class="reaction-btn" data-reaction="👍" title="Me gusta">👍</button>
+    <button class="reaction-btn" data-reaction="💡" title="Interesante">💡</button>
+    <button class="reaction-btn" data-reaction="🙌" title="Gracias">🙌</button>
+    <button class="reaction-btn" data-reaction="📌" title="Lo guardé">📌</button>
   </div>
   {% if sorted_counts %}
   <div class="reaction-counts mt-1 small text-muted">

--- a/crunevo/templates/feed/_post_modal.html
+++ b/crunevo/templates/feed/_post_modal.html
@@ -94,7 +94,14 @@
     <div class="modal-stats">
       <div class="modal-stat-item">
         <i class="bi bi-fire-fill text-danger"></i>
-        <span>{{ reaction_counts.get('🔥', 0) + reaction_counts.get('❤️', 0) + reaction_counts.get('😂', 0) + reaction_counts.get('😮', 0) + reaction_counts.get('😢', 0) + reaction_counts.get('😡', 0) }} reacciones</span>
+        <span>{{
+          reaction_counts.get('🔥', 0) + reaction_counts.get('🧠', 0) +
+          reaction_counts.get('💔', 0) + reaction_counts.get('😠', 0) +
+          reaction_counts.get('🥶', 0) + reaction_counts.get('😂', 0) +
+          reaction_counts.get('🤡', 0) + reaction_counts.get('😲', 0) +
+          reaction_counts.get('👍', 0) + reaction_counts.get('💡', 0) +
+          reaction_counts.get('🙌', 0) + reaction_counts.get('📌', 0)
+        }} reacciones</span>
       </div>
       <div class="modal-stat-item">
         <i class="bi bi-chat"></i>


### PR DESCRIPTION
## Summary
- refresh reaction panel to use modern emojis and floating overlay
- update templates (post cards, modals) with new emoji set and thumb icon
- sync JS with new `.reaction-panel` logic
- document the change in `AGENTS.md`
- **Fix**: restore CRUNEVO emoji set in floating panels and defaults

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6887b78e3fac8325b3f1eff2bf980fc0