### PR TITLE
fix: correct forum editor char counter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1048,3 +1048,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Fixed description validation on /foro/hacer-pregunta with char counter, drag-drop images and backend length check (PR forum-editor-enhancements).
 - Removed duplicate Quill initialization on /foro/hacer-pregunta, ensuring single editor with image uploads and accurate character counter (PR forum-editor-single).
 - Improved /foro/hacer-pregunta editor with precise whitespace-trimmed character validation, richer Quill toolbar, resizable images with tooltip and click-to-expand, and enforcement of 20-character minimum before advancing (PR forum-editor-validation-fix).
+- Fixed character counter on /foro/hacer-pregunta using Quill text content and ignoring punctuation, enabling 20-character validation without errors (PR forum-editor-charcount-bugfix).

--- a/crunevo/templates/forum/ask.html
+++ b/crunevo/templates/forum/ask.html
@@ -1087,16 +1087,13 @@ function updateCharCounter(inputId, maxLength) {
 }
 
 function countRealChars(text) {
-  return text.replace(/\s+/g, ' ').trim().length;
+  return text.replace(/[\s\p{P}\p{S}]/gu, '').length;
 }
 
 function updateContentValidation() {
   if (!window.quillEditor) return;
-  const textoPlano = window.quillEditor
-    .getText()
-    .replace(/\s+/g, ' ')
-    .trim();
-  const len = textoPlano.length;
+  const rawText = window.quillEditor.getText();
+  const len = countRealChars(rawText);
   const counter = document.getElementById('content-counter');
   if (counter) counter.textContent = len;
   const nextBtn = document.getElementById('nextBtn');
@@ -1105,7 +1102,7 @@ function updateContentValidation() {
     errorEl.style.display = 'none';
     if (currentStep === 3) nextBtn.disabled = false;
   } else {
-    if (text.trim().length > 0) {
+    if (rawText.trim().length > 0) {
       errorEl.style.display = 'block';
     } else {
       errorEl.style.display = 'none';


### PR DESCRIPTION
## Summary
- fix forum ask page to count real characters from Quill editor and allow navigation after 20 characters
- document the change in AGENTS.md

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688d889065388325b69825850eb4b003