### PR TITLE
Clean up console logs in templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -896,3 +896,4 @@
 - Cleaned unnecessary console.log statements in static JS and guarded service worker logs with self.DEBUG (PR remove-console-logs).
 - Added audit logging in require_admin before_request to track admin page visits (PR admin-require-logging).
 - Added /admin/api/analytics endpoint and improved applyFilters to send selected filters and redraw charts (PR analytics-filters-api).
+- Replaced debug `console.log` statements in base.html and ranking/index.html with `console.info` for clearer logging (PR template-console-cleanup).

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -226,7 +226,7 @@
     <script>
 if ('serviceWorker' in navigator) {
   navigator.serviceWorker.register('{{ url_for('static', filename='js/service-worker.js') }}')
-    .then(reg => console.log('SW registrado', reg))
+    .then(reg => console.info('Service worker registrado', reg))
     .catch(err => console.error('SW error', err));
 }
     </script>

--- a/crunevo/templates/ranking/index.html
+++ b/crunevo/templates/ranking/index.html
@@ -480,7 +480,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
 function filterRanking(type) {
   // Implementation for filtering ranking by type
-  console.log('Filtering ranking by:', type);
+  console.info('Filtering ranking by:', type);
   // This would call an API endpoint to get filtered results
 }
 </script>


### PR DESCRIPTION
## Summary
- switch service worker registration logging to `console.info`
- update ranking JS logging to `console.info`
- document change in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688877ea8c7083259b02cd7315371aa8