### PR TITLE
Fix mobile reaction panel placement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -889,3 +889,4 @@
 - Fixed reaction panel placement by measuring after display; removed horizontal scrollbar and wrapped buttons; panel now positions reliably above the like button (PR reaction-panel-enhancements).
 - Unified reaction panel logic in main.js and feed.js with dynamic positioning, simplified CSS and templates (PR reaction-panel-unify-fix).
 - Corrected floating reaction panel to appear centered above the pressed "Me gusta" button and reset styles on hide (PR reaction-panel-button-align).
+- Improved mobile reaction panel positioning to center over the tapped like button with screen margins and click-outside close handler (PR mobile-reaction-panel).

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -358,7 +358,7 @@
   flex-wrap: wrap;
   justify-content: center;
   gap: 4px;
-  max-width: 90vw;
+  max-width: calc(100vw - 16px);
   overflow: hidden;
   background: var(--post-bg);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -111,18 +111,33 @@ function showReactionPanel(button) {
 
   panel.classList.remove('d-none');
   panel.classList.add('show');
-
-  const btnRect = button.getBoundingClientRect();
-  const panelRect = panel.getBoundingClientRect();
-  const top = btnRect.top - panelRect.height - 8 + window.scrollY;
-  const left =
-    btnRect.left + btnRect.width / 2 - panelRect.width / 2 + window.scrollX;
-
   panel.style.position = 'absolute';
-  panel.style.top = `${top}px`;
-  panel.style.left = `${left}px`;
-  panel.style.zIndex = '9999';
   panel.style.display = 'flex';
+  panel.style.zIndex = '9999';
+
+  requestAnimationFrame(() => {
+    const btnRect = button.getBoundingClientRect();
+    const panelRect = panel.getBoundingClientRect();
+    let top = btnRect.top - panelRect.height - 8 + window.scrollY;
+    if (top < window.scrollY + 8) {
+      top = btnRect.bottom + 8 + window.scrollY;
+    }
+    let left =
+      btnRect.left + btnRect.width / 2 - panelRect.width / 2 + window.scrollX;
+    const minLeft = window.scrollX + 8;
+    const maxLeft = window.scrollX + window.innerWidth - panelRect.width - 8;
+    left = Math.min(Math.max(left, minLeft), maxLeft);
+    panel.style.top = `${top}px`;
+    panel.style.left = `${left}px`;
+  });
+
+  const onClickOutside = (e) => {
+    if (!panel.contains(e.target) && !button.contains(e.target)) {
+      hideReactionPanel(button);
+    }
+  };
+  document.addEventListener('click', onClickOutside);
+  panel._onClickOutside = onClickOutside;
 
   clearTimeout(panel._timeout);
   panel._timeout = setTimeout(() => {
@@ -138,6 +153,10 @@ function hideReactionPanel(button) {
   panel.classList.remove('show');
   panel.classList.add('d-none');
   panel.removeAttribute('style');
+  if (panel._onClickOutside) {
+    document.removeEventListener('click', panel._onClickOutside);
+    delete panel._onClickOutside;
+  }
 }
 
 window.showReactionPanel = showReactionPanel;


### PR DESCRIPTION
## Summary
- keep reaction panel within screen bounds on mobile
- close the panel when tapping outside
- document the change

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68884e1eb5b88325a90f3b53e4982045