### PR TITLE
fix: remove nested scroll in modal comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1061,3 +1061,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Refactored comment and photo modals into single-page scrollable layouts, locked body scrolling and anchored comment input at bottom for consistency (PR modal-unified-scroll).
 - Ensured modals remain within viewport using 90vh content height, moved all scroll to internal containers and kept comment input fixed to eliminate outer scrollbars (PR modal-scroll-layout-fix).
 - Implemented single-scroll comment modal with compact comment CSS, load-more button fetching paginated comments with has_more flag, and updated tests to cover new API (PR comment-modal-infinite-scroll).
+- Removed nested scroll by stripping overflow and height limits from `.modal-comments-section`, consolidating scrolling to the parent container (PR modal-comments-scroll-fix).

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -1311,9 +1311,7 @@ select:focus {
 
 /* Modal Comments Section */
 .modal-comments-section {
-  padding: 20px;
-  max-height: 400px;
-  overflow-y: auto;
+  padding: 0 20px;
 }
 
 .comments-list {
@@ -1414,8 +1412,8 @@ select:focus {
   }
 
   .modal-comments-section {
-    max-height: 300px;
-    padding: 15px;
+    padding-left: 16px;
+    padding-right: 16px;
   }
 }
 

--- a/crunevo/static/css/photo-modal.css
+++ b/crunevo/static/css/photo-modal.css
@@ -469,9 +469,6 @@
     border-top: 1px solid var(--crunevo-border);
   }
 
-  .modal-comments-section {
-    max-height: none;
-  }
   
   .modal-top-controls {
     top: 10px;


### PR DESCRIPTION
## Summary
- strip overflow and max-height from `.modal-comments-section` to prevent nested scrollbars
- align `feed.css` with single-scroll modal layout

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688e524e933c832594d589d1ada31a4d