### PR TITLE
Fix forum 500 when tables missing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1042,3 +1042,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Added migration 'add_forum_modernization_fields' to create missing tables and columns for the modern forum.
 - Handled missing forum tables gracefully in list_questions to avoid 500 errors (PR forum-500-fix).
 - Added migration 'forum_modernization_schema' and removed temporary error handling from forum routes.
+- Restored error handling in forum list view to prevent crashes when tables are missing (hotfix forum-migration-fallback).


### PR DESCRIPTION
## Summary
- handle `OperationalError` in the forum list view
- record this hotfix in `AGENTS.md`

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688d52f348d483259dd77862a4c9fe25