### PR TITLE
Refactor modal to Facebook style

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1051,3 +1051,6 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Fixed character counter on /foro/hacer-pregunta using Quill text content and ignoring punctuation, enabling 20-character validation without errors (PR forum-editor-charcount-bugfix).
 - Ensured /foro/hacer-pregunta editor enables "Siguiente" after 20 real characters by waiting for Quill initialization and using robust content validation (PR forum-editor-next-btn-fix).
 - Fixed modal navigation by managing history state with a stack and popstate listener, preventing unintended page back navigation when closing new Facebook-style modals (PR modal-history-fix).
+- Unified Facebook-style post modal: added color variables, refactored feed.js with createModal/closeModal helpers, and trimmed _post_modal.html to panel-only content (PR facebook-modal-refactor).
+- Full-screen Facebook-style modal restored zoom, navigation, download and options controls with scroll-safe info panel (PR facebook-modal-controls).
+- Introduced dual modal system: full-screen photo modal with advanced controls and restored Bootstrap comment modal, removing comments-only styles and logic (PR dual-modal-system).

--- a/crunevo/static/css/photo-modal.css
+++ b/crunevo/static/css/photo-modal.css
@@ -1,6 +1,29 @@
 /* CRUNEVO Modern Modal System - Facebook Style */
 
-/* Base modal styles */
+/* ✅ AÑADIDO: Definición de variables de color para asegurar que siempre estén disponibles */
+:root {
+  --crunevo-white: #FFFFFF;
+  --crunevo-black: #1a1a1a;
+  --crunevo-primary: #6D28D9;
+  --crunevo-accent: #8B5CF6;
+  --crunevo-text-dark: #1C1E21;
+  --crunevo-text-light: #E4E6EA;
+  --crunevo-bg-light: #F0F2F5;
+  --crunevo-border: #CED4DA;
+}
+
+[data-bs-theme="dark"] {
+  --crunevo-white: #242526;
+  --crunevo-black: #FFFFFF;
+  --crunevo-primary: #8B5CF6;
+  --crunevo-accent: #6D28D9;
+  --crunevo-text-dark: #E4E6EA;
+  --crunevo-text-light: #B0B3B8;
+  --crunevo-bg-light: #3A3B3C;
+  --crunevo-border: #3A3B3C;
+}
+/* FIN DE LA CORRECCIÓN */
+
 .photo-modal-open {
   overflow: hidden;
 }
@@ -8,12 +31,14 @@
 .image-modal {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.95);
+  background: rgba(20, 20, 20, 0.95);
   z-index: 9999;
   display: flex;
+  align-items: center;
+  justify-content: center;
   opacity: 1;
   transition: opacity 0.3s ease;
-  backdrop-filter: blur(4px);
+  backdrop-filter: blur(8px);
 }
 
 .image-modal.hidden {
@@ -21,86 +46,19 @@
   pointer-events: none;
 }
 
-/* Facebook-style Modal Container */
-.modal-container {
-  display: grid;
-  grid-template-columns: 1fr 400px;
-  width: 100%;
-  height: 100%;
-  max-height: 100vh;
-}
-
-/* For comments-only modal (no image) */
-.modal-container.comments-only {
-  grid-template-columns: 1fr;
-  max-width: 600px;
-  margin: 0 auto;
-  background: var(--crunevo-white);
-  border-radius: 12px;
-  overflow: hidden;
-}
-
-[data-bs-theme="dark"] .modal-container.comments-only {
-  background: #242526;
-}
-
-/* Image section */
-.modal-image-section {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: #000;
-  overflow: hidden;
-}
-
-.modal-container.comments-only .modal-image-section {
-  display: none;
-}
-
-#modalImage {
-  max-width: 100%;
-  max-height: 100%;
-  object-fit: contain;
-  cursor: grab;
-  transition: transform 0.3s ease;
-  user-select: none;
-}
-
-#modalImage:active {
-  cursor: grabbing;
-}
-
-/* Facebook Modal Containers */
+/* ✅ CORREGIDO: Usaremos una sola clase base y modificadores */
 .facebook-modal-container {
   display: grid;
-  grid-template-columns: 1fr 400px;
   width: 100%;
   height: 100%;
+  border-radius: 0;
+  overflow: hidden;
   background: var(--crunevo-white);
   color: var(--crunevo-text-dark);
 }
 
