### PR TITLE
Fix floating reactions on post detail pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -884,3 +884,4 @@
 - Enhanced floating reaction panel design with fade animations, hover bounce and higher z-index; updated CSS, JS and templates (PR reactions-panel-style-improve).
 - Updated reactions macro to use like-btn markup, added blur backdrop and prevented default on long press to fix overlay bug (PR reaction-panel-bugfix).
 - Ensured floating reaction panel is visible by removing overflow restriction on `.facebook-post` (PR fix-reaction-panel-not-showing-v2).
+- ModernFeedManager initializes when any .like-btn is present to restore floating reactions on post detail pages (hotfix floating-reactions-init).

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -849,8 +849,12 @@ document.addEventListener('DOMContentLoaded', () => {
   if (typeof initChatIA === 'function') {
     initChatIA();
   }
-  if (typeof initModernFeedManager === 'function' && document.getElementById('feedContainer')) {
-    initModernFeedManager();
+  if (typeof initModernFeedManager === 'function') {
+    const hasFeed = document.getElementById('feedContainer');
+    const hasReactions = document.querySelector('.like-btn');
+    if (hasFeed || hasReactions) {
+      initModernFeedManager();
+    }
   }
   if (typeof initPhotoComments === 'function' && document.getElementById('comment-section')) {
     initPhotoComments();


### PR DESCRIPTION
## Summary
- initialize ModernFeedManager when any `.like-btn` exists
- document fix in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6887e82bf2188325a461baedd4d70654