### PR TITLE
Fix modal overflow with internal scroll layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1059,3 +1059,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Fixed comment modal layout with flexbox to keep header and input fixed and added compact comment form styles reused in photo modal for consistency (PR comment-modal-compact-form).
 - Removed Bootstrap's extra scroll class from comment modal to ensure a single scroll area and matched photo modal comment form width using w-100 (PR comment-modal-single-scroll).
 - Refactored comment and photo modals into single-page scrollable layouts, locked body scrolling and anchored comment input at bottom for consistency (PR modal-unified-scroll).
+- Ensured modals remain within viewport using 90vh content height, moved all scroll to internal containers and kept comment input fixed to eliminate outer scrollbars (PR modal-scroll-layout-fix).

--- a/crunevo/static/css/main.css
+++ b/crunevo/static/css/main.css
@@ -962,7 +962,7 @@ textarea.form-control {
   display: none;
 }
 
-/* Disable page scroll when photo modal is open */
+/* Block page scroll when a modal is open */
 body.photo-modal-open {
   overflow: hidden;
 }

--- a/crunevo/static/css/photo-modal.css
+++ b/crunevo/static/css/photo-modal.css
@@ -856,3 +856,18 @@
   background-color: var(--crunevo-accent);
 }
 
+/* Ensure the info panel uses a flex column layout with internal scroll */
+.facebook-modal-info-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--crunevo-white);
+  border-left: 1px solid var(--crunevo-border);
+  overflow: hidden;
+}
+
+[data-bs-theme="dark"] .facebook-modal-info-panel {
+  background: #242526;
+  border-left: 1px solid var(--crunevo-border);
+}
+

--- a/crunevo/templates/components/comment_modal.html
+++ b/crunevo/templates/components/comment_modal.html
@@ -4,8 +4,8 @@
 
 <!-- Modal de Comentarios -->
 <div class="modal fade" id="commentsModal-{{ post.id }}" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="commentsModalLabel-{{ post.id }}" aria-hidden="true" style="display: none;">
-  <div class="modal-dialog modal-lg modal-dialog-centered modal-fullscreen-sm-down" style="max-height: 90vh;">
-    <div class="modal-content d-flex flex-column" style="height: 100%; overflow: hidden;">
+  <div class="modal-dialog modal-lg modal-dialog-centered modal-fullscreen-sm-down">
+    <div class="modal-content d-flex flex-column" style="height: 90vh; overflow: hidden;">
       <h5 id="commentsModalLabel-{{ post.id }}" class="visually-hidden">Comentarios</h5>
       <!-- Scrollable Content -->
       <div class="modal-scrollable-content" style="flex-grow: 1; overflow-y: auto;">

--- a/crunevo/templates/feed/_post_modal.html
+++ b/crunevo/templates/feed/_post_modal.html
@@ -108,7 +108,7 @@
 </div>
 
 <!-- Fixed comment form -->
-<div class="w-100 compact-comment-form-container">
+<div class="w-100 compact-comment-form-container" style="flex-shrink: 0;">
   {% if current_user.is_authenticated %}
   <form class="comment-form" data-post-id="{{ post.id }}" onsubmit="submitModalComment(event, '{{ post.id }}')">
     {{ csrf.csrf_field() }}


### PR DESCRIPTION
## Summary
- limit Bootstrap comment modal to 90vh and move scroll inside content area
- ensure photo modal info panel uses flex column layout with overflow hidden
- lock body scroll when modals are open and keep comment form fixed

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688e45c043708325874ec617cb3484fe