### PR TITLE
fix: unify comment form in modals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1054,3 +1054,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Unified Facebook-style post modal: added color variables, refactored feed.js with createModal/closeModal helpers, and trimmed _post_modal.html to panel-only content (PR facebook-modal-refactor).
 - Full-screen Facebook-style modal restored zoom, navigation, download and options controls with scroll-safe info panel (PR facebook-modal-controls).
 - Introduced dual modal system: full-screen photo modal with advanced controls and restored Bootstrap comment modal, removing comments-only styles and logic (PR dual-modal-system).
+- Unified comment input across photo and comment modals with fixed bottom form and reusable CSS for Facebook-like design (PR unified-comment-input).

--- a/crunevo/static/css/photo-modal.css
+++ b/crunevo/static/css/photo-modal.css
@@ -93,13 +93,13 @@
   flex-direction: column;
   height: 100%;
   background: var(--crunevo-white);
-  border-left: 1px solid #E4E6EA;
+  border-left: 1px solid var(--crunevo-border);
   overflow: hidden;
 }
 
 [data-bs-theme="dark"] .facebook-modal-info-panel {
   background: #242526;
-  border-left: 1px solid #3A3B3C;
+  border-left: 1px solid var(--crunevo-border);
 }
 
 /* Post Header */
@@ -355,97 +355,6 @@
   display: block;
 }
 
-/* Comment Form - Fixed at bottom */
-.modal-comment-form {
-  padding: 16px 20px;
-  border-top: 1px solid #E4E6EA;
-  flex-shrink: 0;
-  background: var(--crunevo-white);
-}
-
-[data-bs-theme="dark"] .modal-comment-form {
-  border-top: 1px solid #3A3B3C;
-  background: #242526;
-}
-
-.comment-input-group {
-  display: flex;
-  align-items: flex-end;
-  gap: 12px;
-}
-
-.comment-form-avatar {
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  object-fit: cover;
-  flex-shrink: 0;
-}
-
-.comment-input-wrapper {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  background: #F0F2F5;
-  border-radius: 20px;
-  border: 1px solid #E4E6EA;
-  padding: 8px 12px;
-  gap: 8px;
-}
-
-[data-bs-theme="dark"] .comment-input-wrapper {
-  background: #3A3B3C;
-  border-color: #555;
-}
-
-.comment-input {
-  flex: 1;
-  border: none;
-  background: transparent;
-  font-size: 14px;
-  color: var(--crunevo-text-dark);
-  outline: none;
-  padding: 4px 8px;
-}
-
-[data-bs-theme="dark"] .comment-input {
-  color: #E4E6EA;
-}
-
-.comment-input::placeholder {
-  color: #65676B;
-}
-
-.comment-submit-btn {
-  background: var(--crunevo-primary);
-  border: none;
-  border-radius: 50%;
-  width: 32px;
-  height: 32px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: white;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  flex-shrink: 0;
-}
-
-.comment-submit-btn:hover {
-  background: #5B21B6;
-  transform: scale(1.05);
-}
-
-.comment-submit-btn:disabled {
-  background: #ccc;
-  cursor: not-allowed;
-  transform: none;
-}
-
-.comment-submit-btn i {
-  font-size: 14px;
-}
-
 /* Modal Controls for Image-only view */
 
 .modal-top-controls {
@@ -551,17 +460,17 @@
     grid-template-columns: 1fr;
     grid-template-rows: 60vh auto;
   }
-  
+
   .facebook-modal-info-panel {
     border-left: none;
-    border-top: 1px solid #E4E6EA;
+    border-top: 1px solid var(--crunevo-border);
     max-height: 40vh;
   }
-  
+
   [data-bs-theme="dark"] .facebook-modal-info-panel {
-    border-top: 1px solid #3A3B3C;
+    border-top: 1px solid var(--crunevo-border);
   }
