### PR TITLE
Fix forum list stability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1043,3 +1043,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Handled missing forum tables gracefully in list_questions to avoid 500 errors (PR forum-500-fix).
 - Added migration 'forum_modernization_schema' and removed temporary error handling from forum routes.
 - Fixed popular sort in forum by counting answers via join instead of property (hotfix forum-popular-sort).
+- Improved forum list route with robust DB error handling and orphan author fallbacks (PR forum-list-stability).

--- a/crunevo/routes/forum_routes.py
+++ b/crunevo/routes/forum_routes.py
@@ -14,6 +14,7 @@ from flask import (
 )
 from flask_login import login_required, current_user
 from sqlalchemy import or_, and_, desc, asc
+from sqlalchemy.exc import ProgrammingError, OperationalError
 from datetime import datetime
 from crunevo.extensions import db
 from crunevo.models.forum import (
@@ -83,6 +84,24 @@ GRADE_LEVELS = [
 ]
 
 
+class EmptyPagination:
+    """Fallback pagination object when DB queries fail"""
+
+    def __init__(self, page=1, per_page=15):
+        self.page = page
+        self.per_page = per_page
+        self.items = []
+        self.total = 0
+        self.pages = 0
+        self.has_prev = False
+        self.has_next = False
+        self.prev_num = None
+        self.next_num = None
+
+    def iter_pages(self):
+        return []
+
+
 @forum_bp.route("/foro")
 def list_questions():
     page = request.args.get("page", 1, type=int)
@@ -142,28 +161,40 @@ def list_questions():
     else:  # recent
         query = query.order_by(desc(ForumQuestion.created_at))
 
-    questions = query.paginate(page=page, per_page=15, error_out=False)
+    try:
+        questions = query.paginate(page=page, per_page=15, error_out=False)
 
-    # Get popular tags for sidebar
-    popular_tags = (
-        db.session.query(ForumTag)
-        .join(question_tags)
-        .group_by(ForumTag.id)
-        .order_by(db.func.count(question_tags.c.question_id).desc())
-        .limit(10)
-        .all()
-    )
+        # Get popular tags for sidebar
+        popular_tags = (
+            db.session.query(ForumTag)
+            .join(question_tags)
+            .group_by(ForumTag.id)
+            .order_by(db.func.count(question_tags.c.question_id).desc())
+            .limit(10)
+            .all()
+        )
 
-    # Get statistics
-    stats = {
-        "total_questions": ForumQuestion.query.count(),
-        "solved_questions": ForumQuestion.query.filter_by(is_solved=True).count(),
-        "urgent_questions": ForumQuestion.query.filter_by(is_urgent=True).count(),
-        "questions_today": ForumQuestion.query.filter(
-            ForumQuestion.created_at
-            >= datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
-        ).count(),
-    }
+        # Get statistics
+        stats = {
+            "total_questions": ForumQuestion.query.count(),
+            "solved_questions": ForumQuestion.query.filter_by(is_solved=True).count(),
+            "urgent_questions": ForumQuestion.query.filter_by(is_urgent=True).count(),
+            "questions_today": ForumQuestion.query.filter(
+                ForumQuestion.created_at
+                >= datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+            ).count(),
+        }
+    except (ProgrammingError, OperationalError):
+        current_app.logger.error("Error loading forum questions", exc_info=True)
+        db.session.rollback()
+        questions = EmptyPagination(page, 15)
+        popular_tags = []
+        stats = {
+            "total_questions": 0,
+            "solved_questions": 0,
+            "urgent_questions": 0,
+            "questions_today": 0,
+        }
 
     return render_template(
         "forum/list.html",

--- a/crunevo/templates/forum/list.html
+++ b/crunevo/templates/forum/list.html
@@ -224,10 +224,11 @@
             <div class="question-footer">
               <div class="d-flex align-items-center justify-content-between">
                 <div class="author-info d-flex align-items-center">
-                  <img src="{{ question.author.avatar_url or url_for('static', filename='img/default.png') }}" 
+                  {% set author = question.author %}
+                  <img src="{{ author.avatar_url if author else url_for('static', filename='img/default.png') }}"
                        class="author-avatar me-2" alt="Avatar">
                   <div class="author-details">
-                    <div class="author-name">{{ question.author.username }}</div>
+                    <div class="author-name">{{ author.username if author else 'Usuario eliminado' }}</div>
                     <div class="question-time">{{ question.created_at.strftime('%d/%m/%Y %H:%M') }}</div>
                   </div>
                 </div>

--- a/crunevo/templates/forum/partials/answer_card.html
+++ b/crunevo/templates/forum/partials/answer_card.html
@@ -12,16 +12,17 @@
         <div class="d-flex align-items-start">
             <!-- Enhanced Avatar -->
             <div class="me-3 text-center">
-                <img src="{{ answer.author.avatar_url or url_for('static', filename='img/default.png') }}" 
+                {% set author = answer.author %}
+                <img src="{{ author.avatar_url if author else url_for('static', filename='img/default.png') }}"
                      class="rounded-circle user-avatar" width="48" height="48" alt="Avatar">
-                <div class="small text-muted mt-1">{{ answer.author.points or 0 }}pts</div>
+                <div class="small text-muted mt-1">{{ author.points if author else 0 }}pts</div>
             </div>
             
             <div class="flex-grow-1">
                 <!-- Author Info with Enhanced Design -->
                 <div class="d-flex align-items-center justify-content-between mb-3">
                     <div class="d-flex align-items-center gap-2">
-                        <h6 class="mb-0 fw-bold">@{{ answer.author.username }}</h6>
+                        <h6 class="mb-0 fw-bold">@{{ author.username if author else 'Usuario eliminado' }}</h6>
                         <span class="badge bg-primary bg-opacity-10 text-primary">
                             <i class="bi bi-mortarboard me-1"></i>Colaborador
                         </span>

--- a/crunevo/templates/forum/question.html
+++ b/crunevo/templates/forum/question.html
@@ -63,11 +63,12 @@
                     
                     <!-- Author Info -->
                     <div class="d-flex align-items-center mb-4 p-3 rounded-3" style="background: var(--forum-light-gradient);">
-                        <img src="{{ question.author.avatar_url or url_for('static', filename='img/default.png') }}" 
+                        {% set author = question.author %}
+                        <img src="{{ author.avatar_url if author else url_for('static', filename='img/default.png') }}"
                              class="rounded-circle user-avatar me-3" width="52" height="52" alt="Avatar">
                         <div class="flex-grow-1">
                             <div class="d-flex align-items-center gap-2 mb-1">
-                                <h6 class="mb-0 fw-bold">@{{ question.author.username }}</h6>
+                                <h6 class="mb-0 fw-bold">@{{ author.username if author else 'Usuario eliminado' }}</h6>
                                 <span class="badge bg-primary bg-opacity-10 text-primary">
                                     <i class="bi bi-mortarboard me-1"></i>Estudiante
                                 </span>
@@ -79,7 +80,7 @@
                         </div>
                         <div class="text-end">
                             <div class="small text-muted">Contribuciones</div>
-                            <div class="fw-bold text-primary">{{ question.author.points or 0 }} pts</div>
+                            <div class="fw-bold text-primary">{{ author.points if author else 0 }} pts</div>
                         </div>
                     </div>
                     

--- a/crunevo/templates/forum/search_results.html
+++ b/crunevo/templates/forum/search_results.html
@@ -194,10 +194,11 @@
 
       <div class="result-footer">
         <div class="author-info">
-          <img src="{{ question.author.avatar_url or url_for('static', filename='img/default.png') }}" 
+          {% set author = question.author %}
+          <img src="{{ author.avatar_url if author else url_for('static', filename='img/default.png') }}"
                class="author-avatar" alt="Avatar">
           <div class="author-details">
-            <div class="author-name">{{ question.author.username }}</div>
+            <div class="author-name">{{ author.username if author else 'Usuario eliminado' }}</div>
             <div class="question-time">{{ question.created_at.strftime('%d/%m/%Y %H:%M') }}</div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- handle database errors gracefully in `list_questions`
- log exceptions and show empty forum when DB is unavailable
- ensure templates handle missing authors safely
- document forum fix in `AGENTS.md`

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688d61c4880c832592e2e48eca570a92