### PR TITLE
Refactor modal layout for unified scrolling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1058,3 +1058,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Made photo modal responsive for mobile, added unique IDs per post and ARIA-labelled controls to address accessibility warnings (PR photo-modal-mobile-fix).
 - Fixed comment modal layout with flexbox to keep header and input fixed and added compact comment form styles reused in photo modal for consistency (PR comment-modal-compact-form).
 - Removed Bootstrap's extra scroll class from comment modal to ensure a single scroll area and matched photo modal comment form width using w-100 (PR comment-modal-single-scroll).
+- Refactored comment and photo modals into single-page scrollable layouts, locked body scrolling and anchored comment input at bottom for consistency (PR modal-unified-scroll).

--- a/crunevo/static/css/main.css
+++ b/crunevo/static/css/main.css
@@ -961,3 +961,8 @@ textarea.form-control {
 .hide-scrollbar::-webkit-scrollbar {
   display: none;
 }
+
+/* Disable page scroll when photo modal is open */
+body.photo-modal-open {
+  overflow: hidden;
+}

--- a/crunevo/static/css/photo-modal.css
+++ b/crunevo/static/css/photo-modal.css
@@ -275,10 +275,8 @@
   color: #65676B;
 }
 
-/* Comments Section - Scrollable */
+/* Comments Section */
 .modal-comments-section {
-  flex-grow: 1;
-  overflow-y: auto;
   padding: 0 20px;
 }
 