-  
+
   .modal-comments-section {
     max-height: none;
     flex-grow: 1;
@@ -777,4 +686,66 @@
 @keyframes fadeInOut {
   0%, 100% { opacity: 0; }
   50% { opacity: 1; }
+}
+
+/* ✅ AÑADIDO: Estilo unificado para el formulario de comentarios */
+.unified-comment-form-container {
+  padding: 12px 16px;
+  border-top: 1px solid var(--crunevo-border);
+  background-color: var(--crunevo-white);
+  flex-shrink: 0; /* Asegura que este elemento no se encoja */
+}
+
+.unified-comment-form-group {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.unified-comment-form-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.unified-comment-input-wrapper {
+  flex-grow: 1;
+  display: flex;
+  align-items: center;
+  background-color: var(--crunevo-bg-light);
+  border-radius: 20px;
+  padding: 8px 12px;
+}
+
+.unified-comment-input {
+  flex-grow: 1;
+  border: none;
+  background: transparent;
+  outline: none;
+  font-size: 15px;
+  color: var(--crunevo-text-dark);
+  resize: none; /* Evita que el usuario pueda redimensionarlo */
+  line-height: 1.4;
+  max-height: 80px; /* Limita el crecimiento del textarea */
+  overflow-y: auto; /* Añade scroll si el texto es muy largo */
+}
+
+.unified-comment-submit-btn {
+  background: transparent;
+  border: none;
+  color: var(--crunevo-primary);
+  font-size: 20px;
+  cursor: pointer;
+  padding: 0 8px;
+  transition: transform 0.2s ease;
+}
+
+.unified-comment-submit-btn:disabled {
+  color: #aab2c0; /* Un gris para el estado deshabilitado */
+  cursor: not-allowed;
+}
+
+.unified-comment-submit-btn:not(:disabled):hover {
+  transform: scale(1.1);
 }

--- a/crunevo/templates/components/comment_modal.html
+++ b/crunevo/templates/components/comment_modal.html
@@ -5,7 +5,7 @@
 <!-- Modal de Comentarios -->
 <div class="modal fade" id="commentsModal-{{ post.id }}" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="commentsModalLabel-{{ post.id }}" aria-hidden="true" style="display: none;">
   <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable modal-fullscreen-sm-down">
-    <div class="modal-content">
+    <div class="modal-content d-flex flex-column">
       <h5 id="commentsModalLabel-{{ post.id }}" class="visually-hidden">Comentarios</h5>
       <!-- Header del Modal -->
       <div class="modal-header border-0 pb-0">
@@ -23,7 +23,7 @@
       </div>
 
       <!-- Contenido del Post -->
-      <div class="modal-body p-0">
+      <div class="modal-body p-0" style="overflow-y: auto; flex-grow: 1;">
         <!-- Texto del Post -->
         {% if post.content %}
         <div class="px-4 py-3">
@@ -74,7 +74,7 @@
         </div>
 
         <!-- Sección de Comentarios -->
-        <div class="modal-comments-section">
+        <div class="modal-comments-section px-4">
           <!-- Lista de Comentarios Existentes -->
           {% set more_comments = post.comments|length > 10 %}
           <div class="comments-list" id="commentsList-{{ post.id }}">
@@ -105,29 +105,24 @@
           </div>
           {% endif %}
 
-          <!-- Formulario para Agregar Comentario -->
-          <div class="add-comment-form mt-3">
-            <form class="comment-form d-flex align-items-center" data-post-id="{{ post.id }}" onsubmit="submitModalComment(event, '{{ post.id }}')">
-              {{ csrf.csrf_field() }}
-              <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}"
-                   alt="{{ current_user.username }}"
-                   class="rounded-circle me-2" 
-                   style="width: 32px; height: 32px; object-fit: cover;">
-              <div class="flex-grow-1 position-relative">
-                <input type="text" 
-                       class="form-control comment-input rounded-pill" 
-                       placeholder="Escribe un comentario..." 
-                       name="body"
-                       style="padding-right: 40px;">
-                <button type="submit" 
-                        class="btn position-absolute end-0 top-50 translate-middle-y me-2"
-                        style="border: none; background: none; color: #1877F2;"
-                        disabled>
-                  <i class="bi bi-send-fill"></i>
-                </button>
+        </div>
+      </div>
+      <div class="modal-footer p-0">
+        <div class="w-100 unified-comment-form-container">
+          {% if current_user.is_authenticated %}
+          <form class="comment-form" data-post-id="{{ post.id }}" onsubmit="submitModalComment(event, '{{ post.id }}')">
+            {{ csrf.csrf_field() }}
+            <div class="unified-comment-form-group">
+              <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" alt="{{ current_user.username }}" class="unified-comment-form-avatar">
+              <div class="unified-comment-input-wrapper">
+                <textarea class="unified-comment-input comment-input" name="body" rows="1" placeholder="Escribe un comentario..." oninput="this.style.height = 'auto'; this.style.height = this.scrollHeight + 'px'"></textarea>
+                <button type="submit" class="unified-comment-submit-btn comment-submit-btn" disabled><i class="bi bi-send-fill"></i></button>
               </div>
-            </form>
-          </div>
+            </div>
+          </form>
+          {% else %}
+            <!-- Mensaje de inicio de sesión -->
+          {% endif %}
         </div>
       </div>
     </div>

--- a/crunevo/templates/feed/_post_modal.html
+++ b/crunevo/templates/feed/_post_modal.html
@@ -104,15 +104,19 @@
   {% endif %}
 </div>
 
-<div class="modal-comment-form">
-  <form action="/feed/post/{{ post.id }}/comment" method="post" class="comment-form" data-post-id="{{ post.id }}">
+<div class="unified-comment-form-container">
+  {% if current_user.is_authenticated %}
+  <form class="comment-form" data-post-id="{{ post.id }}" onsubmit="submitModalComment(event, '{{ post.id }}')">
     {{ csrf.csrf_field() }}
-    <div class="comment-input-group">
-      <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" alt="Tu avatar" class="comment-form-avatar">
-      <div class="comment-input-wrapper">
-        <textarea class="comment-input" name="body" rows="1" placeholder="Escribe un comentario..." required></textarea>
-        <button type="submit" class="comment-submit-btn" disabled><i class="bi bi-send"></i></button>
+    <div class="unified-comment-form-group">
+      <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" alt="{{ current_user.username }}" class="unified-comment-form-avatar">
+      <div class="unified-comment-input-wrapper">
+        <textarea class="unified-comment-input comment-input" name="body" rows="1" placeholder="Escribe un comentario..." oninput="this.style.height = 'auto'; this.style.height = this.scrollHeight + 'px'"></textarea>
+        <button type="submit" class="unified-comment-submit-btn comment-submit-btn" disabled><i class="bi bi-send-fill"></i></button>
       </div>
     </div>
   </form>
+  {% else %}
+    <!-- Mensaje de inicio de sesión -->
+  {% endif %}
 </div>


### PR DESCRIPTION
## Summary
- anchor comment input in classic comment modal footer and make body scrollable
- reuse modern comment form in photo modal
- add shared CSS for Facebook-style comment box

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688db90e4070832587edca8483615fba