### PR TITLE
Improve floating reaction panel animations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -881,3 +881,4 @@
   posts issue.
 - Updated reaction panel with floating overlay and modern emojis; adjusted templates and JS.
 - Restored CRUNEVO emojis in floating reaction panel; kept overlay JS improvements (PR modern-floating-reactions-fix).
+- Enhanced floating reaction panel design with fade animations, hover bounce and higher z-index; updated CSS, JS and templates (PR reactions-panel-style-improve).

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -352,10 +352,44 @@
 
 /* Reaction panel */
 .reaction-panel {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translate(-50%, 10px);
+  z-index: 1000;
   overflow-x: auto;
   white-space: nowrap;
   max-width: 300px;
   flex-wrap: nowrap;
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  border-radius: 9999px;
+  padding: 4px 6px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+html[data-bs-theme="dark"] .reaction-panel {
+  background: rgba(39, 39, 42, 0.95);
+}
+
+.reaction-panel.show {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate(-50%, -4px);
+}
+
+.reaction-btn {
+  width: 32px;
+  height: 32px;
+  line-height: 32px;
+  font-size: 20px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.reaction-btn:hover {
+  transform: translateY(-6px) scale(1.2);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
 }
 
 /* Comments section */

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -353,7 +353,8 @@ class ModernFeedManager {
         const likeBtn = container.querySelector('.like-btn');
         likeBtn.dataset.reaction = btn.dataset.reaction;
         this.handleLike(likeBtn);
-        container.querySelector('.reaction-panel')?.classList.add('d-none');
+        const panel = container.querySelector('.reaction-panel');
+        if (panel) this.hideReactionPanel(panel);
       }
     });
 
@@ -532,12 +533,22 @@ class ModernFeedManager {
     const panel = btn.parentElement.querySelector('.reaction-panel');
     if (!panel) return;
     panel.classList.remove('d-none');
+    // trigger reflow to restart animation
+    void panel.offsetWidth;
+    panel.classList.add('show');
     clearTimeout(panel._hideTimer);
     panel._hideTimer = setTimeout(() => {
-      panel.classList.add('d-none');
+      this.hideReactionPanel(panel);
     }, 4000);
+    panel.addEventListener('mouseleave', () => this.hideReactionPanel(panel), {
+      once: true,
+    });
+  }
+
+  hideReactionPanel(panel) {
+    panel.classList.remove('show');
     panel.addEventListener(
-      'mouseleave',
+      'transitionend',
       () => panel.classList.add('d-none'),
       { once: true }
     );

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -108,10 +108,21 @@ function showReactions(btn) {
     });
   }
   options.classList.remove('d-none');
+  void options.offsetWidth;
+  options.classList.add('show');
   clearTimeout(options._timeout);
   options._timeout = setTimeout(() => {
-    options.classList.add('d-none');
+    hideReactions(options);
   }, 4000);
+}
+
+function hideReactions(panel) {
+  panel.classList.remove('show');
+  panel.addEventListener(
+    'transitionend',
+    () => panel.classList.add('d-none'),
+    { once: true }
+  );
 }
 
 // Confirmations for important actions
@@ -264,7 +275,7 @@ function initReactions() {
         btn.classList.add('reaction-active');
         setTimeout(() => btn.classList.remove('reaction-active'), 200);
         sendReaction(reaction);
-        if (options) options.classList.add('d-none');
+        if (options) hideReactions(options);
       });
     });
   });

--- a/crunevo/templates/components/comment_modal.html
+++ b/crunevo/templates/components/comment_modal.html
@@ -46,7 +46,7 @@
                 <span class="action-text">Me gusta</span>
                 <span class="action-count">{{ reaction_counts.get(post.id, {}).get('🔥', '') }}</span>
               </button>
