### PR TITLE
Fix mobile notbar overlap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -899,3 +899,4 @@
 - Replaced debug `console.log` statements in base.html and ranking/index.html with `console.info` for clearer logging (PR template-console-cleanup).
 - Replaced mobile bottom nav with a translucent top "notbar" on small screens, kept hamburger menu intact and removed obsolete component includes (PR facebook-mobile-notbar).
 - Redesigned mobile notbar with purple translucent background, circular icon buttons and updated order (Inicio, Personas, Chat, Apuntes, Notificaciones, Tienda), removing the perfil link (PR mobile-notbar-facebook-style).
+- Ajustado notbar móvil para fondo morado sólido, altura mínima 64px y sombra sutil; modal de búsqueda visible en móviles (PR mobile-navbar-fix).

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -25,7 +25,7 @@ body {
 
 @media (max-width: 768px) {
   body {
-    padding-top: 56px;
+    padding-top: 64px;
   }
   main {
     margin-top: 64px;
@@ -792,12 +792,20 @@ html[data-bs-theme="dark"] footer a {
 
 /* Mobile notbar styles */
 .notbar {
-  background-color: rgba(110, 66, 193, 0.85);
+  background-color: #6e42c1;
   -webkit-backdrop-filter: blur(20px);
   backdrop-filter: blur(20px);
-  height: 48px;
-  padding: 4px 6px;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  min-height: 64px;
+  padding-top: env(safe-area-inset-top);
+  padding-left: 6px;
+  padding-right: 6px;
+  padding-bottom: 4px;
   z-index: 1030;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .notbar .form-control {
@@ -827,4 +835,8 @@ html[data-bs-theme="dark"] footer a {
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+#mobileSearchModal .modal-content {
+  background-color: #fff;
 }


### PR DESCRIPTION
## Summary
- solid purple mobile notbar
- adjust body padding for mobile
- show mobile search modal with white background
- document navbar change in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6889a228085883258c731d729b05b6a1