@@ -473,7 +471,6 @@
 
   .modal-comments-section {
     max-height: none;
-    flex-grow: 1;
   }
   
   .modal-top-controls {
@@ -787,10 +784,12 @@
 
 /* ✅ AÑADIDO: Estilo COMPACTO y UNIFICADO para el formulario de comentarios */
 .compact-comment-form-container {
+  width: 100%;
   padding: 10px 16px;
   border-top: 1px solid var(--crunevo-border);
   background-color: var(--crunevo-white);
   flex-shrink: 0; /* Importantísimo para que no se encoja */
+  box-sizing: border-box;
 }
 
 .compact-comment-form-group {

--- a/crunevo/templates/components/comment_modal.html
+++ b/crunevo/templates/components/comment_modal.html
@@ -5,108 +5,112 @@
 <!-- Modal de Comentarios -->
 <div class="modal fade" id="commentsModal-{{ post.id }}" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="commentsModalLabel-{{ post.id }}" aria-hidden="true" style="display: none;">
   <div class="modal-dialog modal-lg modal-dialog-centered modal-fullscreen-sm-down" style="max-height: 90vh;">
-    <div class="modal-content d-flex flex-column" style="height: 100%;">
+    <div class="modal-content d-flex flex-column" style="height: 100%; overflow: hidden;">
       <h5 id="commentsModalLabel-{{ post.id }}" class="visually-hidden">Comentarios</h5>
-      <!-- Header del Modal -->
-      <div class="modal-header border-0 pb-0" style="flex-shrink: 0;">
-        <div class="d-flex align-items-center">
-          <img src="{{ post.author.avatar_url if post.author else url_for('static', filename='img/default.png') }}" 
-               alt="{{ post.author.username if post.author else 'Usuario eliminado' }}"
-               class="rounded-circle me-3" 
-               style="width: 40px; height: 40px; object-fit: cover;">
-          <div>
-            <h6 class="mb-0 fw-bold">{{ post.author.username if post.author else 'Usuario eliminado' }}</h6>
-            <small class="text-muted">{{ post.created_at|timesince }}</small>
-          </div>
-        </div>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
-      </div>
-
-      <!-- Contenido del Post -->
-      <div class="modal-body p-0" style="overflow-y: auto; flex-grow: 1;">
-        <!-- Texto del Post -->
-        {% if post.content %}
-        <div class="px-4 py-3">
-          <p class="mb-0">{{ post.content }}</p>
-        </div>
-        {% endif %}
-
-        <!-- Galería de Imágenes -->
-        {% if post.images %}
-        {{ gallery.image_gallery(post.images, post.id) }}
-        {% elif post.file_url and not post.file_url.endswith('.pdf') %}
-        {{ gallery.image_gallery([post.file_url], post.id) }}
-        {% endif %}
-
-        <!-- Acciones del Post (Me gusta, etc.) -->
-        <div class="modal-post-actions px-4 py-2 border-top border-bottom">
-          <div class="d-flex justify-content-around">
-            <div class="relative reaction-container" data-post-id="{{ post.id }}" data-my-reaction="{{ user_reactions.get(post.id, '') }}">
-              <button class="modal-action-btn like-btn {{ 'active' if user_reactions.get(post.id) }}" data-post-id="{{ post.id }}">
-                <i class="bi bi-fire{{ '-fill' if user_reactions.get(post.id) else '' }}"></i>
-                <span class="action-text">Me gusta</span>
-                <span class="action-count">{{ reaction_counts.get(post.id, {}).get('🔥', '') }}</span>
-              </button>
-              <div class="reaction-panel d-none">
-                <button class="reaction-btn" data-reaction="🔥" title="Crunazo">🔥</button>
-                <button class="reaction-btn" data-reaction="🧠" title="Neuro">🧠</button>
-                <button class="reaction-btn" data-reaction="💔" title="Roto">💔</button>
-                <button class="reaction-btn" data-reaction="😠" title="Molesto">😠</button>
-                <button class="reaction-btn" data-reaction="🥶" title="Congelao">🥶</button>
-                <button class="reaction-btn" data-reaction="😂" title="Vacilón">😂</button>
-                <button class="reaction-btn" data-reaction="🤡" title="Cringe">🤡</button>
-                <button class="reaction-btn" data-reaction="😲" title="Asu">😲</button>
-                <button class="reaction-btn" data-reaction="👍" title="Me gusta">👍</button>
-                <button class="reaction-btn" data-reaction="💡" title="Interesante">💡</button>
-                <button class="reaction-btn" data-reaction="🙌" title="Gracias">🙌</button>
-                <button class="reaction-btn" data-reaction="📌" title="Lo guardé">📌</button>
-              </div>
+      <!-- Scrollable Content -->
+      <div class="modal-scrollable-content" style="flex-grow: 1; overflow-y: auto;">
+        <!-- Header del Modal -->
+        <div class="modal-header border-0 pb-0">
+          <div class="d-flex align-items-center">
+            <img src="{{ post.author.avatar_url if post.author else url_for('static', filename='img/default.png') }}"
+                 alt="{{ post.author.username if post.author else 'Usuario eliminado' }}"
+                 class="rounded-circle me-3"
+                 style="width: 40px; height: 40px; object-fit: cover;">
+            <div>
+              <h6 class="mb-0 fw-bold">{{ post.author.username if post.author else 'Usuario eliminado' }}</h6>
+              <small class="text-muted">{{ post.created_at|timesince }}</small>
             </div>
-            <button class="modal-action-btn share-btn" data-post-id="{{ post.id }}">
-              <i class="bi bi-share"></i>
-              <span>Compartir</span>
-            </button>
-            <button class="modal-action-btn save-btn {{ 'active' if saved_posts.get(post.id) }}" data-post-id="{{ post.id }}">
-              <i class="bi bi-bookmark{{ '-fill' if saved_posts.get(post.id) else '' }}"></i>
-              <span>Guardar</span>
-            </button>
           </div>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
         </div>
 
-        <!-- Sección de Comentarios -->
-        <div class="modal-comments-section px-4">
-          <!-- Lista de Comentarios Existentes -->
-          {% set more_comments = post.comments|length > 10 %}
-          <div class="comments-list" id="commentsList-{{ post.id }}">
-            {% for comment in post.comments[:10] %}
-            <div class="comment-item d-flex mb-3">
-              <img src="{{ comment.author.avatar_url if comment.author else url_for('static', filename='img/default.png') }}"
-                   alt="{{ comment.author.username if comment.author else 'Usuario' }}"
-                   class="rounded-circle me-2" 
-                   style="width: 32px; height: 32px; object-fit: cover;">
-              <div class="flex-grow-1">
-                <div class="comment-bubble bg-light rounded-3 p-2">
-                  <div class="comment-author fw-semibold small">
-                    {{ comment.author.username if comment.author else 'Usuario eliminado' }}
-                  </div>
-                  <div class="comment-text">{{ comment.body }}</div>
-                </div>
-                <div class="comment-meta mt-1">
-                  <small class="text-muted">{{ comment.timestamp|timesince }}</small>
-                  <button class="btn btn-link btn-sm p-0 ms-2 text-muted">Responder</button>
-                </div>
-              </div>
-            </div>
-            {% endfor %}
-          </div>
-          {% if more_comments %}
-          <div class="text-center my-2">
-            <button class="btn btn-link load-more-comments" data-post-id="{{ post.id }}" data-page="2">Cargar más comentarios</button>
+        <!-- Contenido del Post -->
+        <div class="modal-body p-0">
+          <!-- Texto del Post -->
+          {% if post.content %}
+          <div class="px-4 py-3">
+            <p class="mb-0">{{ post.content }}</p>
           </div>
           {% endif %}
 
+          <!-- Galería de Imágenes -->
+          {% if post.images %}
+          {{ gallery.image_gallery(post.images, post.id) }}
+          {% elif post.file_url and not post.file_url.endswith('.pdf') %}
+          {{ gallery.image_gallery([post.file_url], post.id) }}
+          {% endif %}
+
+          <!-- Acciones del Post (Me gusta, etc.) -->
+          <div class="modal-post-actions px-4 py-2 border-top border-bottom">
+            <div class="d-flex justify-content-around">
+              <div class="relative reaction-container" data-post-id="{{ post.id }}" data-my-reaction="{{ user_reactions.get(post.id, '') }}">
+                <button class="modal-action-btn like-btn {{ 'active' if user_reactions.get(post.id) }}" data-post-id="{{ post.id }}">
+                  <i class="bi bi-fire{{ '-fill' if user_reactions.get(post.id) else '' }}"></i>
+                  <span class="action-text">Me gusta</span>
+                  <span class="action-count">{{ reaction_counts.get(post.id, {}).get('🔥', '') }}</span>
+                </button>
+                <div class="reaction-panel d-none">
+                  <button class="reaction-btn" data-reaction="🔥" title="Crunazo">🔥</button>
+                  <button class="reaction-btn" data-reaction="🧠" title="Neuro">🧠</button>
+                  <button class="reaction-btn" data-reaction="💔" title="Roto">💔</button>
+                  <button class="reaction-btn" data-reaction="😠" title="Molesto">😠</button>
+                  <button class="reaction-btn" data-reaction="🥶" title="Congelao">🥶</button>
+                  <button class="reaction-btn" data-reaction="😂" title="Vacilón">😂</button>
+                  <button class="reaction-btn" data-reaction="🤡" title="Cringe">🤡</button>
+                  <button class="reaction-btn" data-reaction="😲" title="Asu">😲</button>
+                  <button class="reaction-btn" data-reaction="👍" title="Me gusta">👍</button>
+                  <button class="reaction-btn" data-reaction="💡" title="Interesante">💡</button>
+                  <button class="reaction-btn" data-reaction="🙌" title="Gracias">🙌</button>
+                  <button class="reaction-btn" data-reaction="📌" title="Lo guardé">📌</button>
+                </div>
+              </div>
+              <button class="modal-action-btn share-btn" data-post-id="{{ post.id }}">
+                <i class="bi bi-share"></i>
+                <span>Compartir</span>
+              </button>
+              <button class="modal-action-btn save-btn {{ 'active' if saved_posts.get(post.id) }}" data-post-id="{{ post.id }}">
+                <i class="bi bi-bookmark{{ '-fill' if saved_posts.get(post.id) else '' }}"></i>
+                <span>Guardar</span>
+              </button>
+            </div>
+          </div>
+
+          <!-- Sección de Comentarios -->
+          <div class="modal-comments-section px-4">
+            <!-- Lista de Comentarios Existentes -->
+            {% set more_comments = post.comments|length > 10 %}
+            <div class="comments-list" id="commentsList-{{ post.id }}">
+              {% for comment in post.comments[:10] %}
+              <div class="comment-item d-flex mb-3">
+                <img src="{{ comment.author.avatar_url if comment.author else url_for('static', filename='img/default.png') }}"
+                     alt="{{ comment.author.username if comment.author else 'Usuario' }}"
+                     class="rounded-circle me-2"
+                     style="width: 32px; height: 32px; object-fit: cover;">
+                <div class="flex-grow-1">
+                  <div class="comment-bubble bg-light rounded-3 p-2">
+                    <div class="comment-author fw-semibold small">
+                      {{ comment.author.username if comment.author else 'Usuario eliminado' }}
+                    </div>
+                    <div class="comment-text">{{ comment.body }}</div>
+                  </div>
+                  <div class="comment-meta mt-1">
+                    <small class="text-muted">{{ comment.timestamp|timesince }}</small>
+                    <button class="btn btn-link btn-sm p-0 ms-2 text-muted">Responder</button>
+                  </div>
+                </div>
+              </div>
+              {% endfor %}
+            </div>
+            {% if more_comments %}
+            <div class="text-center my-2">
+              <button class="btn btn-link load-more-comments" data-post-id="{{ post.id }}" data-page="2">Cargar más comentarios</button>
+            </div>
+            {% endif %}
+
+          </div>
         </div>
       </div>
+      <!-- Footer fijo con el input -->
       <div class="modal-footer p-0" style="flex-shrink: 0;">
         <div class="w-100 compact-comment-form-container">
           {% if current_user.is_authenticated %}

--- a/crunevo/templates/feed/_post_modal.html
+++ b/crunevo/templates/feed/_post_modal.html
@@ -1,109 +1,113 @@
 {% import 'components/csrf.html' as csrf %}
 {% set saved_posts = saved_posts if saved_posts is defined else {} %}
 
-<div class="modal-post-header">
-  <img src="{{ post.author.avatar_url or url_for('static', filename='img/default.png') }}" alt="Avatar de {{ post.author.username }}" class="modal-post-avatar">
-  <div class="modal-user-info">
-    <h6 class="modal-username">{{ post.author.username }}</h6>
-    {% if post.author.career %}<span class="modal-career-badge">{{ post.author.career }}</span>{% endif %}
-    <small class="modal-timestamp">{{ post.created_at|timesince }}</small>
-  </div>
-  <button type="button" class="modal-close-btn" onclick="modernFeedManager.closeModal()" aria-label="Cerrar">
-    <i class="bi bi-x"></i>
-  </button>
-</div>
-
-{% if post.content %}
-<div class="modal-post-content">
-  <p class="modal-post-text">{{ post.content }}</p>
-</div>
-{% endif %}
-
-<div class="modal-post-actions">
-  <div class="relative reaction-container" data-post-id="{{ post.id }}" data-my-reaction="{{ user_reaction or '' }}">
-    <button class="modal-action-btn like-btn {{ 'active' if user_reaction else '' }}" data-post-id="{{ post.id }}">
-      <i class="bi bi-fire{{ '-fill' if user_reaction else '' }}"></i>
-      <span class="action-text">Me gusta</span>
-      <span class="action-count">{{ reaction_counts.get('🔥', '') if reaction_counts else '' }}</span>
+<!-- Scrollable content -->
+<div class="modal-scrollable-content" style="flex-grow: 1; overflow-y: auto;">
+  <div class="modal-post-header">
+    <img src="{{ post.author.avatar_url or url_for('static', filename='img/default.png') }}" alt="Avatar de {{ post.author.username }}" class="modal-post-avatar">
+    <div class="modal-user-info">
+      <h6 class="modal-username">{{ post.author.username }}</h6>
+      {% if post.author.career %}<span class="modal-career-badge">{{ post.author.career }}</span>{% endif %}
+      <small class="modal-timestamp">{{ post.created_at|timesince }}</small>
+    </div>
+    <button type="button" class="modal-close-btn" onclick="modernFeedManager.closeModal()" aria-label="Cerrar">
+      <i class="bi bi-x"></i>
     </button>
-    <div class="reaction-panel d-none">
-      <button class="reaction-btn" data-reaction="🔥" title="Crunazo">🔥</button>
-      <button class="reaction-btn" data-reaction="🧠" title="Neuro">🧠</button>
-      <button class="reaction-btn" data-reaction="💔" title="Roto">💔</button>
-      <button class="reaction-btn" data-reaction="😠" title="Molesto">😠</button>
-      <button class="reaction-btn" data-reaction="🥶" title="Congelao">🥶</button>
-      <button class="reaction-btn" data-reaction="😂" title="Vacilón">😂</button>
-      <button class="reaction-btn" data-reaction="🤡" title="Cringe">🤡</button>
-      <button class="reaction-btn" data-reaction="😲" title="Asu">😲</button>
-      <button class="reaction-btn" data-reaction="👍" title="Me gusta">👍</button>
-      <button class="reaction-btn" data-reaction="💡" title="Interesante">💡</button>
-      <button class="reaction-btn" data-reaction="🙌" title="Gracias">🙌</button>
-      <button class="reaction-btn" data-reaction="📌" title="Lo guardé">📌</button>
+  </div>
+
+  {% if post.content %}
+  <div class="modal-post-content">
+    <p class="modal-post-text">{{ post.content }}</p>
+  </div>
+  {% endif %}
+
+  <div class="modal-post-actions">
+    <div class="relative reaction-container" data-post-id="{{ post.id }}" data-my-reaction="{{ user_reaction or '' }}">
+      <button class="modal-action-btn like-btn {{ 'active' if user_reaction else '' }}" data-post-id="{{ post.id }}">
+        <i class="bi bi-fire{{ '-fill' if user_reaction else '' }}"></i>
+        <span class="action-text">Me gusta</span>
+        <span class="action-count">{{ reaction_counts.get('🔥', '') if reaction_counts else '' }}</span>
+      </button>
+      <div class="reaction-panel d-none">
+        <button class="reaction-btn" data-reaction="🔥" title="Crunazo">🔥</button>
+        <button class="reaction-btn" data-reaction="🧠" title="Neuro">🧠</button>
+        <button class="reaction-btn" data-reaction="💔" title="Roto">💔</button>
+        <button class="reaction-btn" data-reaction="😠" title="Molesto">😠</button>
+        <button class="reaction-btn" data-reaction="🥶" title="Congelao">🥶</button>
+        <button class="reaction-btn" data-reaction="😂" title="Vacilón">😂</button>
+        <button class="reaction-btn" data-reaction="🤡" title="Cringe">🤡</button>
+        <button class="reaction-btn" data-reaction="😲" title="Asu">😲</button>
+        <button class="reaction-btn" data-reaction="👍" title="Me gusta">👍</button>
+        <button class="reaction-btn" data-reaction="💡" title="Interesante">💡</button>
+        <button class="reaction-btn" data-reaction="🙌" title="Gracias">🙌</button>
+        <button class="reaction-btn" data-reaction="📌" title="Lo guardé">📌</button>
+      </div>
+    </div>
+    <button class="modal-action-btn comment-btn" data-post-id="{{ post.id }}">
+      <i class="bi bi-chat"></i>
+      <span>Comentar</span>
+    </button>
+    <button class="modal-action-btn share-btn" data-post-id="{{ post.id }}">
+      <i class="bi bi-share"></i>
+      <span>Compartir</span>
+    </button>
+    <button class="modal-action-btn save-btn {{ 'active' if saved_posts.get(post.id) }}" data-post-id="{{ post.id }}">
+      <i class="bi bi-bookmark{{ '-fill' if saved_posts.get(post.id) else '' }}"></i>
+      <span>Guardar</span>
+    </button>
+  </div>
+
+  <div class="modal-stats">
+    <div class="modal-stat-item">
+      <i class="bi bi-fire-fill text-danger"></i>
+      <span>{{
+        (reaction_counts.get('🔥', 0) + reaction_counts.get('🧠', 0) +
+        reaction_counts.get('💔', 0) + reaction_counts.get('😠', 0) +
+        reaction_counts.get('🥶', 0) + reaction_counts.get('😂', 0) +
+        reaction_counts.get('🤡', 0) + reaction_counts.get('😲', 0) +
+        reaction_counts.get('👍', 0) + reaction_counts.get('💡', 0) +
+        reaction_counts.get('🙌', 0) + reaction_counts.get('📌', 0)) if reaction_counts else 0
+      }} reacciones</span>
+    </div>
+    <div class="modal-stat-item">
+      <i class="bi bi-chat"></i>
+      <span>{{ post.comments|length }} comentarios</span>
     </div>
   </div>
-  <button class="modal-action-btn comment-btn" data-post-id="{{ post.id }}">
-    <i class="bi bi-chat"></i>
-    <span>Comentar</span>
-  </button>
-  <button class="modal-action-btn share-btn" data-post-id="{{ post.id }}">
-    <i class="bi bi-share"></i>
-    <span>Compartir</span>
-  </button>
-  <button class="modal-action-btn save-btn {{ 'active' if saved_posts.get(post.id) }}" data-post-id="{{ post.id }}">
-    <i class="bi bi-bookmark{{ '-fill' if saved_posts.get(post.id) else '' }}"></i>
-    <span>Guardar</span>
-  </button>
-</div>
 
-<div class="modal-stats">
-  <div class="modal-stat-item">
-    <i class="bi bi-fire-fill text-danger"></i>
-    <span>{{
-      (reaction_counts.get('🔥', 0) + reaction_counts.get('🧠', 0) +
-      reaction_counts.get('💔', 0) + reaction_counts.get('😠', 0) +
-      reaction_counts.get('🥶', 0) + reaction_counts.get('😂', 0) +
-      reaction_counts.get('🤡', 0) + reaction_counts.get('😲', 0) +
-      reaction_counts.get('👍', 0) + reaction_counts.get('💡', 0) +
-      reaction_counts.get('🙌', 0) + reaction_counts.get('📌', 0)) if reaction_counts else 0
-    }} reacciones</span>
-  </div>
-  <div class="modal-stat-item">
-    <i class="bi bi-chat"></i>
-    <span>{{ post.comments|length }} comentarios</span>
-  </div>
-</div>
-
-<div class="modal-comments-section">
-  {% set comments = comments if comments is defined else post.comments %}
-  {% set more_comments = post.comments|length > comments|length %}
-  <div class="comments-list" id="commentsList-{{ post.id }}">
-    {% if comments %}
-      {% for comment in comments %}
-      <div class="comment-item">
-        <img src="{{ comment.author.avatar_url or url_for('static', filename='img/default.png') }}"
-             alt="{{ comment.author.username if comment.author else 'Usuario' }}"
-             class="comment-avatar">
-        <div class="comment-content">
-          <div class="comment-box">
-            <div class="comment-author">{{ comment.author.username if comment.author else 'Usuario eliminado' }}</div>
-            <div class="comment-text">{{ comment.body }}</div>
-          </div>
-          <div class="comment-meta">
-            <small class="text-muted">{{ comment.timestamp|timesince }}</small>
-            <button class="btn btn-link btn-sm p-0 ms-2 text-muted">Responder</button>
+  <div class="modal-comments-section">
+    {% set comments = comments if comments is defined else post.comments %}
+    {% set more_comments = post.comments|length > comments|length %}
+    <div class="comments-list" id="commentsList-{{ post.id }}">
+      {% if comments %}
+        {% for comment in comments %}
+        <div class="comment-item">
+          <img src="{{ comment.author.avatar_url or url_for('static', filename='img/default.png') }}"
+               alt="{{ comment.author.username if comment.author else 'Usuario' }}"
+               class="comment-avatar">
+          <div class="comment-content">
+            <div class="comment-box">
+              <div class="comment-author">{{ comment.author.username if comment.author else 'Usuario eliminado' }}</div>
+              <div class="comment-text">{{ comment.body }}</div>
+            </div>
+            <div class="comment-meta">
+              <small class="text-muted">{{ comment.timestamp|timesince }}</small>
+              <button class="btn btn-link btn-sm p-0 ms-2 text-muted">Responder</button>
+            </div>
           </div>
         </div>
-      </div>
-      {% endfor %}
-    {% else %}
-      <div class="text-muted text-center py-3">Sé el primero en comentar</div>
+        {% endfor %}
+      {% else %}
+        <div class="text-muted text-center py-3">Sé el primero en comentar</div>
+      {% endif %}
+    </div>
+    {% if more_comments %}
+    <button id="loadMoreCommentsBtn-{{ post.id }}" class="btn btn-link btn-sm w-100 mb-3 load-more-comments" data-post-id="{{ post.id }}">Ver más comentarios</button>
     {% endif %}
   </div>
-  {% if more_comments %}
-  <button id="loadMoreCommentsBtn-{{ post.id }}" class="btn btn-link btn-sm w-100 mb-3 load-more-comments" data-post-id="{{ post.id }}">Ver más comentarios</button>
-  {% endif %}
 </div>
 
+<!-- Fixed comment form -->
 <div class="w-100 compact-comment-form-container">
   {% if current_user.is_authenticated %}
   <form class="comment-form" data-post-id="{{ post.id }}" onsubmit="submitModalComment(event, '{{ post.id }}')">


### PR DESCRIPTION
## Summary
- prevent background scrolling when photo modal is open
- refactor comment and photo modals to share single internal scroll
- keep comment input anchored with full-width styling

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688e3d1020e48325a3719db561099ceb