### PR TITLE
fix: streamline forum question editor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1046,3 +1046,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Improved forum list route with robust DB error handling and orphan author fallbacks (PR forum-list-stability).
 - Added ensure_forum_tables helper and manual 500 error for missing schema; created test for /foro (PR forum-table-check).
 - Fixed description validation on /foro/hacer-pregunta with char counter, drag-drop images and backend length check (PR forum-editor-enhancements).
+- Removed duplicate Quill initialization on /foro/hacer-pregunta, ensuring single editor with image uploads and accurate character counter (PR forum-editor-single).

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -911,8 +911,8 @@ document.addEventListener('DOMContentLoaded', () => {
     initializeEnhancedUI();
   }
   if (typeof initForumEditor === 'function') {
-    initForumEditor('#questionEditor');
-    initForumEditor('#answerEditor');
+    window.quillEditor = initForumEditor('#questionEditor');
+    window.answerEditor = initForumEditor('#answerEditor');
   }
 
   document.querySelectorAll('.achievement-card').forEach((el) => {

--- a/crunevo/templates/forum/ask.html
+++ b/crunevo/templates/forum/ask.html
@@ -1030,8 +1030,13 @@ let formData = {
 document.addEventListener('DOMContentLoaded', function() {
   updateProgress();
   setupEventListeners();
-  initializeEditor();
-  updateContentValidation();
+  if (window.quillEditor) {
+    window.quillEditor.on('text-change', function() {
+      updateProgress();
+      updateContentValidation();
+    });
+    updateContentValidation();
+  }
 });
 
 function setupEventListeners() {
@@ -1311,33 +1316,17 @@ function updateBountyDisplay() {
   }
 }
 
-function initializeEditor() {
-  if (typeof Quill !== 'undefined') {
-    window.quillEditor = new Quill('#questionEditor', {
-      theme: 'snow',
-      placeholder: 'Describe tu problema en detalle...',
-      modules: {
-        toolbar: [
-          ['bold', 'italic', 'underline'],
-          [{ list: 'ordered' }, { list: 'bullet' }],
-          ['link', 'image'],
-          ['code-block'],
-          ['clean']
-        ]
-      }
-    });
-    
-    window.quillEditor.on('text-change', function() {
-      updateProgress();
-      updateContentValidation();
-    });
-    updateContentValidation();
-  }
-}
 
 // Form submission
 document.getElementById('questionForm').addEventListener('submit', function(e) {
   if (window.quillEditor) {
+    const len = countRealChars(window.quillEditor.getText());
+    if (len < 20) {
+      e.preventDefault();
+      const errorEl = document.getElementById('content-error');
+      if (errorEl) errorEl.style.display = 'block';
+      return;
+    }
     document.querySelector('input[name="content"]').value = window.quillEditor.root.innerHTML;
   }
   


### PR DESCRIPTION
## Summary
- ensure forum ask page uses a single Quill editor stored globally
- validate description length on submit
- document removal of duplicate editor in AGENTS notes

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688d7a59ad748325b331255fd4336983