### PR TITLE
Fix reaction panel positioning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -889,3 +889,4 @@
 - Fixed reaction panel placement by measuring after display; removed horizontal scrollbar and wrapped buttons; panel now positions reliably above the like button (PR reaction-panel-enhancements).
 - Unified reaction panel logic in main.js and feed.js with dynamic positioning, simplified CSS and templates (PR reaction-panel-unify-fix).
 - Corrected floating reaction panel to appear centered above the pressed "Me gusta" button and reset styles on hide (PR reaction-panel-button-align).
+- Improved reaction panel alignment with responsive positioning and outside click close (PR feed-reaction-panel-responsive).

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -353,17 +353,17 @@
 /* Reaction panel */
 .reaction-panel {
   position: absolute;
-  z-index: 9999;
+  z-index: 1000;
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 4px;
+  gap: 8px;
   max-width: 90vw;
   overflow: hidden;
   background: var(--post-bg);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  border-radius: 12px;
-  padding: 8px;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.15);
+  border-radius: 50px;
+  padding: 6px 12px;
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.2s ease;
@@ -389,12 +389,11 @@ html[data-bs-theme="dark"] .reaction-panel {
   border: none;
   border-radius: 50%;
   padding: 0;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: transform 0.15s ease;
 }
 
 .reaction-btn:hover {
-  transform: translateY(-6px) scale(1.2);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  transform: scale(1.3);
 }
 
 /* Comments section */

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -97,6 +97,17 @@ function applyGalleryOrientation() {
   });
 }
 
+function adjustPanelPosition(panel, container, left) {
+  const containerRect = container.getBoundingClientRect();
+  if (left + panel.offsetWidth > containerRect.width) {
+    left = containerRect.width - panel.offsetWidth - 10;
+  }
+  if (left < 0) {
+    left = 10;
+  }
+  panel.style.left = `${left}px`;
+}
+
 function showReactionPanel(button) {
   const container = button.closest('.reaction-container');
   const panel = container?.querySelector('.reaction-panel');
@@ -113,20 +124,32 @@ function showReactionPanel(button) {
   panel.classList.add('show');
 
   const btnRect = button.getBoundingClientRect();
-  const panelRect = panel.getBoundingClientRect();
-  const top = btnRect.top - panelRect.height - 8 + window.scrollY;
-  const left =
-    btnRect.left + btnRect.width / 2 - panelRect.width / 2 + window.scrollX;
+  const containerRect = container.getBoundingClientRect();
+  const top = btnRect.top - containerRect.top - panel.offsetHeight - 8;
+  let left =
+    btnRect.left -
+    containerRect.left +
+    btnRect.width / 2 -
+    panel.offsetWidth / 2;
 
   panel.style.position = 'absolute';
   panel.style.top = `${top}px`;
-  panel.style.left = `${left}px`;
-  panel.style.zIndex = '9999';
+  adjustPanelPosition(panel, container, left);
+  panel.style.zIndex = '1000';
   panel.style.display = 'flex';
+
+  function outside(e) {
+    if (!panel.contains(e.target) && !button.contains(e.target)) {
+      hideReactionPanel(button);
+      document.removeEventListener('click', outside);
+    }
+  }
+  document.addEventListener('click', outside);
 
   clearTimeout(panel._timeout);
   panel._timeout = setTimeout(() => {
     hideReactionPanel(button);
+    document.removeEventListener('click', outside);
   }, 4000);
 }
 


### PR DESCRIPTION
## Summary
- refine JS to position reaction panel relative to the like button and adjust for post edges
- add outside click handler to hide the panel
- restyle reaction panel with larger shadow and rounded corners

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68884837488483258f826730fa7595fa