### PR TITLE
Fix floating reaction panel alignment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -888,3 +888,4 @@
 - Fix position and style of floating reaction panel above "Me gusta" button (PR reactions-panel-position-fix).
 - Fixed reaction panel placement by measuring after display; removed horizontal scrollbar and wrapped buttons; panel now positions reliably above the like button (PR reaction-panel-enhancements).
 - Unified reaction panel logic in main.js and feed.js with dynamic positioning, simplified CSS and templates (PR reaction-panel-unify-fix).
+- Corrected floating reaction panel to appear centered above the pressed "Me gusta" button and reset styles on hide (PR reaction-panel-button-align).

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -353,8 +353,7 @@ class ModernFeedManager {
         const likeBtn = container.querySelector('.like-btn');
         likeBtn.dataset.reaction = btn.dataset.reaction;
         this.handleLike(likeBtn);
-        const panel = container.querySelector('.reaction-panel');
-        if (panel) this.hideReactionPanel(panel);
+        this.hideReactionPanel(likeBtn);
       }
     });
 
@@ -535,8 +534,8 @@ class ModernFeedManager {
     window.showReactionPanel(btn);
   }
 
-  hideReactionPanel(panel) {
-    window.hideReactionPanel(panel);
+  hideReactionPanel(btn) {
+    window.hideReactionPanel(btn);
   }
 
   // Handle share button with graceful fallback

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -97,39 +97,47 @@ function applyGalleryOrientation() {
   });
 }
 
-function showReactionPanel(btn) {
-  const container = btn.closest('.reaction-container');
-  const panel = container.querySelector('.reaction-panel');
+function showReactionPanel(button) {
+  const container = button.closest('.reaction-container');
+  const panel = container?.querySelector('.reaction-panel');
   if (!panel) return;
+
   const current = container.dataset.myReaction;
   if (current) {
     panel.querySelectorAll('.reaction-btn').forEach((b) => {
       b.classList.toggle('active', b.dataset.reaction === current);
     });
   }
+
   panel.classList.remove('d-none');
-  const rect = btn.getBoundingClientRect();
-  panel.style.left = `${rect.left + rect.width / 2 - panel.offsetWidth / 2}px`;
-  panel.style.top = `${rect.top - panel.offsetHeight - 8}px`;
-  panel.style.zIndex = '9999';
-  void panel.offsetWidth;
   panel.classList.add('show');
+
+  const btnRect = button.getBoundingClientRect();
+  const panelRect = panel.getBoundingClientRect();
+  const top = btnRect.top - panelRect.height - 8 + window.scrollY;
+  const left =
+    btnRect.left + btnRect.width / 2 - panelRect.width / 2 + window.scrollX;
+
+  panel.style.position = 'absolute';
+  panel.style.top = `${top}px`;
+  panel.style.left = `${left}px`;
+  panel.style.zIndex = '9999';
+  panel.style.display = 'flex';
+
   clearTimeout(panel._timeout);
   panel._timeout = setTimeout(() => {
-    hideReactionPanel(panel);
+    hideReactionPanel(button);
   }, 4000);
 }
 
-function hideReactionPanel(panel) {
+function hideReactionPanel(button) {
+  const container = button.closest('.reaction-container');
+  const panel = container?.querySelector('.reaction-panel');
+  if (!panel) return;
+
   panel.classList.remove('show');
-  panel.addEventListener(
-    'transitionend',
-    () => {
-      panel.classList.add('d-none');
-      panel.removeAttribute('style');
-    },
-    { once: true }
-  );
+  panel.classList.add('d-none');
+  panel.removeAttribute('style');
 }
 
 window.showReactionPanel = showReactionPanel;
@@ -285,7 +293,7 @@ function initReactions() {
         btn.classList.add('reaction-active');
         setTimeout(() => btn.classList.remove('reaction-active'), 200);
         sendReaction(reaction);
-        if (options) hideReactionPanel(options);
+        hideReactionPanel(mainBtn);
       });
     });
   });


### PR DESCRIPTION
## Summary
- ensure floating reaction panel positions above the pressed `Me gusta` button and reset styles when hidden
- update feed manager to close the panel after selecting a reaction
- document improvement in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68883ef0c064832598366089309e6503