-.facebook-modal-container.image-only {
-  grid-template-columns: 1fr;
-  background: #000;
-}
-
-.facebook-modal-container.comments-only {
-  grid-template-columns: 1fr;
-  max-width: 600px;
-  margin: 0 auto;
-  border-radius: 12px;
-  overflow: hidden;
-}
-
-[data-bs-theme="dark"] .facebook-modal-container {
-  background: #242526;
-  color: #E4E6EA;
-}
-
-[data-bs-theme="dark"] .facebook-modal-container.image-only {
-  background: #000;
+.facebook-modal-container.image-with-comments {
+  grid-template-columns: 1fr 400px;
 }
 
 /* Image Section */
@@ -111,10 +69,6 @@
   justify-content: center;
   background: #000;
   overflow: hidden;
-}
-
-.facebook-modal-container.comments-only .facebook-modal-image-section {
-  display: none;
 }
 
 .modal-image-container {
@@ -143,21 +97,9 @@
   overflow: hidden;
 }
 
-.facebook-modal-container.image-only .facebook-modal-info-panel {
-  display: none;
-}
-
-.facebook-modal-container.comments-only .facebook-modal-info-panel {
-  border-left: none;
-}
-
 [data-bs-theme="dark"] .facebook-modal-info-panel {
   background: #242526;
   border-left: 1px solid #3A3B3C;
-}
-
-[data-bs-theme="dark"] .facebook-modal-container.comments-only .facebook-modal-info-panel {
-  border-left: none;
 }
 
 /* Post Header */
@@ -338,7 +280,6 @@
   flex-grow: 1;
   overflow-y: auto;
   padding: 0 20px;
-  max-height: calc(100vh - 400px);
 }
 
 .comments-list {
@@ -506,33 +447,34 @@
 }
 
 /* Modal Controls for Image-only view */
+
 .modal-top-controls {
   position: absolute;
-  top: 20px;
-  right: 20px;
+  top: 15px;
+  right: 15px;
   display: flex;
-  gap: 8px;
-  z-index: 10;
+  gap: 10px;
+  z-index: 100;
 }
 
 .modal-control-btn {
-  width: 44px;
-  height: 44px;
+  width: 40px;
+  height: 40px;
   border-radius: 50%;
-  background: rgba(255, 255, 255, 0.2);
+  background: rgba(30, 30, 30, 0.7);
   border: none;
   color: white;
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  transition: all 0.3s ease;
-  backdrop-filter: blur(10px);
+  transition: all 0.2s ease;
+  backdrop-filter: blur(5px);
   font-size: 18px;
 }
 
 .modal-control-btn:hover {
-  background: rgba(255, 255, 255, 0.3);
+  background: rgba(50, 50, 50, 0.9);
   transform: scale(1.1);
 }
 
