### PR TITLE
fix comment modal scroll layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1057,3 +1057,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Unified comment input across photo and comment modals with fixed bottom form and reusable CSS for Facebook-like design (PR unified-comment-input).
 - Made photo modal responsive for mobile, added unique IDs per post and ARIA-labelled controls to address accessibility warnings (PR photo-modal-mobile-fix).
 - Fixed comment modal layout with flexbox to keep header and input fixed and added compact comment form styles reused in photo modal for consistency (PR comment-modal-compact-form).
+- Removed Bootstrap's extra scroll class from comment modal to ensure a single scroll area and matched photo modal comment form width using w-100 (PR comment-modal-single-scroll).

--- a/crunevo/templates/components/comment_modal.html
+++ b/crunevo/templates/components/comment_modal.html
@@ -4,7 +4,7 @@
 
 <!-- Modal de Comentarios -->
 <div class="modal fade" id="commentsModal-{{ post.id }}" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="commentsModalLabel-{{ post.id }}" aria-hidden="true" style="display: none;">
-  <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable modal-fullscreen-sm-down" style="max-height: 90vh;">
+  <div class="modal-dialog modal-lg modal-dialog-centered modal-fullscreen-sm-down" style="max-height: 90vh;">
     <div class="modal-content d-flex flex-column" style="height: 100%;">
       <h5 id="commentsModalLabel-{{ post.id }}" class="visually-hidden">Comentarios</h5>
       <!-- Header del Modal -->

--- a/crunevo/templates/feed/_post_modal.html
+++ b/crunevo/templates/feed/_post_modal.html
@@ -104,7 +104,7 @@
   {% endif %}
 </div>
 
-<div class="compact-comment-form-container">
+<div class="w-100 compact-comment-form-container">
   {% if current_user.is_authenticated %}
   <form class="comment-form" data-post-id="{{ post.id }}" onsubmit="submitModalComment(event, '{{ post.id }}')">
     {{ csrf.csrf_field() }}


### PR DESCRIPTION
## Summary
- remove Bootstrap scroll class from comment modal to ensure single scrollable body
- align photo modal comment form container width for consistent layout

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688e3678726c8325a04247f03a9feeae