### PR TITLE
Refactor modal to Facebook style

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1051,3 +1051,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Fixed character counter on /foro/hacer-pregunta using Quill text content and ignoring punctuation, enabling 20-character validation without errors (PR forum-editor-charcount-bugfix).
 - Ensured /foro/hacer-pregunta editor enables "Siguiente" after 20 real characters by waiting for Quill initialization and using robust content validation (PR forum-editor-next-btn-fix).
 - Fixed modal navigation by managing history state with a stack and popstate listener, preventing unintended page back navigation when closing new Facebook-style modals (PR modal-history-fix).
+- Unified Facebook-style post modal: added color variables, refactored feed.js with createModal/closeModal helpers, and trimmed _post_modal.html to panel-only content (PR facebook-modal-refactor).

--- a/crunevo/static/css/photo-modal.css
+++ b/crunevo/static/css/photo-modal.css
@@ -1,6 +1,29 @@
 /* CRUNEVO Modern Modal System - Facebook Style */
 
-/* Base modal styles */
+/* ✅ AÑADIDO: Definición de variables de color para asegurar que siempre estén disponibles */
+:root {
+  --crunevo-white: #FFFFFF;
+  --crunevo-black: #1a1a1a;
+  --crunevo-primary: #6D28D9;
+  --crunevo-accent: #8B5CF6;
+  --crunevo-text-dark: #1C1E21;
+  --crunevo-text-light: #E4E6EA;
+  --crunevo-bg-light: #F0F2F5;
+  --crunevo-border: #CED4DA;
+}
+
+[data-bs-theme="dark"] {
+  --crunevo-white: #242526;
+  --crunevo-black: #FFFFFF;
+  --crunevo-primary: #8B5CF6;
+  --crunevo-accent: #6D28D9;
+  --crunevo-text-dark: #E4E6EA;
+  --crunevo-text-light: #B0B3B8;
+  --crunevo-bg-light: #3A3B3C;
+  --crunevo-border: #3A3B3C;
+}
+/* FIN DE LA CORRECCIÓN */
+
 .photo-modal-open {
   overflow: hidden;
 }
@@ -8,12 +31,14 @@
 .image-modal {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.95);
+  background: rgba(20, 20, 20, 0.9);
   z-index: 9999;
   display: flex;
+  align-items: center;
+  justify-content: center;
   opacity: 1;
   transition: opacity 0.3s ease;
-  backdrop-filter: blur(4px);
+  backdrop-filter: blur(8px);
 }
 
 .image-modal.hidden {
@@ -21,86 +46,28 @@
   pointer-events: none;
 }
 
-/* Facebook-style Modal Container */
-.modal-container {
-  display: grid;
-  grid-template-columns: 1fr 400px;
-  width: 100%;
-  height: 100%;
-  max-height: 100vh;
-}
-
-/* For comments-only modal (no image) */
-.modal-container.comments-only {
-  grid-template-columns: 1fr;
-  max-width: 600px;
-  margin: 0 auto;
-  background: var(--crunevo-white);
-  border-radius: 12px;
-  overflow: hidden;
-}
-
-[data-bs-theme="dark"] .modal-container.comments-only {
-  background: #242526;
-}
-
-/* Image section */
-.modal-image-section {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: #000;
-  overflow: hidden;
-}
-
-.modal-container.comments-only .modal-image-section {
-  display: none;
-}
-
-#modalImage {
-  max-width: 100%;
-  max-height: 100%;
-  object-fit: contain;
-  cursor: grab;
-  transition: transform 0.3s ease;
-  user-select: none;
-}
-
-#modalImage:active {
-  cursor: grabbing;
-}
-
-/* Facebook Modal Containers */
+/* ✅ CORREGIDO: Usaremos una sola clase base y modificadores */
 .facebook-modal-container {
   display: grid;
-  grid-template-columns: 1fr 400px;
-  width: 100%;
-  height: 100%;
+  width: calc(100% - 40px);
+  height: calc(100% - 40px);
+  max-height: 95vh;
+  border-radius: 12px;
+  overflow: hidden;
   background: var(--crunevo-white);
   color: var(--crunevo-text-dark);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.2);
 }
 