@@ -605,17 +547,9 @@
 
 /* Responsive Design */
 @media (max-width: 768px) {
-  .modal-container,
   .facebook-modal-container {
     grid-template-columns: 1fr;
     grid-template-rows: 60vh auto;
-  }
-  
-  .facebook-modal-container.comments-only {
-    grid-template-rows: 1fr;
-    height: 100vh;
-    max-width: 100%;
-    border-radius: 0;
   }
   
   .facebook-modal-info-panel {

--- a/crunevo/static/js/comment.js
+++ b/crunevo/static/js/comment.js
@@ -1,15 +1,6 @@
 // Comment modal utilities
 
 function openCommentsModal(postId) {
-  // Deprecated: Use modernFeedManager.openCommentsModal() instead
-  console.warn('openCommentsModal() is deprecated. Use modernFeedManager.openCommentsModal() instead.');
-  
-  if (window.modernFeedManager && window.modernFeedManager.openCommentsModal) {
-    window.modernFeedManager.openCommentsModal(postId);
-    return;
-  }
-  
-  // Fallback to old Bootstrap modal
   const modal = new bootstrap.Modal(
     document.getElementById(`commentsModal-${postId}`)
   );

--- a/crunevo/templates/components/comment_modal.html
+++ b/crunevo/templates/components/comment_modal.html
@@ -2,24 +2,10 @@
 {% import 'components/csrf.html' as csrf %}
 {% set saved_posts = saved_posts if saved_posts is defined else {} %}
 
-{# ==========================================
-   ARCHIVO OBSOLETO - NO USAR
-   ==========================================
-   Este modal ha sido reemplazado por el nuevo sistema
-   estilo Facebook en _post_modal.html + feed.js
-   
-   Mantener solo para compatibilidad temporal.
-   TODO: Eliminar completamente después de migración.
-   ========================================== #}
-
-<!-- Modal de Comentarios con Galería Completa - OBSOLETO -->
+<!-- Modal de Comentarios -->
 <div class="modal fade" id="commentsModal-{{ post.id }}" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="commentsModalLabel-{{ post.id }}" aria-hidden="true" style="display: none;">
   <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable modal-fullscreen-sm-down">
     <div class="modal-content">
-      <div class="alert alert-warning m-3 mb-0">
-        <i class="bi bi-exclamation-triangle"></i>
-        <strong>Aviso:</strong> Este modal está obsoleto. Use el nuevo sistema estilo Facebook.
-      </div>
       <h5 id="commentsModalLabel-{{ post.id }}" class="visually-hidden">Comentarios</h5>
       <!-- Header del Modal -->
       <div class="modal-header border-0 pb-0">

--- a/crunevo/templates/components/post_card.html
+++ b/crunevo/templates/components/post_card.html
@@ -168,7 +168,7 @@
       </div>
     </div>
 
-    <button class="fb-action-btn comment-btn" data-post-id="{{ post.id }}" onclick="modernFeedManager.openCommentsModal('{{ post.id }}')">
+    <button class="fb-action-btn comment-btn" data-post-id="{{ post.id }}" onclick="openCommentsModal('{{ post.id }}')">
       <i class="bi bi-chat"></i>
       <span class="action-text">Comentar</span>
       <span class="action-count">{{ post.comments|length if post.comments|length > 0 else '' }}</span>

--- a/crunevo/templates/feed/_post_modal.html
+++ b/crunevo/templates/feed/_post_modal.html
@@ -1,496 +1,118 @@
-
 {% import 'components/csrf.html' as csrf %}
-{% import 'components/image_gallery.html' as gallery %}
 {% set saved_posts = saved_posts if saved_posts is defined else {} %}
 
-<!-- Modal Principal Estilo Facebook -->
-<div class="facebook-modal-container">
-  <!-- Sección de Imagen (solo visible cuando hay imágenes) -->
-  <div class="facebook-modal-image-section" id="modalImageSection">
-    {% if post.images %}
-      {{ gallery.image_gallery(post.images, post.id, modal_view=true) }}
-    {% elif post.file_url and not post.file_url.endswith('.pdf') %}
-      <div class="modal-image-container">
-        <img src="{{ post.file_url }}" alt="Imagen de la publicación" class="modal-main-image" id="modalMainImage">
-      </div>
-    {% endif %}
+<div class="modal-post-header">
+  <img src="{{ post.author.avatar_url or url_for('static', filename='img/default.png') }}" alt="Avatar de {{ post.author.username }}" class="modal-post-avatar">
+  <div class="modal-user-info">
+    <h6 class="modal-username">{{ post.author.username }}</h6>
+    {% if post.author.career %}<span class="modal-career-badge">{{ post.author.career }}</span>{% endif %}
+    <small class="modal-timestamp">{{ post.created_at|timesince }}</small>
   </div>
+  <button type="button" class="modal-close-btn" onclick="modernFeedManager.closeModal()" aria-label="Cerrar">
+    <i class="bi bi-x"></i>
+  </button>
+</div>
 
-  <!-- Panel de Información y Comentarios -->
-  <div class="facebook-modal-info-panel">
-    <!-- Header del Post -->
-    <div class="modal-post-header">
-      <img src="{{ post.author.avatar_url or url_for('static', filename='img/default.png') }}"
-           alt="Avatar de {{ post.author.username }}"
-           class="modal-post-avatar">
-      <div class="modal-user-info">
-        <h6 class="modal-username">{{ post.author.username }}</h6>
-        {% if post.author.career %}
-        <span class="modal-career-badge">{{ post.author.career }}</span>
-        {% endif %}
-        <small class="modal-timestamp">{{ post.created_at|timesince }}</small>
-      </div>
-      <button type="button" class="modal-close-btn" onclick="modernFeedManager.closeModal()" aria-label="Cerrar">
-        <i class="bi bi-x"></i>
-      </button>
-    </div>
+{% if post.content %}
+<div class="modal-post-content">
+  <p class="modal-post-text">{{ post.content }}</p>
+</div>
+{% endif %}
 
-    <!-- Contenido del Post -->
-    {% if post.content %}
-    <div class="modal-post-content">
-      <p class="modal-post-text">{{ post.content }}</p>
+<div class="modal-post-actions">
+  <div class="relative reaction-container" data-post-id="{{ post.id }}" data-my-reaction="{{ user_reaction or '' }}">
+    <button class="modal-action-btn like-btn {{ 'active' if user_reaction else '' }}" data-post-id="{{ post.id }}">
+      <i class="bi bi-fire{{ '-fill' if user_reaction else '' }}"></i>
+      <span class="action-text">Me gusta</span>
+      <span class="action-count">{{ reaction_counts.get('🔥', '') if reaction_counts else '' }}</span>
+    </button>
+    <div class="reaction-panel d-none">
+      <button class="reaction-btn" data-reaction="🔥" title="Crunazo">🔥</button>
+      <button class="reaction-btn" data-reaction="🧠" title="Neuro">🧠</button>
+      <button class="reaction-btn" data-reaction="💔" title="Roto">💔</button>
+      <button class="reaction-btn" data-reaction="😠" title="Molesto">😠</button>
+      <button class="reaction-btn" data-reaction="🥶" title="Congelao">🥶</button>
+      <button class="reaction-btn" data-reaction="😂" title="Vacilón">😂</button>
+      <button class="reaction-btn" data-reaction="🤡" title="Cringe">🤡</button>
+      <button class="reaction-btn" data-reaction="😲" title="Asu">😲</button>
+      <button class="reaction-btn" data-reaction="👍" title="Me gusta">👍</button>
+      <button class="reaction-btn" data-reaction="💡" title="Interesante">💡</button>
+      <button class="reaction-btn" data-reaction="🙌" title="Gracias">🙌</button>
+      <button class="reaction-btn" data-reaction="📌" title="Lo guardé">📌</button>
     </div>
-    {% endif %}
+  </div>
+  <button class="modal-action-btn comment-btn" data-post-id="{{ post.id }}">
+    <i class="bi bi-chat"></i>
+    <span>Comentar</span>
+  </button>
+  <button class="modal-action-btn share-btn" data-post-id="{{ post.id }}">
+    <i class="bi bi-share"></i>
+    <span>Compartir</span>
+  </button>
+  <button class="modal-action-btn save-btn {{ 'active' if saved_posts.get(post.id) }}" data-post-id="{{ post.id }}">
+    <i class="bi bi-bookmark{{ '-fill' if saved_posts.get(post.id) else '' }}"></i>
+    <span>Guardar</span>
+  </button>
+</div>
 
-    <!-- Acciones del Post -->
-    <div class="modal-post-actions">
-      <div class="relative reaction-container" data-post-id="{{ post.id }}" data-my-reaction="{{ user_reaction or '' }}">
-        <button class="modal-action-btn like-btn {{ 'active' if user_reaction else '' }}" data-post-id="{{ post.id }}">
-          <i class="bi bi-fire{{ '-fill' if user_reaction else '' }}"></i>
-          <span class="action-text">Me gusta</span>
-          <span class="action-count">{{ reaction_counts.get('🔥', '') if reaction_counts else '' }}</span>
-        </button>
-        <div class="reaction-panel d-none">
-          <button class="reaction-btn" data-reaction="🔥" title="Crunazo">🔥</button>
-          <button class="reaction-btn" data-reaction="🧠" title="Neuro">🧠</button>
-          <button class="reaction-btn" data-reaction="💔" title="Roto">💔</button>
-          <button class="reaction-btn" data-reaction="😠" title="Molesto">😠</button>
-          <button class="reaction-btn" data-reaction="🥶" title="Congelao">🥶</button>
-          <button class="reaction-btn" data-reaction="😂" title="Vacilón">😂</button>
-          <button class="reaction-btn" data-reaction="🤡" title="Cringe">🤡</button>
-          <button class="reaction-btn" data-reaction="😲" title="Asu">😲</button>
-          <button class="reaction-btn" data-reaction="👍" title="Me gusta">👍</button>
-          <button class="reaction-btn" data-reaction="💡" title="Interesante">💡</button>
-          <button class="reaction-btn" data-reaction="🙌" title="Gracias">🙌</button>
-          <button class="reaction-btn" data-reaction="📌" title="Lo guardé">📌</button>
-        </div>
-      </div>
-      <button class="modal-action-btn comment-btn" data-post-id="{{ post.id }}">
-        <i class="bi bi-chat"></i>
-        <span>Comentar</span>
-      </button>
-      <button class="modal-action-btn share-btn" data-post-id="{{ post.id }}">
-        <i class="bi bi-share"></i>
-        <span>Compartir</span>
-      </button>
-      <button class="modal-action-btn save-btn {{ 'active' if saved_posts.get(post.id) }}" data-post-id="{{ post.id }}">
-        <i class="bi bi-bookmark{{ '-fill' if saved_posts.get(post.id) else '' }}"></i>
-        <span>Guardar</span>
-      </button>
-    </div>
-
-    <!-- Estadísticas -->
-    <div class="modal-stats">
-      <div class="modal-stat-item">
-        <i class="bi bi-fire-fill text-danger"></i>
-        <span>{{
-          (reaction_counts.get('🔥', 0) + reaction_counts.get('🧠', 0) +
-          reaction_counts.get('💔', 0) + reaction_counts.get('😠', 0) +
-          reaction_counts.get('🥶', 0) + reaction_counts.get('😂', 0) +
-          reaction_counts.get('🤡', 0) + reaction_counts.get('😲', 0) +
-          reaction_counts.get('👍', 0) + reaction_counts.get('💡', 0) +
-          reaction_counts.get('🙌', 0) + reaction_counts.get('📌', 0)) if reaction_counts else 0
-        }} reacciones</span>
-      </div>
-      <div class="modal-stat-item">
-        <i class="bi bi-chat"></i>
-        <span>{{ post.comments|length }} comentarios</span>
-      </div>
-    </div>
-
-    <!-- Sección de Comentarios Scrollable -->
-    <div class="modal-comments-section">
-      {% set comments = comments if comments is defined else post.comments %}
-      {% set more_comments = post.comments|length > comments|length %}
-      <div class="comments-list" id="commentsList-{{ post.id }}">
-        {% if comments %}
-          {% for comment in comments %}
-          <div class="comment-item">
-            <img src="{{ comment.author.avatar_url or url_for('static', filename='img/default.png') }}"
-                 alt="{{ comment.author.username if comment.author else 'Usuario' }}"
-                 class="comment-avatar">
-            <div class="comment-content">
-              <div class="comment-box">
-                <div class="comment-author">{{ comment.author.username if comment.author else 'Usuario eliminado' }}</div>
-                <div class="comment-text">{{ comment.body }}</div>
-              </div>
-              <div class="comment-meta">
-                <small class="text-muted">{{ comment.timestamp|timesince }}</small>
-                <button class="btn btn-link btn-sm p-0 ms-2 text-muted">Responder</button>
-              </div>
-            </div>
-          </div>
-          {% endfor %}
-        {% else %}
-          <div class="empty-comments">
-            <i class="bi bi-chat-dots"></i>
-            <p>Sé el primero en comentar</p>
-          </div>
-        {% endif %}
-      </div>
-      {% if more_comments %}
-      <div class="text-center my-2">
-        <button class="btn btn-link load-more-comments" data-post-id="{{ post.id }}" data-page="2">Cargar más comentarios</button>
-      </div>
-      {% endif %}
-    </div>
-
-    <!-- Formulario de Comentarios Fijo -->
-    <div class="modal-comment-form">
-      {% if current_user.is_authenticated %}
-      <form class="comment-form" data-post-id="{{ post.id }}" onsubmit="submitModalComment(event, '{{ post.id }}')">
-        {{ csrf.csrf_field() }}
-        <div class="comment-input-group">
-          <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}"
-               alt="{{ current_user.username }}"
-               class="comment-form-avatar">
-          <div class="comment-input-wrapper">
-            <input type="text" 
-                   class="comment-input" 
-                   placeholder="Escribe un comentario..." 
-                   name="body">
-            <button type="submit" class="comment-submit-btn" disabled>
-              <i class="bi bi-send-fill"></i>
-            </button>
-          </div>
-        </div>
-      </form>
-      {% else %}
-      <div class="text-center p-3">
-        <a href="{{ url_for('auth.login') }}" class="btn btn-primary">Inicia sesión para comentar</a>
-      </div>
-      {% endif %}
-    </div>
+<div class="modal-stats">
+  <div class="modal-stat-item">
+    <i class="bi bi-fire-fill text-danger"></i>
+    <span>{{
+      (reaction_counts.get('🔥', 0) + reaction_counts.get('🧠', 0) +
+      reaction_counts.get('💔', 0) + reaction_counts.get('😠', 0) +
+      reaction_counts.get('🥶', 0) + reaction_counts.get('😂', 0) +
+      reaction_counts.get('🤡', 0) + reaction_counts.get('😲', 0) +
+      reaction_counts.get('👍', 0) + reaction_counts.get('💡', 0) +
+      reaction_counts.get('🙌', 0) + reaction_counts.get('📌', 0)) if reaction_counts else 0
+    }} reacciones</span>
+  </div>
+  <div class="modal-stat-item">
+    <i class="bi bi-chat"></i>
+    <span>{{ post.comments|length }} comentarios</span>
   </div>
 </div>
 
-<style>
-.facebook-modal-container {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  background: var(--crunevo-white);
-  color: var(--crunevo-text-dark);
-}
+<div class="modal-comments-section">
+  {% set comments = comments if comments is defined else post.comments %}
+  {% set more_comments = post.comments|length > comments|length %}
+  <div class="comments-list" id="commentsList-{{ post.id }}">
+    {% if comments %}
+      {% for comment in comments %}
+      <div class="comment-item">
+        <img src="{{ comment.author.avatar_url or url_for('static', filename='img/default.png') }}"
+             alt="{{ comment.author.username if comment.author else 'Usuario' }}"
+             class="comment-avatar">
+        <div class="comment-content">
+          <div class="comment-box">
+            <div class="comment-author">{{ comment.author.username if comment.author else 'Usuario eliminado' }}</div>
+            <div class="comment-text">{{ comment.body }}</div>
+          </div>
+          <div class="comment-meta">
+            <small class="text-muted">{{ comment.timestamp|timesince }}</small>
+            <button class="btn btn-link btn-sm p-0 ms-2 text-muted">Responder</button>
+          </div>
+        </div>
+      </div>
+      {% endfor %}
+    {% else %}
+      <div class="text-muted text-center py-3">Sé el primero en comentar</div>
+    {% endif %}
+  </div>
+  {% if more_comments %}
+  <button class="btn btn-link btn-sm w-100 mb-3 load-more-comments" data-post-id="{{ post.id }}">Ver más comentarios</button>
+  {% endif %}
+</div>
 
-.facebook-modal-image-section {
-  flex-shrink: 0;
-  padding: 20px;
-  border-bottom: 1px solid var(--crunevo-border);
-  background: var(--crunevo-bg-light);
-}
-
-.facebook-modal-info-panel {
-  flex-grow: 1;
-  display: flex;
-  flex-direction: column;
-  padding: 20px;
-  overflow-y: auto;
-}
-
-.modal-post-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 15px 0;
-  border-bottom: 1px solid var(--crunevo-border);
-}
-
-.modal-post-avatar {
-  width: 48px;
-  height: 48px;
-  border-radius: 50%;
-  border: 2px solid var(--crunevo-primary);
-  object-fit: cover;
-}
-
-.modal-user-info {
-  flex: 1;
-}
-
-.modal-username {
-  margin: 0;
-  font-weight: 600;
-  font-size: 16px;
-  color: var(--crunevo-text-dark);
-}
-
-.modal-career-badge {
-  display: inline-block;
-  background: var(--crunevo-accent);
-  color: white;
-  font-size: 11px;
-  padding: 2px 8px;
-  border-radius: 12px;
-  margin-left: 8px;
-  font-weight: 500;
-}
-
-.modal-timestamp {
-  display: block;
-  font-size: 13px;
-  color: #65676B;
-  margin-top: 2px;
-}
-
-.modal-post-content {
-  padding: 20px 0;
-  border-bottom: 1px solid var(--crunevo-border);
-}
-
-.modal-post-text {
-  font-size: 15px;
-  line-height: 1.5;
-  color: var(--crunevo-text-dark);
-  margin: 0;
-  word-wrap: break-word;
-}
-
-.modal-post-actions {
-  display: flex;
-  padding: 12px 0;
-  border-bottom: 1px solid var(--crunevo-border);
-  gap: 8px;
-}
-
-.modal-action-btn {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  padding: 10px 12px;
-  border: none;
-  background: transparent;
-  color: #65676B;
-  border-radius: 8px;
-  font-weight: 500;
-  font-size: 14px;
-  cursor: pointer;
-  transition: var(--crunevo-transition);
-}
-
-.modal-action-btn:hover {
-  background: var(--crunevo-hover);
-  color: var(--crunevo-primary);
-}
-
-.modal-action-btn.active {
-  color: var(--crunevo-primary);
-  background: var(--crunevo-hover);
-}
-
-.modal-action-btn i {
-  font-size: 16px;
-}
-
-.modal-stats {
-  display: flex;
-  gap: 24px;
-  padding: 12px 0;
-  border-bottom: 1px solid var(--crunevo-border);
-  font-size: 13px;
-}
-
-.modal-stat-item {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  color: #65676B;
-}
-
-.modal-comments-section {
-  flex-grow: 1;
-  padding: 20px 0;
-  overflow-y: auto;
-}
-
-.comments-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-.comment-item {
-  display: flex;
-  gap: 12px;
-  margin-bottom: 16px;
-}
-
-.comment-avatar {
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  object-fit: cover;
-  flex-shrink: 0;
-}
-
-.comment-content {
-  flex: 1;
-}
-
-.comment-box {
-  background: var(--crunevo-bg-light);
-  border-radius: 16px;
-  padding: 12px 16px;
-  margin-bottom: 4px;
-}
-
-[data-bs-theme="dark"] .comment-box {
-  background: #3A3B3C;
-}
-
-.comment-author {
-  font-weight: 600;
-  font-size: 13px;
-  color: var(--crunevo-text-dark);
-  margin-bottom: 4px;
-}
-
-.comment-text {
-  font-size: 14px;
-  line-height: 1.4;
-  color: var(--crunevo-text-dark);
-}
-
-.comment-meta {
-  display: flex;
-  align-items: center;
-  padding-left: 16px;
-}
-
-.empty-comments {
-  text-align: center;
-  padding: 40px 20px;
-}
-
-.empty-comments i {
-  font-size: 32px;
-  margin-bottom: 12px;
-  display: block;
-}
-
-.modal-comment-form {
-  padding: 16px 20px;
-  border-top: 1px solid var(--crunevo-border);
-}
-
-.comment-input-group {
-  display: flex;
-  align-items: flex-end;
-  gap: 12px;
-}
-
-.comment-form-avatar {
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  object-fit: cover;
-  flex-shrink: 0;
-}
-
-.comment-input-wrapper {
-  flex: 1;
-  position: relative;
-  display: flex;
-  align-items: center;
-  background: var(--crunevo-bg-light);
-  border-radius: 20px;
-  border: 1px solid var(--crunevo-border);
-  padding: 8px 12px;
-}
-
-[data-bs-theme="dark"] .comment-input-wrapper {
-  background: #3A3B3C;
-  border-color: #555;
-}
-
-.comment-input {
-  flex: 1;
-  border: none;
-  background: transparent;
-  font-size: 14px;
-  color: var(--crunevo-text-dark);
-  outline: none;
-  padding: 4px 8px;
-}
-
-.comment-input::placeholder {
-  color: #65676B;
-}
-
-.comment-submit-btn {
-  background: var(--crunevo-primary);
-  border: none;
-  border-radius: 50%;
-  width: 32px;
-  height: 32px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: white;
-  cursor: pointer;
-  transition: var(--crunevo-transition);
-  margin-left: 8px;
-}
-
-.comment-submit-btn:hover {
-  background: #5B21B6;
-  transform: scale(1.05);
-}
-
-.comment-submit-btn:disabled {
-  background: #ccc;
-  cursor: not-allowed;
-  transform: none;
-}
-
-.comment-submit-btn i {
-  font-size: 14px;
-}
-
-/* Responsive adjustments */
-@media (max-width: 768px) {
-  .facebook-modal-container {
-    flex-direction: column;
-    height: auto;
-  }
-
-  .facebook-modal-image-section {
-    padding: 16px;
-  }
-
-  .facebook-modal-info-panel {
-    padding: 16px;
-  }
-
-  .modal-post-header {
-    padding: 12px 0;
-  }
-
-  .modal-post-actions,
-  .modal-stats,
-  .modal-comment-form {
-    padding: 12px 0;
-  }
-  
-  .modal-action-btn {
-    padding: 8px 10px;
-    font-size: 13px;
-  }
-  
-  .modal-action-btn span {
-    display: none;
-  }
-  
-  .comment-input-wrapper {
-    padding: 6px 10px;
-  }
-  
-  .comment-submit-btn {
-    width: 28px;
-    height: 28px;
-  }
-}
-</style>
+<div class="modal-comment-form">
+  <form action="/feed/post/{{ post.id }}/comment" method="post" class="comment-form" data-post-id="{{ post.id }}">
+    {{ csrf.csrf_field() }}
+    <div class="comment-input-group">
+      <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" alt="Tu avatar" class="comment-form-avatar">
+      <div class="comment-input-wrapper">
+        <textarea class="comment-input" name="body" rows="1" placeholder="Escribe un comentario..." required></textarea>
+        <button type="submit" class="comment-submit-btn" disabled><i class="bi bi-send"></i></button>
+      </div>
+    </div>
+  </form>
+</div>


### PR DESCRIPTION
## Summary
- add full-screen photo modal with floating controls and keyboard navigation
- restore Bootstrap comment modal and remove comments-only styles
- wire comment button to global handler and document dual modal system in agents guide

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688daa050d4083258720bfd449403a90