### PR TITLE
Refactor post modals to two-panel layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1062,3 +1062,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Ensured modals remain within viewport using 90vh content height, moved all scroll to internal containers and kept comment input fixed to eliminate outer scrollbars (PR modal-scroll-layout-fix).
 - Implemented single-scroll comment modal with compact comment CSS, load-more button fetching paginated comments with has_more flag, and updated tests to cover new API (PR comment-modal-infinite-scroll).
 - Removed nested scroll by stripping overflow and height limits from `.modal-comments-section`, consolidating scrolling to the parent container (PR modal-comments-scroll-fix).
+- Rebuilt post and comment modals with two-panel layout, fixed header and bottom comment form, and single scrollable info panel with responsive stacking (PR modal-two-panel-layout).

--- a/crunevo/static/css/photo-modal.css
+++ b/crunevo/static/css/photo-modal.css
@@ -49,8 +49,10 @@
 /* ✅ CORREGIDO: Usaremos una sola clase base y modificadores */
 .facebook-modal-container {
   display: grid;
-  width: 100%;
-  height: 100%;
+  grid-template-columns: 1fr 400px;
+  width: 90vw;
+  height: 90vh;
+  max-width: 1400px;
   border-radius: 0;
   overflow: hidden;
   background: var(--crunevo-white);
@@ -58,7 +60,7 @@
 }
 
 .facebook-modal-container.image-with-comments {
-  grid-template-columns: 1fr 400px;
+  /* modifier retained for compatibility */
 }
 
 /* Image Section */
@@ -100,6 +102,31 @@
 [data-bs-theme="dark"] .facebook-modal-info-panel {
   background: #242526;
   border-left: 1px solid var(--crunevo-border);
+}
+
+/* Single scroll layout */
+.modal-scrollable-content {
+  flex-grow: 1;
+  overflow-y: auto;
+}
+
+@media (max-width: 768px) {
+  .facebook-modal-container {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr;
+    width: 100%;
+    height: 100%;
+  }
+
+  .facebook-modal-info-panel {
+    border-left: none;
+    border-top: 1px solid var(--crunevo-border);
+    max-height: 50vh;
+  }
+
+  [data-bs-theme="dark"] .facebook-modal-info-panel {
+    border-top: 1px solid var(--crunevo-border);
+  }
 }
 
 /* Post Header */
@@ -452,70 +479,6 @@
   backdrop-filter: blur(10px);
 }
 
