### PR TITLE
Fix reaction panel overlay and hold gesture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -882,3 +882,4 @@
 - Updated reaction panel with floating overlay and modern emojis; adjusted templates and JS.
 - Restored CRUNEVO emojis in floating reaction panel; kept overlay JS improvements (PR modern-floating-reactions-fix).
 - Enhanced floating reaction panel design with fade animations, hover bounce and higher z-index; updated CSS, JS and templates (PR reactions-panel-style-improve).
+- Updated reactions macro to use like-btn markup, added blur backdrop and prevented default on long press to fix overlay bug (PR reaction-panel-bugfix).

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -361,7 +361,9 @@
   white-space: nowrap;
   max-width: 300px;
   flex-wrap: nowrap;
-  background: rgba(255, 255, 255, 0.95);
+  background: rgba(255, 255, 255, 0.8);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   border-radius: 9999px;
   padding: 4px 6px;
@@ -370,7 +372,9 @@
   transition: opacity 0.2s ease, transform 0.2s ease;
 }
 html[data-bs-theme="dark"] .reaction-panel {
-  background: rgba(39, 39, 42, 0.95);
+  background: rgba(39, 39, 42, 0.8);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
 }
 
 .reaction-panel.show {

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -362,12 +362,13 @@ class ModernFeedManager {
     document.addEventListener('touchstart', (e) => {
       const btn = e.target.closest('.like-btn');
       if (!btn) return;
+      e.preventDefault();
       btn._longPress = false;
       btn._pressTimer = setTimeout(() => {
         btn._longPress = true;
         this.showReactionPanel(btn);
       }, 500);
-    });
+    }, { passive: false });
 
     document.addEventListener('touchend', (e) => {
       const btn = e.target.closest('.like-btn');
@@ -381,6 +382,7 @@ class ModernFeedManager {
     document.addEventListener('mousedown', (e) => {
       const btn = e.target.closest('.like-btn');
       if (!btn) return;
+      e.preventDefault();
       btn._longPress = false;
       btn._pressTimer = setTimeout(() => {
         btn._longPress = true;

--- a/crunevo/templates/components/reactions.html
+++ b/crunevo/templates/components/reactions.html
@@ -2,8 +2,10 @@
 {% set sorted_counts = counts|dictsort(false, 'value')|reverse|list if counts else [] %}
 {% set main = sorted_counts[0][0] if sorted_counts else '🔥' %}
 <div class="reaction-container position-relative d-inline-block" data-post-id="{{ post.id }}" data-my-reaction="{{ my or '' }}">
-  <button class="btn btn-reaction">
-    <span class="main-emoji">{{ main }}</span> <span class="count">{{ post.likes or 0 }}</span>
+  <button class="fb-action-btn like-btn {{ 'active' if my }}" data-post-id="{{ post.id }}">
+    <i class="bi bi-fire{{ '-fill' if my else '' }}"></i>
+    <span class="action-text">Me gusta</span>
+    <span class="action-count">{{ post.likes or 0 }}</span>
   </button>
   <div class="reaction-panel absolute bottom-full left-1/2 -translate-x-1/2 mb-2 flex flex-wrap gap-1 p-1 rounded-full shadow-lg bg-white/90 dark:bg-zinc-800/90 z-50 d-none">
     <button class="reaction-btn" data-reaction="🔥" title="Crunazo">🔥</button>


### PR DESCRIPTION
## Summary
- modernize reactions macro with `like-btn` markup
- add blur backdrop to floating reaction panel
- prevent default on long press so overlay appears reliably
- document the update in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6887d09d4d448325a62b2cd3622266c1