### PR TITLE
Fix reaction panel overlay

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -886,3 +886,4 @@
 - Ensured floating reaction panel is visible by removing overflow restriction on `.facebook-post` (PR fix-reaction-panel-not-showing-v2).
 - ModernFeedManager initializes when any .like-btn is present to restore floating reactions on post detail pages (hotfix floating-reactions-init).
 - Fix position and style of floating reaction panel above "Me gusta" button (PR reactions-panel-position-fix).
+- Fixed reaction panel placement by measuring after display; removed horizontal scrollbar and wrapped buttons; panel now positions reliably above the like button (PR reaction-panel-enhancements).

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -357,10 +357,12 @@
   left: 50%;
   transform: translate(-50%, 10px);
   z-index: 9999;
-  overflow-x: auto;
-  white-space: nowrap;
-  max-width: 300px;
-  flex-wrap: nowrap;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 4px;
+  max-width: 90vw;
+  overflow: hidden;
   background: rgba(255, 255, 255, 0.8);
   backdrop-filter: blur(6px);
   -webkit-backdrop-filter: blur(6px);

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -535,11 +535,12 @@ class ModernFeedManager {
     const panel = btn.parentElement.querySelector('.reaction-panel');
     if (!panel) return;
     const rect = btn.getBoundingClientRect();
-    panel.style.position = 'fixed';
-    panel.style.left = `${rect.left + rect.width / 2 - panel.offsetWidth / 2}px`;
-    panel.style.top = `${rect.top - panel.offsetHeight - 8}px`;
-    panel.style.zIndex = '9999';
     panel.classList.remove('d-none');
+    panel.style.position = 'fixed';
+    const { offsetWidth, offsetHeight } = panel;
+    panel.style.left = `${rect.left + rect.width / 2 - offsetWidth / 2}px`;
+    panel.style.top = `${rect.top - offsetHeight - 8}px`;
+    panel.style.zIndex = '9999';
     // trigger reflow to restart animation
     void panel.offsetWidth;
     panel.classList.add('show');

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -108,6 +108,12 @@ function showReactions(btn) {
     });
   }
   options.classList.remove('d-none');
+  options.style.position = 'fixed';
+  const rect = btn.getBoundingClientRect();
+  const { offsetWidth, offsetHeight } = options;
+  options.style.left = `${rect.left + rect.width / 2 - offsetWidth / 2}px`;
+  options.style.top = `${rect.top - offsetHeight - 8}px`;
+  options.style.zIndex = '9999';
   void options.offsetWidth;
   options.classList.add('show');
   clearTimeout(options._timeout);
@@ -120,7 +126,13 @@ function hideReactions(panel) {
   panel.classList.remove('show');
   panel.addEventListener(
     'transitionend',
-    () => panel.classList.add('d-none'),
+    () => {
+      panel.classList.add('d-none');
+      panel.style.position = '';
+      panel.style.left = '';
+      panel.style.top = '';
+      panel.style.zIndex = '';
+    },
     { once: true }
   );
 }


### PR DESCRIPTION
## Summary
- refine JS to measure reaction panel dimensions before positioning so it floats directly above the like button
- allow reactions to wrap and remove horizontal scrollbar
- keep panel above other elements when shown
- document changes in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6887f67cc3b483259ddae620d488ef5e