-/* Responsive Design */
-@media (max-width: 768px) {
-  .facebook-modal-container {
-    grid-template-columns: 1fr;
-    grid-template-rows: 60vh auto;
-  }
-
-  .facebook-modal-info-panel {
-    border-left: none;
-    border-top: 1px solid var(--crunevo-border);
-    max-height: 40vh;
-  }
-
-  [data-bs-theme="dark"] .facebook-modal-info-panel {
-    border-top: 1px solid var(--crunevo-border);
-  }
-
-  
-  .modal-top-controls {
-    top: 10px;
-    right: 10px;
-  }
-  
-  .modal-control-btn {
-    width: 40px;
-    height: 40px;
-    font-size: 16px;
-  }
-  
-  .modal-nav {
-    width: 48px;
-    height: 48px;
-    font-size: 20px;
-  }
-  
-  .modal-nav.prev {
-    left: 10px;
-  }
-  
-  .modal-nav.next {
-    right: 10px;
-  }
-  
-  .modal-counter {
-    bottom: 10px;
-    font-size: 12px;
-    padding: 6px 12px;
-  }
-  
-  .modal-post-header,
-  .modal-post-content,
-  .modal-post-actions,
-  .modal-stats,
-  .modal-comment-form {
-    padding-left: 16px;
-    padding-right: 16px;
-  }
-  
-  .modal-comments-section {
-    padding-left: 16px;
-    padding-right: 16px;
-  }
-}
-
 @media (max-width: 480px) {
   .modal-top-controls {
     gap: 4px;
@@ -745,40 +708,6 @@
 }
 
 /* ✅ AÑADIDO: Media Query para Tablets y Móviles */
-@media (max-width: 992px) {
-  /* Hacemos que el grid se convierta en una sola columna y dos filas */
-  .facebook-modal-container.image-with-comments {
-    grid-template-columns: 1fr; /* Una sola columna */
-    grid-template-rows: 55vh auto; /* Imagen 55% de la altura, panel el resto */
-    width: 100%;
-    height: 100%;
-    border-radius: 0;
-  }
-
-  .facebook-modal-info-panel {
-    border-left: none;
-    border-top: 1px solid var(--crunevo-border);
-    max-height: 45vh; /* Limitamos altura del panel de info */
-  }
-
-  .modal-top-controls {
-    top: 10px;
-    right: 10px;
-    gap: 8px;
-  }
-
-  .modal-control-btn {
-    width: 38px;
-    height: 38px;
-    font-size: 16px;
-  }
-
-.modal-nav {
-    width: 48px;
-    height: 48px;
-  }
-}
-
 /* ✅ AÑADIDO: Estilo COMPACTO y UNIFICADO para el formulario de comentarios */
 .compact-comment-form-container {
   width: 100%;

--- a/crunevo/static/js/comment.js
+++ b/crunevo/static/js/comment.js
@@ -60,6 +60,7 @@ function submitModalComment(event, postId) {
       if (data) {
         addCommentToModalUI(data, postId);
         input.value = '';
+        input.style.height = 'auto';
         window.modernFeedManager?.showToast('Comentario agregado', 'success');
 
         // Update comment count in main feed
@@ -137,9 +138,12 @@ function addCommentToModalUI(comment, postId) {
 
   commentsList.insertAdjacentHTML('beforeend', commentHTML);
 
-  // Scroll to bottom - handle both modal types
-  const commentsSection = commentsList.closest('.modal-comments-section') || commentsList;
-  commentsSection.scrollTop = commentsSection.scrollHeight;
+  // Scroll to bottom within the modal's scrollable area
+  const scrollContainer =
+    commentsList.closest('.modal-scrollable-content') ||
+    commentsList.closest('.modal-comments-section') ||
+    commentsList;
+  scrollContainer.scrollTop = scrollContainer.scrollHeight;
 }
 
 let commentsInitialized = false;

--- a/crunevo/templates/components/comment_modal.html
+++ b/crunevo/templates/components/comment_modal.html
@@ -7,125 +7,112 @@
   <div class="modal-dialog modal-lg modal-dialog-centered modal-fullscreen-sm-down">
     <div class="modal-content d-flex flex-column" style="height: 90vh; overflow: hidden;">
       <h5 id="commentsModalLabel-{{ post.id }}" class="visually-hidden">Comentarios</h5>
+
+      <!-- Header (non-scrollable) -->
+      <div class="modal-post-header">
+        <img src="{{ post.author.avatar_url if post.author else url_for('static', filename='img/default.png') }}"
+             alt="{{ post.author.username if post.author else 'Usuario eliminado' }}"
+             class="modal-post-avatar">
+        <div class="modal-user-info">
+          <h6 class="modal-username">{{ post.author.username if post.author else 'Usuario eliminado' }}</h6>
+          <small class="modal-timestamp">{{ post.created_at|timesince }}</small>
+        </div>
+        <button type="button" class="modal-close-btn" data-bs-dismiss="modal" aria-label="Cerrar">
+          <i class="bi bi-x"></i>
+        </button>
+      </div>
+
       <!-- Scrollable Content -->
-      <div class="modal-scrollable-content" style="flex-grow: 1; overflow-y: auto;">
-        <!-- Header del Modal -->
-        <div class="modal-header border-0 pb-0">
-          <div class="d-flex align-items-center">
-            <img src="{{ post.author.avatar_url if post.author else url_for('static', filename='img/default.png') }}"
-                 alt="{{ post.author.username if post.author else 'Usuario eliminado' }}"
-                 class="rounded-circle me-3"
-                 style="width: 40px; height: 40px; object-fit: cover;">
-            <div>
-              <h6 class="mb-0 fw-bold">{{ post.author.username if post.author else 'Usuario eliminado' }}</h6>
-              <small class="text-muted">{{ post.created_at|timesince }}</small>
+      <div class="modal-scrollable-content">
+        {% if post.content %}
+        <div class="modal-post-content">
+          <p class="modal-post-text">{{ post.content }}</p>
+        </div>
+        {% endif %}
+
+        {% if post.images %}
+        {{ gallery.image_gallery(post.images, post.id) }}
+        {% elif post.file_url and not post.file_url.endswith('.pdf') %}
+        {{ gallery.image_gallery([post.file_url], post.id) }}
+        {% endif %}
+
+        <div class="modal-post-actions">
+          <div class="relative reaction-container" data-post-id="{{ post.id }}" data-my-reaction="{{ user_reactions.get(post.id, '') }}">
+            <button class="modal-action-btn like-btn {{ 'active' if user_reactions.get(post.id) }}" data-post-id="{{ post.id }}">
+              <i class="bi bi-fire{{ '-fill' if user_reactions.get(post.id) else '' }}"></i>
+              <span class="action-text">Me gusta</span>
+              <span class="action-count">{{ reaction_counts.get(post.id, {}).get('🔥', '') }}</span>
+            </button>
+            <div class="reaction-panel d-none">
+              <button class="reaction-btn" data-reaction="🔥" title="Crunazo">🔥</button>
+              <button class="reaction-btn" data-reaction="🧠" title="Neuro">🧠</button>
+              <button class="reaction-btn" data-reaction="💔" title="Roto">💔</button>
+              <button class="reaction-btn" data-reaction="😠" title="Molesto">😠</button>
+              <button class="reaction-btn" data-reaction="🥶" title="Congelao">🥶</button>
+              <button class="reaction-btn" data-reaction="😂" title="Vacilón">😂</button>
+              <button class="reaction-btn" data-reaction="🤡" title="Cringe">🤡</button>
+              <button class="reaction-btn" data-reaction="😲" title="Asu">😲</button>
+              <button class="reaction-btn" data-reaction="👍" title="Me gusta">👍</button>
+              <button class="reaction-btn" data-reaction="💡" title="Interesante">💡</button>
+              <button class="reaction-btn" data-reaction="🙌" title="Gracias">🙌</button>
+              <button class="reaction-btn" data-reaction="📌" title="Lo guardé">📌</button>
             </div>
           </div>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+          <button class="modal-action-btn share-btn" data-post-id="{{ post.id }}">
+            <i class="bi bi-share"></i>
+            <span>Compartir</span>
+          </button>
+          <button class="modal-action-btn save-btn {{ 'active' if saved_posts.get(post.id) }}" data-post-id="{{ post.id }}">
+            <i class="bi bi-bookmark{{ '-fill' if saved_posts.get(post.id) else '' }}"></i>
+            <span>Guardar</span>
+          </button>
         </div>
 
-        <!-- Contenido del Post -->
-        <div class="modal-body p-0">
-          <!-- Texto del Post -->
-          {% if post.content %}
-          <div class="px-4 py-3">
-            <p class="mb-0">{{ post.content }}</p>
-          </div>
-          {% endif %}
-
-          <!-- Galería de Imágenes -->
-          {% if post.images %}
-          {{ gallery.image_gallery(post.images, post.id) }}
-          {% elif post.file_url and not post.file_url.endswith('.pdf') %}
-          {{ gallery.image_gallery([post.file_url], post.id) }}
-          {% endif %}
-
-          <!-- Acciones del Post (Me gusta, etc.) -->
-          <div class="modal-post-actions px-4 py-2 border-top border-bottom">
-            <div class="d-flex justify-content-around">
-              <div class="relative reaction-container" data-post-id="{{ post.id }}" data-my-reaction="{{ user_reactions.get(post.id, '') }}">
-                <button class="modal-action-btn like-btn {{ 'active' if user_reactions.get(post.id) }}" data-post-id="{{ post.id }}">
-                  <i class="bi bi-fire{{ '-fill' if user_reactions.get(post.id) else '' }}"></i>
-                  <span class="action-text">Me gusta</span>
-                  <span class="action-count">{{ reaction_counts.get(post.id, {}).get('🔥', '') }}</span>
-                </button>
-                <div class="reaction-panel d-none">
-                  <button class="reaction-btn" data-reaction="🔥" title="Crunazo">🔥</button>
-                  <button class="reaction-btn" data-reaction="🧠" title="Neuro">🧠</button>
-                  <button class="reaction-btn" data-reaction="💔" title="Roto">💔</button>
-                  <button class="reaction-btn" data-reaction="😠" title="Molesto">😠</button>
-                  <button class="reaction-btn" data-reaction="🥶" title="Congelao">🥶</button>
-                  <button class="reaction-btn" data-reaction="😂" title="Vacilón">😂</button>
-                  <button class="reaction-btn" data-reaction="🤡" title="Cringe">🤡</button>
-                  <button class="reaction-btn" data-reaction="😲" title="Asu">😲</button>
-                  <button class="reaction-btn" data-reaction="👍" title="Me gusta">👍</button>
-                  <button class="reaction-btn" data-reaction="💡" title="Interesante">💡</button>
-                  <button class="reaction-btn" data-reaction="🙌" title="Gracias">🙌</button>
-                  <button class="reaction-btn" data-reaction="📌" title="Lo guardé">📌</button>
+        <div class="modal-comments-section">
+          {% set more_comments = post.comments|length > 10 %}
+          <div class="comments-list" id="commentsList-{{ post.id }}">
+            {% for comment in post.comments[:10] %}
+            <div class="comment-item">
+              <img src="{{ comment.author.avatar_url if comment.author else url_for('static', filename='img/default.png') }}"
+                   alt="{{ comment.author.username if comment.author else 'Usuario' }}"
+                   class="comment-avatar">
+              <div class="comment-content">
+                <div class="comment-box">
+                  <div class="comment-author">{{ comment.author.username if comment.author else 'Usuario eliminado' }}</div>
+                  <div class="comment-text">{{ comment.body }}</div>
+                </div>
+                <div class="comment-meta">
+                  <small class="text-muted">{{ comment.timestamp|timesince }}</small>
+                  <button class="btn btn-link btn-sm p-0 ms-2 text-muted">Responder</button>
                 </div>
               </div>
-              <button class="modal-action-btn share-btn" data-post-id="{{ post.id }}">
-                <i class="bi bi-share"></i>
-                <span>Compartir</span>
-              </button>
-              <button class="modal-action-btn save-btn {{ 'active' if saved_posts.get(post.id) }}" data-post-id="{{ post.id }}">
-                <i class="bi bi-bookmark{{ '-fill' if saved_posts.get(post.id) else '' }}"></i>
-                <span>Guardar</span>
-              </button>
             </div>
+            {% endfor %}
           </div>
-
-          <!-- Sección de Comentarios -->
-          <div class="modal-comments-section">
-            {% set more_comments = post.comments|length > 10 %}
-            <div class="comments-list" id="commentsList-{{ post.id }}">
-              {% for comment in post.comments[:10] %}
-              <div class="comment-item">
-                <img src="{{ comment.author.avatar_url if comment.author else url_for('static', filename='img/default.png') }}"
-                     alt="{{ comment.author.username if comment.author else 'Usuario' }}"
-                     class="comment-avatar">
-                <div class="comment-content">
-                  <div class="comment-box">
-                    <div class="comment-author">
-                      {{ comment.author.username if comment.author else 'Usuario eliminado' }}
-                    </div>
-                    <div class="comment-text">{{ comment.body }}</div>
-                  </div>
-                  <div class="comment-meta">
-                    <small class="text-muted">{{ comment.timestamp|timesince }}</small>
-                    <button class="btn btn-link btn-sm p-0 ms-2 text-muted">Responder</button>
-                  </div>
-                </div>
-              </div>
-              {% endfor %}
-            </div>
-            {% if more_comments %}
-            <div class="text-center my-2">
-              <button class="btn btn-link load-more-comments" data-post-id="{{ post.id }}" data-page="2">Cargar más comentarios</button>
-            </div>
-            {% endif %}
-
+          {% if more_comments %}
+          <div class="text-center my-2">
+            <button class="btn btn-link load-more-comments" data-post-id="{{ post.id }}" data-page="2">Cargar más comentarios</button>
           </div>
+          {% endif %}
         </div>
       </div>
+
       <!-- Footer fijo con el input -->
-      <div class="modal-footer p-0" style="flex-shrink: 0;">
-        <div class="w-100 compact-comment-form-container">
-          {% if current_user.is_authenticated %}
-          <form class="comment-form" data-post-id="{{ post.id }}" onsubmit="submitModalComment(event, '{{ post.id }}')">
-            {{ csrf.csrf_field() }}
-            <div class="compact-comment-form-group">
-              <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" alt="{{ current_user.username }}" class="compact-comment-form-avatar">
-              <div class="compact-comment-input-wrapper">
-                <textarea class="compact-comment-input comment-input" name="body" rows="1" placeholder="Escribe un comentario..." oninput="this.style.height = 'auto'; this.style.height = this.scrollHeight + 'px'"></textarea>
-                <button type="submit" class="compact-comment-submit-btn comment-submit-btn" disabled><i class="bi bi-send-fill"></i></button>
-              </div>
+      <div class="unified-comment-form-container compact-comment-form-container">
+        {% if current_user.is_authenticated %}
+        <form class="comment-form" data-post-id="{{ post.id }}" onsubmit="submitModalComment(event, '{{ post.id }}')">
+          {{ csrf.csrf_field() }}
+          <div class="compact-comment-form-group">
+            <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" alt="{{ current_user.username }}" class="compact-comment-form-avatar">
+            <div class="compact-comment-input-wrapper">
+              <textarea class="compact-comment-input comment-input" name="body" rows="1" placeholder="Escribe un comentario..." oninput="this.style.height = 'auto'; this.style.height = this.scrollHeight + 'px'"></textarea>
+              <button type="submit" class="compact-comment-submit-btn comment-submit-btn" disabled><i class="bi bi-send-fill"></i></button>
             </div>
-          </form>
-          {% else %}
-            <!-- Mensaje de inicio de sesión -->
-          {% endif %}
-        </div>
+          </div>
+        </form>
+        {% else %}
+          <!-- Mensaje de inicio de sesión -->
+        {% endif %}
       </div>
     </div>
   </div>

--- a/crunevo/templates/feed/_post_modal.html
+++ b/crunevo/templates/feed/_post_modal.html
@@ -1,20 +1,21 @@
 {% import 'components/csrf.html' as csrf %}
 {% set saved_posts = saved_posts if saved_posts is defined else {} %}
 
-<!-- Scrollable content -->
-<div class="modal-scrollable-content" style="flex-grow: 1; overflow-y: auto;">
-  <div class="modal-post-header">
-    <img src="{{ post.author.avatar_url or url_for('static', filename='img/default.png') }}" alt="Avatar de {{ post.author.username }}" class="modal-post-avatar">
-    <div class="modal-user-info">
-      <h6 class="modal-username">{{ post.author.username }}</h6>
-      {% if post.author.career %}<span class="modal-career-badge">{{ post.author.career }}</span>{% endif %}
-      <small class="modal-timestamp">{{ post.created_at|timesince }}</small>
-    </div>
-    <button type="button" class="modal-close-btn" onclick="modernFeedManager.closeModal()" aria-label="Cerrar">
-      <i class="bi bi-x"></i>
-    </button>
+<!-- Header (non-scrollable) -->
+<div class="modal-post-header">
+  <img src="{{ post.author.avatar_url or url_for('static', filename='img/default.png') }}" alt="Avatar de {{ post.author.username }}" class="modal-post-avatar">
+  <div class="modal-user-info">
+    <h6 class="modal-username">{{ post.author.username }}</h6>
+    {% if post.author.career %}<span class="modal-career-badge">{{ post.author.career }}</span>{% endif %}
+    <small class="modal-timestamp">{{ post.created_at|timesince }}</small>
   </div>
+  <button type="button" class="modal-close-btn" onclick="modernFeedManager.closeModal()" aria-label="Cerrar">
+    <i class="bi bi-x"></i>
+  </button>
+</div>
 
+<!-- Scrollable content -->
+<div class="modal-scrollable-content">
   {% if post.content %}
   <div class="modal-post-content">
     <p class="modal-post-text">{{ post.content }}</p>
@@ -110,7 +111,7 @@
 </div>
 
 <!-- Fixed comment form -->
-<div class="w-100 compact-comment-form-container" style="flex-shrink: 0;">
+<div class="unified-comment-form-container compact-comment-form-container">
   {% if current_user.is_authenticated %}
   <form class="comment-form" data-post-id="{{ post.id }}" onsubmit="submitModalComment(event, '{{ post.id }}')">
     {{ csrf.csrf_field() }}


### PR DESCRIPTION
## Summary
- Rebuild post and comment modals with static media pane and scrollable info/comments pane
- Add grid/flex CSS for two-panel desktop layout and stacked mobile layout
- Reset comment textarea and auto-scroll after posting

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688e7b38a63883259dcb154cc8880185