### PR TITLE
Fix reactions panel positioning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -885,3 +885,4 @@
 - Updated reactions macro to use like-btn markup, added blur backdrop and prevented default on long press to fix overlay bug (PR reaction-panel-bugfix).
 - Ensured floating reaction panel is visible by removing overflow restriction on `.facebook-post` (PR fix-reaction-panel-not-showing-v2).
 - ModernFeedManager initializes when any .like-btn is present to restore floating reactions on post detail pages (hotfix floating-reactions-init).
+- Fix position and style of floating reaction panel above "Me gusta" button (PR reactions-panel-position-fix).

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -356,7 +356,7 @@
   bottom: 100%;
   left: 50%;
   transform: translate(-50%, 10px);
-  z-index: 1000;
+  z-index: 9999;
   overflow-x: auto;
   white-space: nowrap;
   max-width: 300px;
@@ -384,10 +384,17 @@ html[data-bs-theme="dark"] .reaction-panel {
 }
 
 .reaction-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   width: 32px;
   height: 32px;
   line-height: 32px;
   font-size: 20px;
+  background: transparent;
+  border: none;
+  border-radius: 50%;
+  padding: 0;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -534,6 +534,11 @@ class ModernFeedManager {
   showReactionPanel(btn) {
     const panel = btn.parentElement.querySelector('.reaction-panel');
     if (!panel) return;
+    const rect = btn.getBoundingClientRect();
+    panel.style.position = 'fixed';
+    panel.style.left = `${rect.left + rect.width / 2 - panel.offsetWidth / 2}px`;
+    panel.style.top = `${rect.top - panel.offsetHeight - 8}px`;
+    panel.style.zIndex = '9999';
     panel.classList.remove('d-none');
     // trigger reflow to restart animation
     void panel.offsetWidth;
@@ -551,7 +556,13 @@ class ModernFeedManager {
     panel.classList.remove('show');
     panel.addEventListener(
       'transitionend',
-      () => panel.classList.add('d-none'),
+      () => {
+        panel.classList.add('d-none');
+        panel.style.position = '';
+        panel.style.left = '';
+        panel.style.top = '';
+        panel.style.zIndex = '';
+      },
       { once: true }
     );
   }


### PR DESCRIPTION
## Summary
- fix reaction panel to position relative to the Like button
- tweak z-index and styles for reaction panel buttons
- document change in `AGENTS.md`

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6887edd7e73c8325af827e1e2ca0b6d3