### PR TITLE
Fix mobile photo modal responsiveness and accessibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1055,3 +1055,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Full-screen Facebook-style modal restored zoom, navigation, download and options controls with scroll-safe info panel (PR facebook-modal-controls).
 - Introduced dual modal system: full-screen photo modal with advanced controls and restored Bootstrap comment modal, removing comments-only styles and logic (PR dual-modal-system).
 - Unified comment input across photo and comment modals with fixed bottom form and reusable CSS for Facebook-like design (PR unified-comment-input).
+- Made photo modal responsive for mobile, added unique IDs per post and ARIA-labelled controls to address accessibility warnings (PR photo-modal-mobile-fix).

--- a/crunevo/static/css/photo-modal.css
+++ b/crunevo/static/css/photo-modal.css
@@ -749,3 +749,38 @@
 .unified-comment-submit-btn:not(:disabled):hover {
   transform: scale(1.1);
 }
+
+/* ✅ AÑADIDO: Media Query para Tablets y Móviles */
+@media (max-width: 992px) {
+  /* Hacemos que el grid se convierta en una sola columna y dos filas */
+  .facebook-modal-container.image-with-comments {
+    grid-template-columns: 1fr; /* Una sola columna */
+    grid-template-rows: 55vh auto; /* Imagen 55% de la altura, panel el resto */
+    width: 100%;
+    height: 100%;
+    border-radius: 0;
+  }
+
+  .facebook-modal-info-panel {
+    border-left: none;
+    border-top: 1px solid var(--crunevo-border);
+    max-height: 45vh; /* Limitamos altura del panel de info */
+  }
+
+  .modal-top-controls {
+    top: 10px;
+    right: 10px;
+    gap: 8px;
+  }
+
+  .modal-control-btn {
+    width: 38px;
+    height: 38px;
+    font-size: 16px;
+  }
+
+  .modal-nav {
+    width: 48px;
+    height: 48px;
+  }
+}

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -677,7 +677,7 @@ class ModernFeedManager {
 
         <div class="modal-top-controls">
           <div class="dropdown">
-            <button class="modal-control-btn" type="button" data-bs-toggle="dropdown" aria-expanded="false" title="Más opciones">
+            <button class="modal-control-btn" type="button" data-bs-toggle="dropdown" aria-expanded="false" title="Más opciones" aria-label="Más opciones">
               <i class="bi bi-three-dots"></i>
             </button>
             <ul class="dropdown-menu dropdown-menu-dark dropdown-menu-end">
@@ -687,15 +687,15 @@ class ModernFeedManager {
               <li><a class="dropdown-item" href="#" onclick="copyPostLink('${postId}')"><i class="bi bi-link-45deg me-2"></i> Copiar enlace</a></li>
             </ul>
           </div>
-          <button class="modal-control-btn" onclick="modernFeedManager.zoomIn()" title="Aumentar"><i class="bi bi-plus-lg"></i></button>
-          <button class="modal-control-btn" onclick="modernFeedManager.zoomOut()" title="Reducir"><i class="bi bi-dash-lg"></i></button>
-          <a id="modalDownloadLink" href="#" download class="modal-control-btn" title="Descargar"><i class="bi bi-download"></i></a>
-          <button class="modal-control-btn" onclick="modernFeedManager.closeModal()" title="Cerrar (Esc)"><i class="bi bi-x-lg"></i></button>
+          <button class="modal-control-btn" onclick="modernFeedManager.zoomIn()" title="Aumentar" aria-label="Aumentar Zoom"><i class="bi bi-plus-lg"></i></button>
+          <button class="modal-control-btn" onclick="modernFeedManager.zoomOut()" title="Reducir" aria-label="Reducir Zoom"><i class="bi bi-dash-lg"></i></button>
+          <a id="modalDownloadLink" href="#" download class="modal-control-btn" title="Descargar" aria-label="Descargar Imagen"><i class="bi bi-download"></i></a>
+          <button class="modal-control-btn" onclick="modernFeedManager.closeModal()" title="Cerrar (Esc)" aria-label="Cerrar"><i class="bi bi-x-lg"></i></button>
         </div>
 
         ${hasMultiple ? `
-          <button type="button" class="modal-nav prev" onclick="modernFeedManager.prevImage()" title="Anterior (←)"><i class="bi bi-chevron-left"></i></button>
-          <button type="button" class="modal-nav next" onclick="modernFeedManager.nextImage()" title="Siguiente (→)"><i class="bi bi-chevron-right"></i></button>
+          <button type="button" class="modal-nav prev" onclick="modernFeedManager.prevImage()" title="Anterior (←)" aria-label="Anterior"><i class="bi bi-chevron-left"></i></button>
+          <button type="button" class="modal-nav next" onclick="modernFeedManager.nextImage()" title="Siguiente (→)" aria-label="Siguiente"><i class="bi bi-chevron-right"></i></button>
         ` : ''}
       </div>
       <div class="facebook-modal-info-panel" id="facebookModalInfoPanel">

--- a/crunevo/templates/components/post_card.html
+++ b/crunevo/templates/components/post_card.html
@@ -6,7 +6,7 @@
 {% set saved_posts = saved_posts if saved_posts is defined else {} %}
 {% import 'components/image_gallery.html' as gallery %}
 
-<article class="facebook-post" data-post-id="{{ post.id }}" data-comment-permission="{{ post.comment_permission }}">
+<article id="post-{{ post.id }}" class="facebook-post" data-post-id="{{ post.id }}" data-comment-permission="{{ post.comment_permission }}">
   <!-- Post Header -->
   <div class="post-header">
     <div class="post-avatar">

--- a/crunevo/templates/feed/_post_modal.html
+++ b/crunevo/templates/feed/_post_modal.html
@@ -100,13 +100,13 @@
     {% endif %}
   </div>
   {% if more_comments %}
-  <button class="btn btn-link btn-sm w-100 mb-3 load-more-comments" data-post-id="{{ post.id }}">Ver más comentarios</button>
+  <button id="loadMoreCommentsBtn-{{ post.id }}" class="btn btn-link btn-sm w-100 mb-3 load-more-comments" data-post-id="{{ post.id }}">Ver más comentarios</button>
   {% endif %}
 </div>
 
 <div class="unified-comment-form-container">
   {% if current_user.is_authenticated %}
-  <form class="comment-form" data-post-id="{{ post.id }}" onsubmit="submitModalComment(event, '{{ post.id }}')">
+  <form id="commentForm-{{ post.id }}" class="comment-form" data-post-id="{{ post.id }}" onsubmit="submitModalComment(event, '{{ post.id }}')">
     {{ csrf.csrf_field() }}
     <div class="unified-comment-form-group">
       <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" alt="{{ current_user.username }}" class="unified-comment-form-avatar">


### PR DESCRIPTION
## Summary
- make photo modal responsive on small screens
- assign unique IDs to post elements and modal components to avoid duplicates
- add ARIA labels for modal controls to improve accessibility

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688dbdcae5748325abc19845ac81f89e