### PR TITLE
Fix forum sorting crash

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1042,3 +1042,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Added migration 'add_forum_modernization_fields' to create missing tables and columns for the modern forum.
 - Handled missing forum tables gracefully in list_questions to avoid 500 errors (PR forum-500-fix).
 - Added migration 'forum_modernization_schema' and removed temporary error handling from forum routes.
+- Fixed popular sort in forum by counting answers via join instead of property (hotfix forum-popular-sort).

--- a/crunevo/routes/forum_routes.py
+++ b/crunevo/routes/forum_routes.py
@@ -122,8 +122,10 @@ def list_questions():
 
     # Apply sorting
     if sort_by == "popular":
-        query = query.order_by(
-            desc(ForumQuestion.views), desc(ForumQuestion.answer_count)
+        query = (
+            query.outerjoin(ForumAnswer)
+            .group_by(ForumQuestion.id)
+            .order_by(desc(db.func.count(ForumAnswer.id)), desc(ForumQuestion.views))
         )
     elif sort_by == "urgent":
         query = query.filter_by(is_urgent=True).order_by(desc(ForumQuestion.created_at))


### PR DESCRIPTION
## Summary
- fix /foro popular sorting using join to count answers
- document hotfix in AGENTS notes

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688d52f348d483259dd77862a4c9fe25