### PR TITLE
Fix reaction panel overlay

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -883,3 +883,4 @@
 - Restored CRUNEVO emojis in floating reaction panel; kept overlay JS improvements (PR modern-floating-reactions-fix).
 - Enhanced floating reaction panel design with fade animations, hover bounce and higher z-index; updated CSS, JS and templates (PR reactions-panel-style-improve).
 - Updated reactions macro to use like-btn markup, added blur backdrop and prevented default on long press to fix overlay bug (PR reaction-panel-bugfix).
+- Ensured floating reaction panel is visible by removing overflow restriction on `.facebook-post` (PR fix-reaction-panel-not-showing-v2).

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -50,7 +50,7 @@
   border-radius: var(--border-radius);
   margin-bottom: 20px;
   box-shadow: var(--shadow-light);
-  overflow: hidden;
+  overflow: visible;
   transition: var(--transition);
 }
 


### PR DESCRIPTION
## Summary
- ensure `.facebook-post` allows overflow so floating reactions show
- document fix in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6887e362e368832594dc82452b7561a1