-              <div class="reaction-panel absolute bottom-full left-1/2 -translate-x-1/2 mb-2 flex flex-wrap gap-1 p-1 rounded-full shadow-lg bg-white dark:bg-zinc-800 d-none">
+              <div class="reaction-panel absolute bottom-full left-1/2 -translate-x-1/2 mb-2 flex flex-wrap gap-1 p-1 rounded-full shadow-lg bg-white/90 dark:bg-zinc-800/90 z-50 d-none">
                 <button class="reaction-btn" data-reaction="🔥" title="Crunazo">🔥</button>
                 <button class="reaction-btn" data-reaction="🧠" title="Neuro">🧠</button>
                 <button class="reaction-btn" data-reaction="💔" title="Roto">💔</button>

--- a/crunevo/templates/components/post_card.html
+++ b/crunevo/templates/components/post_card.html
@@ -152,7 +152,7 @@
         <span class="action-text">Me gusta</span>
         <span class="action-count">{{ reaction_counts.get(post.id, {}).get('🔥', '') }}</span>
       </button>
-      <div class="reaction-panel absolute bottom-full left-1/2 -translate-x-1/2 mb-2 flex flex-wrap gap-1 p-1 rounded-full shadow-lg bg-white dark:bg-zinc-800 d-none">
+      <div class="reaction-panel absolute bottom-full left-1/2 -translate-x-1/2 mb-2 flex flex-wrap gap-1 p-1 rounded-full shadow-lg bg-white/90 dark:bg-zinc-800/90 z-50 d-none">
         <button class="reaction-btn" data-reaction="🔥" title="Crunazo">🔥</button>
         <button class="reaction-btn" data-reaction="🧠" title="Neuro">🧠</button>
         <button class="reaction-btn" data-reaction="💔" title="Roto">💔</button>

--- a/crunevo/templates/components/reactions.html
+++ b/crunevo/templates/components/reactions.html
@@ -5,7 +5,7 @@
   <button class="btn btn-reaction">
     <span class="main-emoji">{{ main }}</span> <span class="count">{{ post.likes or 0 }}</span>
   </button>
-  <div class="reaction-panel absolute bottom-full left-1/2 -translate-x-1/2 mb-2 flex flex-wrap gap-1 p-1 rounded-full shadow-lg bg-white dark:bg-zinc-800 d-none">
+  <div class="reaction-panel absolute bottom-full left-1/2 -translate-x-1/2 mb-2 flex flex-wrap gap-1 p-1 rounded-full shadow-lg bg-white/90 dark:bg-zinc-800/90 z-50 d-none">
     <button class="reaction-btn" data-reaction="🔥" title="Crunazo">🔥</button>
     <button class="reaction-btn" data-reaction="🧠" title="Neuro">🧠</button>
     <button class="reaction-btn" data-reaction="💔" title="Roto">💔</button>

--- a/crunevo/templates/feed/_post_modal.html
+++ b/crunevo/templates/feed/_post_modal.html
@@ -62,7 +62,7 @@
           <span class="action-text">Me gusta</span>
           <span class="action-count">{{ reaction_counts.get('🔥', '') }}</span>
         </button>
-        <div class="reaction-panel absolute bottom-full left-1/2 -translate-x-1/2 mb-2 flex flex-wrap gap-1 p-1 rounded-full shadow-lg bg-white dark:bg-zinc-800 d-none">
+        <div class="reaction-panel absolute bottom-full left-1/2 -translate-x-1/2 mb-2 flex flex-wrap gap-1 p-1 rounded-full shadow-lg bg-white/90 dark:bg-zinc-800/90 z-50 d-none">
           <button class="reaction-btn" data-reaction="🔥" title="Crunazo">🔥</button>
           <button class="reaction-btn" data-reaction="🧠" title="Neuro">🧠</button>
           <button class="reaction-btn" data-reaction="💔" title="Roto">💔</button>


### PR DESCRIPTION
## Summary
- style reaction panel as true floating overlay with fade and hover effects
- add JS helpers to show/hide panel with animation
- apply new classes in comment modal, post card and reactions components
- document update in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6887cb5e87048325b731649eca833337