### PR TITLE
Fix comment modal layout and unify compact comment form

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1056,3 +1056,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Introduced dual modal system: full-screen photo modal with advanced controls and restored Bootstrap comment modal, removing comments-only styles and logic (PR dual-modal-system).
 - Unified comment input across photo and comment modals with fixed bottom form and reusable CSS for Facebook-like design (PR unified-comment-input).
 - Made photo modal responsive for mobile, added unique IDs per post and ARIA-labelled controls to address accessibility warnings (PR photo-modal-mobile-fix).
+- Fixed comment modal layout with flexbox to keep header and input fixed and added compact comment form styles reused in photo modal for consistency (PR comment-modal-compact-form).

--- a/crunevo/static/css/photo-modal.css
+++ b/crunevo/static/css/photo-modal.css
@@ -779,8 +779,81 @@
     font-size: 16px;
   }
 
-  .modal-nav {
+.modal-nav {
     width: 48px;
     height: 48px;
   }
 }
+
+/* ✅ AÑADIDO: Estilo COMPACTO y UNIFICADO para el formulario de comentarios */
+.compact-comment-form-container {
+  padding: 10px 16px;
+  border-top: 1px solid var(--crunevo-border);
+  background-color: var(--crunevo-white);
+  flex-shrink: 0; /* Importantísimo para que no se encoja */
+}
+
+.compact-comment-form-group {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.compact-comment-form-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.compact-comment-input-wrapper {
+  flex-grow: 1;
+  display: flex;
+  align-items: center;
+  background-color: var(--crunevo-bg-light);
+  border-radius: 20px;
+  /* Padding ajustado para que el botón quepa adentro */
+  padding: 6px 6px 6px 12px; 
+}
+
+.compact-comment-input {
+  flex-grow: 1;
+  border: none;
+  background: transparent;
+  outline: none;
+  font-size: 15px;
+  color: var(--crunevo-text-dark);
+  resize: none;
+  line-height: 1.4;
+  max-height: 80px;
+  overflow-y: auto;
+  padding-right: 8px; /* Espacio para el botón */
+}
+
+.compact-comment-submit-btn {
+  background: var(--crunevo-primary);
+  color: white;
+  border: none;
+  border-radius: 50%;
+  width: 28px;
+  height: 28px;
+  font-size: 14px;
+  cursor: pointer;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.2s ease, background-color 0.2s ease;
+}
+
+.compact-comment-submit-btn:disabled {
+  background-color: #aab2c0;
+  cursor: not-allowed;
+}
+
+.compact-comment-submit-btn:not(:disabled):hover {
+  transform: scale(1.1);
+  background-color: var(--crunevo-accent);
+}
+

--- a/crunevo/templates/components/comment_modal.html
+++ b/crunevo/templates/components/comment_modal.html
@@ -4,11 +4,11 @@
 
 <!-- Modal de Comentarios -->
 <div class="modal fade" id="commentsModal-{{ post.id }}" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="commentsModalLabel-{{ post.id }}" aria-hidden="true" style="display: none;">
-  <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable modal-fullscreen-sm-down">
-    <div class="modal-content d-flex flex-column">
+  <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable modal-fullscreen-sm-down" style="max-height: 90vh;">
+    <div class="modal-content d-flex flex-column" style="height: 100%;">
       <h5 id="commentsModalLabel-{{ post.id }}" class="visually-hidden">Comentarios</h5>
       <!-- Header del Modal -->
-      <div class="modal-header border-0 pb-0">
+      <div class="modal-header border-0 pb-0" style="flex-shrink: 0;">
         <div class="d-flex align-items-center">
           <img src="{{ post.author.avatar_url if post.author else url_for('static', filename='img/default.png') }}" 
                alt="{{ post.author.username if post.author else 'Usuario eliminado' }}"
@@ -107,16 +107,16 @@
 
         </div>
       </div>
-      <div class="modal-footer p-0">
-        <div class="w-100 unified-comment-form-container">
+      <div class="modal-footer p-0" style="flex-shrink: 0;">
+        <div class="w-100 compact-comment-form-container">
           {% if current_user.is_authenticated %}
           <form class="comment-form" data-post-id="{{ post.id }}" onsubmit="submitModalComment(event, '{{ post.id }}')">
             {{ csrf.csrf_field() }}
-            <div class="unified-comment-form-group">
-              <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" alt="{{ current_user.username }}" class="unified-comment-form-avatar">
-              <div class="unified-comment-input-wrapper">
-                <textarea class="unified-comment-input comment-input" name="body" rows="1" placeholder="Escribe un comentario..." oninput="this.style.height = 'auto'; this.style.height = this.scrollHeight + 'px'"></textarea>
-                <button type="submit" class="unified-comment-submit-btn comment-submit-btn" disabled><i class="bi bi-send-fill"></i></button>
+            <div class="compact-comment-form-group">
+              <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" alt="{{ current_user.username }}" class="compact-comment-form-avatar">
+              <div class="compact-comment-input-wrapper">
+                <textarea class="compact-comment-input comment-input" name="body" rows="1" placeholder="Escribe un comentario..." oninput="this.style.height = 'auto'; this.style.height = this.scrollHeight + 'px'"></textarea>
+                <button type="submit" class="compact-comment-submit-btn comment-submit-btn" disabled><i class="bi bi-send-fill"></i></button>
               </div>
             </div>
           </form>

--- a/crunevo/templates/feed/_post_modal.html
+++ b/crunevo/templates/feed/_post_modal.html
@@ -104,15 +104,15 @@
   {% endif %}
 </div>
 
-<div class="unified-comment-form-container">
+<div class="compact-comment-form-container">
   {% if current_user.is_authenticated %}
-  <form id="commentForm-{{ post.id }}" class="comment-form" data-post-id="{{ post.id }}" onsubmit="submitModalComment(event, '{{ post.id }}')">
+  <form class="comment-form" data-post-id="{{ post.id }}" onsubmit="submitModalComment(event, '{{ post.id }}')">
     {{ csrf.csrf_field() }}
-    <div class="unified-comment-form-group">
-      <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" alt="{{ current_user.username }}" class="unified-comment-form-avatar">
-      <div class="unified-comment-input-wrapper">
-        <textarea class="unified-comment-input comment-input" name="body" rows="1" placeholder="Escribe un comentario..." oninput="this.style.height = 'auto'; this.style.height = this.scrollHeight + 'px'"></textarea>
-        <button type="submit" class="unified-comment-submit-btn comment-submit-btn" disabled><i class="bi bi-send-fill"></i></button>
+    <div class="compact-comment-form-group">
+      <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" alt="{{ current_user.username }}" class="compact-comment-form-avatar">
+      <div class="compact-comment-input-wrapper">
+        <textarea class="compact-comment-input comment-input" name="body" rows="1" placeholder="Escribe un comentario..." oninput="this.style.height = 'auto'; this.style.height = this.scrollHeight + 'px'"></textarea>
+        <button type="submit" class="compact-comment-submit-btn comment-submit-btn" disabled><i class="bi bi-send-fill"></i></button>
       </div>
     </div>
   </form>


### PR DESCRIPTION
## Summary
- add compact comment form styles
- use flexbox layout in comment modal and restrict scroll to body
- update photo modal to reuse compact comment form

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688dc5bf785c8325afdbdc5cd28b6bc4