### PR TITLE
Implement admin request audit logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -893,3 +893,4 @@
 - Restored repository to pre-replit state and removed stray metrics migration to fix Alembic heads (hotfix revert-replit)
 - Restored Fly volume mount in fly.toml to match existing machine configuration (PR fix-fly-volume-config)
 - Cleaned unnecessary console.log statements in static JS and guarded service worker logs with self.DEBUG (PR remove-console-logs).
+- Added audit logging in require_admin before_request to track admin page visits (PR admin-require-logging).

--- a/crunevo/routes/admin_routes.py
+++ b/crunevo/routes/admin_routes.py
@@ -57,7 +57,9 @@ admin_bp = Blueprint("admin", __name__, url_prefix="/admin")
 @login_required
 @admin_required
 def require_admin():
-    pass
+    """Ensure admin access and log each admin visit."""
+    if request.endpoint != "admin.admin_logs":
+        log_admin_action(f"Accessed {request.path}")
 
 
 @admin_bp.route("/")


### PR DESCRIPTION
## Summary
- log admin page visits via `require_admin` before_request handler
- document the change in AGENTS guidelines

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688872381e6083259ab68dc8ee429855