### PR TITLE
feat: unify comment modal scroll with infinite load

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1060,3 +1060,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Removed Bootstrap's extra scroll class from comment modal to ensure a single scroll area and matched photo modal comment form width using w-100 (PR comment-modal-single-scroll).
 - Refactored comment and photo modals into single-page scrollable layouts, locked body scrolling and anchored comment input at bottom for consistency (PR modal-unified-scroll).
 - Ensured modals remain within viewport using 90vh content height, moved all scroll to internal containers and kept comment input fixed to eliminate outer scrollbars (PR modal-scroll-layout-fix).
+- Implemented single-scroll comment modal with compact comment CSS, load-more button fetching paginated comments with has_more flag, and updated tests to cover new API (PR comment-modal-infinite-scroll).

--- a/crunevo/routes/feed/api.py
+++ b/crunevo/routes/feed/api.py
@@ -134,24 +134,26 @@ def api_comments(post_id):
     post = Post.query.get_or_404(post_id)
     page = request.args.get("page", default=1, type=int)
     per_page = 10
-    comments = (
-        PostComment.query.filter_by(post_id=post.id, pending=False)
-        .order_by(PostComment.timestamp.desc())
-        .offset((page - 1) * per_page)
-        .limit(per_page)
-        .all()
+    query = PostComment.query.filter_by(post_id=post.id, pending=False).order_by(
+        PostComment.timestamp.desc()
     )
+    comments = query.offset((page - 1) * per_page).limit(per_page + 1).all()
+    has_more = len(comments) > per_page
+    comments = comments[:per_page]
     return jsonify(
-        [
-            {
-                "body": c.body,
-                "author": c.author.username,
-                "avatar": c.author.avatar_url
-                or url_for("static", filename="img/default.png"),
-                "timestamp": c.timestamp.isoformat(),
-            }
-            for c in comments
-        ]
+        {
+            "comments": [
+                {
+                    "body": c.body,
+                    "author": c.author.username,
+                    "avatar": c.author.avatar_url
+                    or url_for("static", filename="img/default.png"),
+                    "timestamp": c.timestamp.isoformat(),
+                }
+                for c in comments
+            ],
+            "has_more": has_more,
+        }
     )
 
 

--- a/crunevo/static/css/photo-modal.css
+++ b/crunevo/static/css/photo-modal.css
@@ -286,8 +286,8 @@
 
 .comment-item {
   display: flex;
-  gap: 12px;
-  margin-bottom: 16px;
+  gap: 10px;
+  margin-bottom: 12px;
 }
 
 .comment-avatar {
@@ -303,10 +303,10 @@
 }
 
 .comment-box {
-  background: #F0F2F5;
+  background: var(--crunevo-bg-light);
   border-radius: 16px;
-  padding: 12px 16px;
-  margin-bottom: 4px;
+  padding: 8px 12px;
+  margin-bottom: 2px;
 }
 
 [data-bs-theme="dark"] .comment-box {
@@ -337,8 +337,8 @@
 .comment-meta {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding-left: 16px;
+  gap: 8px;
+  padding-left: 12px;
 }
 
 .empty-comments {

--- a/crunevo/templates/components/comment_modal.html
+++ b/crunevo/templates/components/comment_modal.html
@@ -76,24 +76,22 @@
           </div>
 
           <!-- Sección de Comentarios -->
-          <div class="modal-comments-section px-4">
-            <!-- Lista de Comentarios Existentes -->
+          <div class="modal-comments-section">
             {% set more_comments = post.comments|length > 10 %}
             <div class="comments-list" id="commentsList-{{ post.id }}">
               {% for comment in post.comments[:10] %}
-              <div class="comment-item d-flex mb-3">
+              <div class="comment-item">
                 <img src="{{ comment.author.avatar_url if comment.author else url_for('static', filename='img/default.png') }}"
                      alt="{{ comment.author.username if comment.author else 'Usuario' }}"
-                     class="rounded-circle me-2"
-                     style="width: 32px; height: 32px; object-fit: cover;">
-                <div class="flex-grow-1">
-                  <div class="comment-bubble bg-light rounded-3 p-2">
-                    <div class="comment-author fw-semibold small">
+                     class="comment-avatar">
+                <div class="comment-content">
+                  <div class="comment-box">
+                    <div class="comment-author">
                       {{ comment.author.username if comment.author else 'Usuario eliminado' }}
                     </div>
                     <div class="comment-text">{{ comment.body }}</div>
                   </div>
-                  <div class="comment-meta mt-1">
+                  <div class="comment-meta">
                     <small class="text-muted">{{ comment.timestamp|timesince }}</small>
                     <button class="btn btn-link btn-sm p-0 ms-2 text-muted">Responder</button>
                   </div>

--- a/crunevo/templates/feed/_post_modal.html
+++ b/crunevo/templates/feed/_post_modal.html
@@ -102,7 +102,9 @@
       {% endif %}
     </div>
     {% if more_comments %}
-    <button id="loadMoreCommentsBtn-{{ post.id }}" class="btn btn-link btn-sm w-100 mb-3 load-more-comments" data-post-id="{{ post.id }}">Ver más comentarios</button>
+    <div class="text-center my-2">
+      <button class="btn btn-link load-more-comments" data-post-id="{{ post.id }}" data-page="2">Ver más comentarios</button>
+    </div>
     {% endif %}
   </div>
 </div>

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -242,8 +242,12 @@ def test_comments_api_pagination(client, db_session, test_user):
     resp2 = client.get(f"/feed/api/comments/{post.id}?page=2")
     assert resp1.status_code == 200
     assert resp2.status_code == 200
-    assert len(resp1.get_json()) == 10
-    assert len(resp2.get_json()) == 5
+    data1 = resp1.get_json()
+    data2 = resp2.get_json()
+    assert len(data1["comments"]) == 10
+    assert data1["has_more"] is True
+    assert len(data2["comments"]) == 5
+    assert data2["has_more"] is False
 
 
 def test_comment_disabled_returns_403(client, db_session, test_user, another_user):


### PR DESCRIPTION
## Summary
- streamline comment modal layout and styles
- add paginated comment loading with client-side handler
- expose has_more in comments API and cover with tests

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688e4a003db88325be120f44cbb02504