-.facebook-modal-container.image-only {
-  grid-template-columns: 1fr;
-  background: #000;
+.facebook-modal-container.image-with-comments {
+  grid-template-columns: 1fr 400px;
+  max-width: 1300px;
 }
 
 .facebook-modal-container.comments-only {
   grid-template-columns: 1fr;
-  max-width: 600px;
-  margin: 0 auto;
-  border-radius: 12px;
-  overflow: hidden;
-}
-
-[data-bs-theme="dark"] .facebook-modal-container {
-  background: #242526;
-  color: #E4E6EA;
-}
-
-[data-bs-theme="dark"] .facebook-modal-container.image-only {
-  background: #000;
+  max-width: 680px;
+  max-height: 90vh;
 }
 
 /* Image Section */
@@ -141,10 +108,6 @@
   background: var(--crunevo-white);
   border-left: 1px solid #E4E6EA;
   overflow: hidden;
-}
-
-.facebook-modal-container.image-only .facebook-modal-info-panel {
-  display: none;
 }
 
 .facebook-modal-container.comments-only .facebook-modal-info-panel {
@@ -605,7 +568,6 @@
 
 /* Responsive Design */
 @media (max-width: 768px) {
-  .modal-container,
   .facebook-modal-container {
     grid-template-columns: 1fr;
     grid-template-rows: 60vh auto;

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -612,18 +612,7 @@ class ModernFeedManager {
   handleModalKeydown(e) {
     if (!this.currentPostId) return;
     if (e.key === 'Escape') {
-      this.closeImageModal();
-    } else if (e.key === 'ArrowRight') {
-      this.nextImage();
-    } else if (e.key === 'ArrowLeft') {
-      this.prevImage();
-    } else if (e.key === '+') {
-      this.zoomIn();
-    } else if (e.key === '-') {
-      this.zoomOut();
-    } else if (e.key === ' ') {
-      e.preventDefault();
-      this.resetZoom();
+      this.closeModal();
     }
   }
 
@@ -645,10 +634,15 @@ class ModernFeedManager {
 
     this.currentImageIndex = index;
     this.currentPostId = postId;
-    this.currentScale = 1;
 
     this.prevUrlStack.push(window.location.href);
-    this.createImageModal(src, index);
+    this.createModal('image-with-comments', postId);
+    setTimeout(() => {
+      const imgEl = document.getElementById('modalMainImage');
+      if (imgEl) {
+        imgEl.src = src;
+      }
+    }, 50);
     window.history.pushState({ modal: true }, '', `/feed/post/${postId}/photo/${index + 1}`);
     if (this.prevUrlStack.length === 1) {
       window.addEventListener('popstate', this.handlePopState);
@@ -659,134 +653,65 @@ class ModernFeedManager {
   openCommentsModal(postId) {
     this.currentPostId = postId;
     this.prevUrlStack.push(window.location.href);
-    this.createCommentsModal(postId);
+    this.createModal('comments-only', postId);
     window.history.pushState({ modal: true }, '', `/feed/post/${postId}/comments`);
     if (this.prevUrlStack.length === 1) {
       window.addEventListener('popstate', this.handlePopState);
     }
   }
 
-  // Create comments modal (Facebook-style)
-  createCommentsModal(postId) {
-    const modal = document.createElement('div');
-    modal.id = 'facebookModal';
-    modal.className = 'image-modal hidden';
-    modal.setAttribute('role', 'dialog');
-    modal.setAttribute('aria-modal', 'true');
-    modal.setAttribute('aria-labelledby', 'facebookModalLabel');
-    modal.setAttribute('tabindex', '-1');
+  // ✅ NUEVA FUNCIÓN UNIFICADA para crear el modal
+  createModal(type, postId) {
+    this.closeModal();
 
-    modal.innerHTML = `
-      <div class="modal-container comments-only" onclick="modernFeedManager.outsideModalClick(event)">
-        <h2 id="facebookModalLabel" class="visually-hidden">Comentarios del post</h2>
-        <div class="facebook-modal-info-panel" id="facebookModalInfo">
-          <div class="d-flex justify-content-center align-items-center h-100">
-            <div class="spinner-border text-primary"></div>
-          </div>
+    const modalWrapper = document.createElement('div');
+    modalWrapper.id = 'facebookModal';
+    modalWrapper.className = 'image-modal hidden';
+    modalWrapper.setAttribute('role', 'dialog');
+    modalWrapper.setAttribute('tabindex', '-1');
+
+    modalWrapper.addEventListener('click', (e) => {
+      if (e.target.id === 'facebookModal') {
+        this.closeModal();
+      }
+    });
+
+    const modalContainer = document.createElement('div');
+    modalContainer.className = `facebook-modal-container ${type}`;
+
+    let innerHTML = '';
+
+    if (type === 'image-with-comments') {
+      innerHTML = `
+      <div class="facebook-modal-image-section">
+        <div class="modal-image-container">
+          <img id="modalMainImage" src="" alt="Imagen del post" class="modal-main-image">
         </div>
-      </div>`;
+      </div>
+      <div class="facebook-modal-info-panel" id="facebookModalInfoPanel">
+        <div class="modal-loading"><div class="spinner-border"></div></div>
+      </div>
+    `;
+    } else if (type === 'comments-only') {
+      innerHTML = `
+      <div class="facebook-modal-info-panel" id="facebookModalInfoPanel">
+        <div class="modal-loading"><div class="spinner-border"></div></div>
+      </div>
+    `;
+    }
 
-    document.body.appendChild(modal);
-    modal.focus();
+    modalContainer.innerHTML = innerHTML;
+    modalWrapper.appendChild(modalContainer);
+    document.body.appendChild(modalWrapper);
     document.body.classList.add('photo-modal-open');
 
-    setTimeout(() => modal.classList.remove('hidden'), 10);
-    this.loadPostDataForModal(postId, true);
+    setTimeout(() => modalWrapper.classList.remove('hidden'), 10);
+
+    this.loadPostDataForModal(postId);
   }
 
-  // Create image modal
-  createImageModal(src, index) {
-    const modal = document.createElement('div');
-    modal.id = 'imageModal';
-    modal.className = 'image-modal hidden';
-    modal.setAttribute('role', 'dialog');
-    modal.setAttribute('aria-modal', 'true');
-    modal.setAttribute('aria-labelledby', 'imageModalLabel');
-    modal.setAttribute('tabindex', '-1');
-
-    const hasMultiple = this.imageList.length > 1;
-    modal.innerHTML = `
-      <div class="modal-container" onclick="modernFeedManager.outsideImageClick(event)">
-        <h2 id="imageModalLabel" class="visually-hidden">Visor de imagen</h2>
-        <div class="modal-image-section">
-          <img id="modalImage" src="${src}" alt="Imagen ${index + 1}">
-          <div class="modal-top-controls">
-            <button type="button" class="modal-control-btn" onclick="modernFeedManager.zoomOut()" title="Reducir zoom" aria-label="Reducir zoom"><i class="bi bi-dash"></i></button>
-            <button type="button" class="modal-control-btn" onclick="modernFeedManager.zoomIn()" title="Aumentar zoom" aria-label="Aumentar zoom"><i class="bi bi-plus"></i></button>
-            <button type="button" class="modal-control-btn" onclick="modernFeedManager.resetZoom()" title="Tamaño original" aria-label="Tamaño original"><i class="bi bi-arrows-fullscreen"></i></button>
-            <a href="${src}" target="_blank" class="modal-control-btn" title="Abrir en nueva pestaña" aria-label="Abrir en nueva pestaña"><i class="bi bi-box-arrow-up-right"></i></a>
-            <button type="button" class="modal-control-btn" onclick="modernFeedManager.closeImageModal()" title="Cerrar" aria-label="Cerrar"><i class="bi bi-x"></i></button>
-          </div>
-          ${hasMultiple ? `
-            <button type="button" class="modal-nav prev" onclick="modernFeedManager.prevImage()" aria-label="Imagen anterior" ${index === 0 ? 'style="opacity:0.5"' : ''}><i class="bi bi-chevron-left"></i></button>
-            <button type="button" class="modal-nav next" onclick="modernFeedManager.nextImage()" aria-label="Imagen siguiente" ${index === this.imageList.length - 1 ? 'style="opacity:0.5"' : ''}><i class="bi bi-chevron-right"></i></button>
-          ` : ''}
-          <div class="modal-counter" id="modalCounter">${index + 1} / ${this.imageList.length}</div>
-        </div>
-        <div class="modal-info-section" id="imageModalInfo">
-          <div class="d-flex justify-content-center align-items-center h-100">
-            <div class="spinner-border text-primary"></div>
-          </div>
-        </div>
-      </div>`;
-
-    document.body.appendChild(modal);
-    modal.focus();
-    document.body.classList.add('photo-modal-open');
-
-    this.modalImageEl = modal.querySelector('#modalImage');
-    this.modalImageEl.addEventListener('wheel', (e) => this.handleWheel(e), { passive: false });
-    this.modalImageEl.addEventListener('touchstart', (e) => this.handleTouchStart(e));
-    this.modalImageEl.addEventListener('touchend', (e) => this.handleTouchEnd(e));
-
-    setTimeout(() => modal.classList.remove('hidden'), 10);
-    this.loadPostDataForModal(this.currentPostId);
-  }
-
-  // Close image modal
-  closeImageModal(fromPopState = false) {
-    const modal = document.getElementById('imageModal');
-    if (modal) {
-      modal.classList.add('hidden');
-      setTimeout(() => {
-        modal.remove();
-        if (!document.getElementById('facebookModal')) {
-          document.body.classList.remove('photo-modal-open');
-        }
-      }, 300);
-    }
-
-    if (this.modalImageEl) {
-      this.modalImageEl.removeEventListener('wheel', this.handleWheel);
-      this.modalImageEl.removeEventListener('touchstart', this.handleTouchStart);
-      this.modalImageEl.removeEventListener('touchend', this.handleTouchEnd);
-    }
-    this.modalImageEl = null;
-    this.currentScale = 1;
-
-    if (!document.getElementById('facebookModal')) {
-      this.currentPostId = null;
-    }
-    this.currentImageIndex = 0;
-    this.imageList = [];
-
-    this.popModalHistory(fromPopState);
-  }
-
-  // Close modal (generic)
+  // ✅ FUNCIÓN UNIFICADA para cerrar cualquier modal
   closeModal(fromPopState = false) {
-    const imageModal = document.getElementById('imageModal');
-    const facebookModal = document.getElementById('facebookModal');
-
-    if (imageModal) {
-      this.closeImageModal(fromPopState);
-    } else if (facebookModal) {
-      this.closeCommentsModal(fromPopState);
-    }
-  }
-
-  // Close comments modal
-  closeCommentsModal(fromPopState = false) {
     const modal = document.getElementById('facebookModal');
     if (modal) {
       modal.classList.add('hidden');
@@ -795,9 +720,7 @@ class ModernFeedManager {
         document.body.classList.remove('photo-modal-open');
       }, 300);
     }
-
     this.currentPostId = null;
-
     this.popModalHistory(fromPopState);
   }
 
@@ -821,135 +744,36 @@ class ModernFeedManager {
     }
   }
 
-  // Handle outside modal click
-  outsideModalClick(e) {
-    if (e.target.classList.contains('modal-container')) {
-      this.closeModal();
-    }
-  }
+  // Placeholder methods for future image navigation/zoom features
+  nextImage() {}
+  prevImage() {}
+  updateModalImage() {}
+  handleWheel() {}
+  handleTouchStart() {}
+  handleTouchEnd() {}
+  handleSwipe() {}
+  applyZoom() {}
+  zoomIn() {}
+  zoomOut() {}
+  resetZoom() {}
 
-  // Navigate to next image
-  nextImage() {
-    if (this.currentImageIndex < this.imageList.length - 1) {
-      this.currentImageIndex++;
-      this.updateModalImage();
-    }
-  }
-
-  // Navigate to previous image
-  prevImage() {
-    if (this.currentImageIndex > 0) {
-      this.currentImageIndex--;
-      this.updateModalImage();
-    }
-  }
-
-  // Update modal image
-  updateModalImage() {
-    const modal = document.getElementById('imageModal');
-    if (!modal) return;
-
-    const img = modal.querySelector('#modalImage');
-    const counter = modal.querySelector('.modal-counter');
-    const prevBtn = modal.querySelector('.modal-nav.prev');
-    const nextBtn = modal.querySelector('.modal-nav.next');
-
-    if (img) {
-      img.src = this.imageList[this.currentImageIndex];
-      img.alt = `Imagen ${this.currentImageIndex + 1}`;
-    }
-
-    if (counter) {
-      counter.textContent = `${this.currentImageIndex + 1} / ${this.imageList.length}`;
-    }
-
-    if (prevBtn) {
-      prevBtn.disabled = this.currentImageIndex === 0;
-    }
-
-    if (nextBtn) {
-      nextBtn.disabled = this.currentImageIndex === this.imageList.length - 1;
-    }
-
-    // Update URL
-    if (this.currentPostId) {
-      window.history.replaceState({ photo: true }, '', `/feed/post/${this.currentPostId}/photo/${this.currentImageIndex + 1}`);
-    }
-  }
-
-  handleWheel(e) {
-    e.preventDefault();
-    if (e.deltaY < 0) {
-      this.zoomIn();
-    } else {
-      this.zoomOut();
-    }
-  }
-
-  handleTouchStart(e) {
-    this.touchStartX = e.changedTouches[0].screenX;
-  }
-
-  handleTouchEnd(e) {
-    this.touchEndX = e.changedTouches[0].screenX;
-    this.handleSwipe();
-  }
-
-  handleSwipe() {
-    const diff = this.touchStartX - this.touchEndX;
-    if (Math.abs(diff) > 50) {
-      if (diff > 0) {
-        this.nextImage();
-      } else {
-        this.prevImage();
-      }
-    }
-  }
-
-  applyZoom() {
-    if (this.modalImageEl) {
-      this.modalImageEl.style.transform = `scale(${this.currentScale})`;
-    }
-  }
-
-  zoomIn() {
-    this.currentScale = Math.min(3, this.currentScale + 0.2);
-    this.applyZoom();
-  }
-
-  zoomOut() {
-    this.currentScale = Math.max(0.2, this.currentScale - 0.2);
-    this.applyZoom();
-  }
-
-  resetZoom() {
-    this.currentScale = 1;
-    this.applyZoom();
-  }
-
-  outsideImageClick(e) {
-    if (e.target.id === 'imageModal') {
-      this.closeImageModal();
-    }
-  }
-
-  loadPostDataForModal(postId, commentsOnly = false) {
+  loadPostDataForModal(postId) {
     fetch(`/feed/api/post/${postId}`)
       .then(r => r.json())
       .then(data => {
-        const targetId = commentsOnly ? 'facebookModalInfo' : 'imageModalInfo';
-        const info = document.getElementById(targetId);
-        if (info && data.html) {
-          info.innerHTML = data.html;
-          this.initPostInteractions();
-          this.initCommentSystem();
+        const infoPanel = document.getElementById('facebookModalInfoPanel');
+        if (infoPanel && data.html) {
+          infoPanel.innerHTML = data.html;
           this.initCommentInput();
+          this.initPostInteractions();
         }
       })
-      .catch(() => {
-        const targetId = commentsOnly ? 'facebookModalInfo' : 'imageModalInfo';
-        const info = document.getElementById(targetId);
-        if (info) info.innerHTML = '<div class="text-center text-muted p-3">Error al cargar información del post</div>';
+      .catch(error => {
+        console.error('Error al cargar datos del modal:', error);
+        const infoPanel = document.getElementById('facebookModalInfoPanel');
+        if (infoPanel) {
+          infoPanel.innerHTML = '<div class="text-center text-danger p-4">No se pudo cargar el contenido del post.</div>';
+        }
       });
   }
 

--- a/crunevo/templates/feed/_post_modal.html
+++ b/crunevo/templates/feed/_post_modal.html
@@ -1,496 +1,118 @@
-
 {% import 'components/csrf.html' as csrf %}
-{% import 'components/image_gallery.html' as gallery %}
 {% set saved_posts = saved_posts if saved_posts is defined else {} %}
 
-<!-- Modal Principal Estilo Facebook -->
-<div class="facebook-modal-container">
-  <!-- Sección de Imagen (solo visible cuando hay imágenes) -->
-  <div class="facebook-modal-image-section" id="modalImageSection">
-    {% if post.images %}
-      {{ gallery.image_gallery(post.images, post.id, modal_view=true) }}
-    {% elif post.file_url and not post.file_url.endswith('.pdf') %}
-      <div class="modal-image-container">
-        <img src="{{ post.file_url }}" alt="Imagen de la publicación" class="modal-main-image" id="modalMainImage">
-      </div>
-    {% endif %}
+<div class="modal-post-header">
+  <img src="{{ post.author.avatar_url or url_for('static', filename='img/default.png') }}" alt="Avatar de {{ post.author.username }}" class="modal-post-avatar">
+  <div class="modal-user-info">
+    <h6 class="modal-username">{{ post.author.username }}</h6>
+    {% if post.author.career %}<span class="modal-career-badge">{{ post.author.career }}</span>{% endif %}
+    <small class="modal-timestamp">{{ post.created_at|timesince }}</small>
   </div>
+  <button type="button" class="modal-close-btn" onclick="modernFeedManager.closeModal()" aria-label="Cerrar">
+    <i class="bi bi-x"></i>
+  </button>
+</div>
 
-  <!-- Panel de Información y Comentarios -->
-  <div class="facebook-modal-info-panel">
-    <!-- Header del Post -->
-    <div class="modal-post-header">
-      <img src="{{ post.author.avatar_url or url_for('static', filename='img/default.png') }}"
-           alt="Avatar de {{ post.author.username }}"
-           class="modal-post-avatar">
-      <div class="modal-user-info">
-        <h6 class="modal-username">{{ post.author.username }}</h6>
-        {% if post.author.career %}
-        <span class="modal-career-badge">{{ post.author.career }}</span>
-        {% endif %}
-        <small class="modal-timestamp">{{ post.created_at|timesince }}</small>
-      </div>
-      <button type="button" class="modal-close-btn" onclick="modernFeedManager.closeModal()" aria-label="Cerrar">
-        <i class="bi bi-x"></i>
-      </button>
-    </div>
+{% if post.content %}
+<div class="modal-post-content">
+  <p class="modal-post-text">{{ post.content }}</p>
+</div>
+{% endif %}
 
-    <!-- Contenido del Post -->
-    {% if post.content %}
-    <div class="modal-post-content">
-      <p class="modal-post-text">{{ post.content }}</p>
+<div class="modal-post-actions">
+  <div class="relative reaction-container" data-post-id="{{ post.id }}" data-my-reaction="{{ user_reaction or '' }}">
+    <button class="modal-action-btn like-btn {{ 'active' if user_reaction else '' }}" data-post-id="{{ post.id }}">
+      <i class="bi bi-fire{{ '-fill' if user_reaction else '' }}"></i>
+      <span class="action-text">Me gusta</span>
+      <span class="action-count">{{ reaction_counts.get('🔥', '') if reaction_counts else '' }}</span>
+    </button>
+    <div class="reaction-panel d-none">
+      <button class="reaction-btn" data-reaction="🔥" title="Crunazo">🔥</button>
+      <button class="reaction-btn" data-reaction="🧠" title="Neuro">🧠</button>
+      <button class="reaction-btn" data-reaction="💔" title="Roto">💔</button>
+      <button class="reaction-btn" data-reaction="😠" title="Molesto">😠</button>
+      <button class="reaction-btn" data-reaction="🥶" title="Congelao">🥶</button>
+      <button class="reaction-btn" data-reaction="😂" title="Vacilón">😂</button>
+      <button class="reaction-btn" data-reaction="🤡" title="Cringe">🤡</button>
+      <button class="reaction-btn" data-reaction="😲" title="Asu">😲</button>
+      <button class="reaction-btn" data-reaction="👍" title="Me gusta">👍</button>
+      <button class="reaction-btn" data-reaction="💡" title="Interesante">💡</button>
+      <button class="reaction-btn" data-reaction="🙌" title="Gracias">🙌</button>
+      <button class="reaction-btn" data-reaction="📌" title="Lo guardé">📌</button>
     </div>
-    {% endif %}
+  </div>
+  <button class="modal-action-btn comment-btn" data-post-id="{{ post.id }}">
+    <i class="bi bi-chat"></i>
+    <span>Comentar</span>
+  </button>
+  <button class="modal-action-btn share-btn" data-post-id="{{ post.id }}">
+    <i class="bi bi-share"></i>
+    <span>Compartir</span>
+  </button>
+  <button class="modal-action-btn save-btn {{ 'active' if saved_posts.get(post.id) }}" data-post-id="{{ post.id }}">
+    <i class="bi bi-bookmark{{ '-fill' if saved_posts.get(post.id) else '' }}"></i>
+    <span>Guardar</span>
+  </button>
+</div>
 
-    <!-- Acciones del Post -->
-    <div class="modal-post-actions">
-      <div class="relative reaction-container" data-post-id="{{ post.id }}" data-my-reaction="{{ user_reaction or '' }}">
-        <button class="modal-action-btn like-btn {{ 'active' if user_reaction else '' }}" data-post-id="{{ post.id }}">
-          <i class="bi bi-fire{{ '-fill' if user_reaction else '' }}"></i>
-          <span class="action-text">Me gusta</span>
-          <span class="action-count">{{ reaction_counts.get('🔥', '') if reaction_counts else '' }}</span>
-        </button>
-        <div class="reaction-panel d-none">
-          <button class="reaction-btn" data-reaction="🔥" title="Crunazo">🔥</button>
-          <button class="reaction-btn" data-reaction="🧠" title="Neuro">🧠</button>
-          <button class="reaction-btn" data-reaction="💔" title="Roto">💔</button>
-          <button class="reaction-btn" data-reaction="😠" title="Molesto">😠</button>
-          <button class="reaction-btn" data-reaction="🥶" title="Congelao">🥶</button>
-          <button class="reaction-btn" data-reaction="😂" title="Vacilón">😂</button>
-          <button class="reaction-btn" data-reaction="🤡" title="Cringe">🤡</button>
-          <button class="reaction-btn" data-reaction="😲" title="Asu">😲</button>
-          <button class="reaction-btn" data-reaction="👍" title="Me gusta">👍</button>
-          <button class="reaction-btn" data-reaction="💡" title="Interesante">💡</button>
-          <button class="reaction-btn" data-reaction="🙌" title="Gracias">🙌</button>
-          <button class="reaction-btn" data-reaction="📌" title="Lo guardé">📌</button>
-        </div>
-      </div>
-      <button class="modal-action-btn comment-btn" data-post-id="{{ post.id }}">
-        <i class="bi bi-chat"></i>
-        <span>Comentar</span>
-      </button>
-      <button class="modal-action-btn share-btn" data-post-id="{{ post.id }}">
-        <i class="bi bi-share"></i>
-        <span>Compartir</span>
-      </button>
-      <button class="modal-action-btn save-btn {{ 'active' if saved_posts.get(post.id) }}" data-post-id="{{ post.id }}">
-        <i class="bi bi-bookmark{{ '-fill' if saved_posts.get(post.id) else '' }}"></i>
-        <span>Guardar</span>
-      </button>
-    </div>
-
-    <!-- Estadísticas -->
-    <div class="modal-stats">
-      <div class="modal-stat-item">
-        <i class="bi bi-fire-fill text-danger"></i>
-        <span>{{
-          (reaction_counts.get('🔥', 0) + reaction_counts.get('🧠', 0) +
-          reaction_counts.get('💔', 0) + reaction_counts.get('😠', 0) +
-          reaction_counts.get('🥶', 0) + reaction_counts.get('😂', 0) +
-          reaction_counts.get('🤡', 0) + reaction_counts.get('😲', 0) +
-          reaction_counts.get('👍', 0) + reaction_counts.get('💡', 0) +
-          reaction_counts.get('🙌', 0) + reaction_counts.get('📌', 0)) if reaction_counts else 0
-        }} reacciones</span>
-      </div>
-      <div class="modal-stat-item">
-        <i class="bi bi-chat"></i>
-        <span>{{ post.comments|length }} comentarios</span>
-      </div>
-    </div>
-
-    <!-- Sección de Comentarios Scrollable -->
-    <div class="modal-comments-section">
-      {% set comments = comments if comments is defined else post.comments %}
-      {% set more_comments = post.comments|length > comments|length %}
-      <div class="comments-list" id="commentsList-{{ post.id }}">
-        {% if comments %}
-          {% for comment in comments %}
-          <div class="comment-item">
-            <img src="{{ comment.author.avatar_url or url_for('static', filename='img/default.png') }}"
-                 alt="{{ comment.author.username if comment.author else 'Usuario' }}"
-                 class="comment-avatar">
-            <div class="comment-content">
-              <div class="comment-box">
-                <div class="comment-author">{{ comment.author.username if comment.author else 'Usuario eliminado' }}</div>
-                <div class="comment-text">{{ comment.body }}</div>
-              </div>
-              <div class="comment-meta">
-                <small class="text-muted">{{ comment.timestamp|timesince }}</small>
-                <button class="btn btn-link btn-sm p-0 ms-2 text-muted">Responder</button>
-              </div>
-            </div>
-          </div>
-          {% endfor %}
-        {% else %}
-          <div class="empty-comments">
-            <i class="bi bi-chat-dots"></i>
-            <p>Sé el primero en comentar</p>
-          </div>
-        {% endif %}
-      </div>
-      {% if more_comments %}
-      <div class="text-center my-2">
-        <button class="btn btn-link load-more-comments" data-post-id="{{ post.id }}" data-page="2">Cargar más comentarios</button>
-      </div>
-      {% endif %}
-    </div>
-
-    <!-- Formulario de Comentarios Fijo -->
-    <div class="modal-comment-form">
-      {% if current_user.is_authenticated %}
-      <form class="comment-form" data-post-id="{{ post.id }}" onsubmit="submitModalComment(event, '{{ post.id }}')">
-        {{ csrf.csrf_field() }}
-        <div class="comment-input-group">
-          <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}"
-               alt="{{ current_user.username }}"
-               class="comment-form-avatar">
-          <div class="comment-input-wrapper">
-            <input type="text" 
-                   class="comment-input" 
-                   placeholder="Escribe un comentario..." 
-                   name="body">
-            <button type="submit" class="comment-submit-btn" disabled>
-              <i class="bi bi-send-fill"></i>
-            </button>
-          </div>
-        </div>
-      </form>
-      {% else %}
-      <div class="text-center p-3">
-        <a href="{{ url_for('auth.login') }}" class="btn btn-primary">Inicia sesión para comentar</a>
-      </div>
-      {% endif %}
-    </div>
+<div class="modal-stats">
+  <div class="modal-stat-item">
+    <i class="bi bi-fire-fill text-danger"></i>
+    <span>{{
+      (reaction_counts.get('🔥', 0) + reaction_counts.get('🧠', 0) +
+      reaction_counts.get('💔', 0) + reaction_counts.get('😠', 0) +
+      reaction_counts.get('🥶', 0) + reaction_counts.get('😂', 0) +
+      reaction_counts.get('🤡', 0) + reaction_counts.get('😲', 0) +
+      reaction_counts.get('👍', 0) + reaction_counts.get('💡', 0) +
+      reaction_counts.get('🙌', 0) + reaction_counts.get('📌', 0)) if reaction_counts else 0
+    }} reacciones</span>
+  </div>
+  <div class="modal-stat-item">
+    <i class="bi bi-chat"></i>
+    <span>{{ post.comments|length }} comentarios</span>
   </div>
 </div>
 
-<style>
-.facebook-modal-container {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  background: var(--crunevo-white);
-  color: var(--crunevo-text-dark);
-}
+<div class="modal-comments-section">
+  {% set comments = comments if comments is defined else post.comments %}
+  {% set more_comments = post.comments|length > comments|length %}
+  <div class="comments-list" id="commentsList-{{ post.id }}">
+    {% if comments %}
+      {% for comment in comments %}
+      <div class="comment-item">
+        <img src="{{ comment.author.avatar_url or url_for('static', filename='img/default.png') }}"
+             alt="{{ comment.author.username if comment.author else 'Usuario' }}"
+             class="comment-avatar">
+        <div class="comment-content">
+          <div class="comment-box">
+            <div class="comment-author">{{ comment.author.username if comment.author else 'Usuario eliminado' }}</div>
+            <div class="comment-text">{{ comment.body }}</div>
+          </div>
+          <div class="comment-meta">
+            <small class="text-muted">{{ comment.timestamp|timesince }}</small>
+            <button class="btn btn-link btn-sm p-0 ms-2 text-muted">Responder</button>
+          </div>
+        </div>
+      </div>
+      {% endfor %}
+    {% else %}
+      <div class="text-muted text-center py-3">Sé el primero en comentar</div>
+    {% endif %}
+  </div>
+  {% if more_comments %}
+  <button class="btn btn-link btn-sm w-100 mb-3 load-more-comments" data-post-id="{{ post.id }}">Ver más comentarios</button>
+  {% endif %}
+</div>
 
-.facebook-modal-image-section {
-  flex-shrink: 0;
-  padding: 20px;
-  border-bottom: 1px solid var(--crunevo-border);
-  background: var(--crunevo-bg-light);
-}
-
-.facebook-modal-info-panel {
-  flex-grow: 1;
-  display: flex;
-  flex-direction: column;
-  padding: 20px;
-  overflow-y: auto;
-}
-
-.modal-post-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 15px 0;
-  border-bottom: 1px solid var(--crunevo-border);
-}
-
-.modal-post-avatar {
-  width: 48px;
-  height: 48px;
-  border-radius: 50%;
-  border: 2px solid var(--crunevo-primary);
-  object-fit: cover;
-}
-
-.modal-user-info {
-  flex: 1;
-}
-
-.modal-username {
-  margin: 0;
-  font-weight: 600;
-  font-size: 16px;
-  color: var(--crunevo-text-dark);
-}
-
-.modal-career-badge {
-  display: inline-block;
-  background: var(--crunevo-accent);
-  color: white;
-  font-size: 11px;
-  padding: 2px 8px;
-  border-radius: 12px;
-  margin-left: 8px;
-  font-weight: 500;
-}
-
-.modal-timestamp {
-  display: block;
-  font-size: 13px;
-  color: #65676B;
-  margin-top: 2px;
-}
-
-.modal-post-content {
-  padding: 20px 0;
-  border-bottom: 1px solid var(--crunevo-border);
-}
-
-.modal-post-text {
-  font-size: 15px;
-  line-height: 1.5;
-  color: var(--crunevo-text-dark);
-  margin: 0;
-  word-wrap: break-word;
-}
-
-.modal-post-actions {
-  display: flex;
-  padding: 12px 0;
-  border-bottom: 1px solid var(--crunevo-border);
-  gap: 8px;
-}
-
-.modal-action-btn {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  padding: 10px 12px;
-  border: none;
-  background: transparent;
-  color: #65676B;
-  border-radius: 8px;
-  font-weight: 500;
-  font-size: 14px;
-  cursor: pointer;
-  transition: var(--crunevo-transition);
-}
-
-.modal-action-btn:hover {
-  background: var(--crunevo-hover);
-  color: var(--crunevo-primary);
-}
-
-.modal-action-btn.active {
-  color: var(--crunevo-primary);
-  background: var(--crunevo-hover);
-}
-
-.modal-action-btn i {
-  font-size: 16px;
-}
-
-.modal-stats {
-  display: flex;
-  gap: 24px;
-  padding: 12px 0;
-  border-bottom: 1px solid var(--crunevo-border);
-  font-size: 13px;
-}
-
-.modal-stat-item {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  color: #65676B;
-}
-
-.modal-comments-section {
-  flex-grow: 1;
-  padding: 20px 0;
-  overflow-y: auto;
-}
-
-.comments-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-.comment-item {
-  display: flex;
-  gap: 12px;
-  margin-bottom: 16px;
-}
-
-.comment-avatar {
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  object-fit: cover;
-  flex-shrink: 0;
-}
-
-.comment-content {
-  flex: 1;
-}
-
-.comment-box {
-  background: var(--crunevo-bg-light);
-  border-radius: 16px;
-  padding: 12px 16px;
-  margin-bottom: 4px;
-}
-
-[data-bs-theme="dark"] .comment-box {
-  background: #3A3B3C;
-}
-
-.comment-author {
-  font-weight: 600;
-  font-size: 13px;
-  color: var(--crunevo-text-dark);
-  margin-bottom: 4px;
-}
-
-.comment-text {
-  font-size: 14px;
-  line-height: 1.4;
-  color: var(--crunevo-text-dark);
-}
-
-.comment-meta {
-  display: flex;
-  align-items: center;
-  padding-left: 16px;
-}
-
-.empty-comments {
-  text-align: center;
-  padding: 40px 20px;
-}
-
-.empty-comments i {
-  font-size: 32px;
-  margin-bottom: 12px;
-  display: block;
-}
-
-.modal-comment-form {
-  padding: 16px 20px;
-  border-top: 1px solid var(--crunevo-border);
-}
-
-.comment-input-group {
-  display: flex;
-  align-items: flex-end;
-  gap: 12px;
-}
-
-.comment-form-avatar {
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  object-fit: cover;
-  flex-shrink: 0;
-}
-
-.comment-input-wrapper {
-  flex: 1;
-  position: relative;
-  display: flex;
-  align-items: center;
-  background: var(--crunevo-bg-light);
-  border-radius: 20px;
-  border: 1px solid var(--crunevo-border);
-  padding: 8px 12px;
-}
-
-[data-bs-theme="dark"] .comment-input-wrapper {
-  background: #3A3B3C;
-  border-color: #555;
-}
-
-.comment-input {
-  flex: 1;
-  border: none;
-  background: transparent;
-  font-size: 14px;
-  color: var(--crunevo-text-dark);
-  outline: none;
-  padding: 4px 8px;
-}
-
-.comment-input::placeholder {
-  color: #65676B;
-}
-
-.comment-submit-btn {
-  background: var(--crunevo-primary);
-  border: none;
-  border-radius: 50%;
-  width: 32px;
-  height: 32px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: white;
-  cursor: pointer;
-  transition: var(--crunevo-transition);
-  margin-left: 8px;
-}
-
-.comment-submit-btn:hover {
-  background: #5B21B6;
-  transform: scale(1.05);
-}
-
-.comment-submit-btn:disabled {
-  background: #ccc;
-  cursor: not-allowed;
-  transform: none;
-}
-
-.comment-submit-btn i {
-  font-size: 14px;
-}
-
-/* Responsive adjustments */
-@media (max-width: 768px) {
-  .facebook-modal-container {
-    flex-direction: column;
-    height: auto;
-  }
-
-  .facebook-modal-image-section {
-    padding: 16px;
-  }
-
-  .facebook-modal-info-panel {
-    padding: 16px;
-  }
-
-  .modal-post-header {
-    padding: 12px 0;
-  }
-
-  .modal-post-actions,
-  .modal-stats,
-  .modal-comment-form {
-    padding: 12px 0;
-  }
-  
-  .modal-action-btn {
-    padding: 8px 10px;
-    font-size: 13px;
-  }
-  
-  .modal-action-btn span {
-    display: none;
-  }
-  
-  .comment-input-wrapper {
-    padding: 6px 10px;
-  }
-  
-  .comment-submit-btn {
-    width: 28px;
-    height: 28px;
-  }
-}
-</style>
+<div class="modal-comment-form">
+  <form action="/feed/post/{{ post.id }}/comment" method="post" class="comment-form" data-post-id="{{ post.id }}">
+    {{ csrf.csrf_field() }}
+    <div class="comment-input-group">
+      <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" alt="Tu avatar" class="comment-form-avatar">
+      <div class="comment-input-wrapper">
+        <textarea class="comment-input" name="body" rows="1" placeholder="Escribe un comentario..." required></textarea>
+        <button type="submit" class="comment-submit-btn" disabled><i class="bi bi-send"></i></button>
+      </div>
+    </div>
+  </form>
+</div>


### PR DESCRIPTION
## Summary
- add color variables and unified Facebook-style modal container
- unify image/comments modals with createModal and closeModal helpers
- slim post modal template to panel content only

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688daa050d4083258720bfd449403a90