### PR TITLE
Fix double scroll in comment modal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1063,3 +1063,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Implemented single-scroll comment modal with compact comment CSS, load-more button fetching paginated comments with has_more flag, and updated tests to cover new API (PR comment-modal-infinite-scroll).
 - Removed nested scroll by stripping overflow and height limits from `.modal-comments-section`, consolidating scrolling to the parent container (PR modal-comments-scroll-fix).
 - Rebuilt post and comment modals with two-panel layout, fixed header and bottom comment form, and single scrollable info panel with responsive stacking (PR modal-two-panel-layout).
+- Resolved double scroll in Facebook-style modal by enforcing flexbox layout with a single scrollable content area, updating comment modal markup and scroll handling (PR modal-single-scroll-fix).

--- a/crunevo/static/css/photo-modal.css
+++ b/crunevo/static/css/photo-modal.css
@@ -108,6 +108,16 @@
 .modal-scrollable-content {
   flex-grow: 1;
   overflow-y: auto;
+  padding: 16px;
+}
+
+.modal-post-header,
+.unified-comment-form-container {
+  flex-shrink: 0;
+}
+
+.modal-content {
+  overflow: hidden;
 }
 
 @media (max-width: 768px) {
@@ -136,7 +146,6 @@
   gap: 12px;
   padding: 20px;
   border-bottom: 1px solid #E4E6EA;
-  flex-shrink: 0;
 }
 
 [data-bs-theme="dark"] .modal-post-header {
@@ -650,7 +659,6 @@
   padding: 12px 16px;
   border-top: 1px solid var(--crunevo-border);
   background-color: var(--crunevo-white);
-  flex-shrink: 0; /* Asegura que este elemento no se encoja */
 }
 
 .unified-comment-form-group {
@@ -714,7 +722,6 @@
   padding: 10px 16px;
   border-top: 1px solid var(--crunevo-border);
   background-color: var(--crunevo-white);
-  flex-shrink: 0; /* Importantísimo para que no se encoja */
   box-sizing: border-box;
 }
 
@@ -780,20 +787,5 @@
 .compact-comment-submit-btn:not(:disabled):hover {
   transform: scale(1.1);
   background-color: var(--crunevo-accent);
-}
-
-/* Ensure the info panel uses a flex column layout with internal scroll */
-.facebook-modal-info-panel {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  background: var(--crunevo-white);
-  border-left: 1px solid var(--crunevo-border);
-  overflow: hidden;
-}
-
-[data-bs-theme="dark"] .facebook-modal-info-panel {
-  background: #242526;
-  border-left: 1px solid var(--crunevo-border);
 }
 

--- a/crunevo/static/js/comment.js
+++ b/crunevo/static/js/comment.js
@@ -139,11 +139,10 @@ function addCommentToModalUI(comment, postId) {
   commentsList.insertAdjacentHTML('beforeend', commentHTML);
 
   // Scroll to bottom within the modal's scrollable area
-  const scrollContainer =
-    commentsList.closest('.modal-scrollable-content') ||
-    commentsList.closest('.modal-comments-section') ||
-    commentsList;
-  scrollContainer.scrollTop = scrollContainer.scrollHeight;
+  const scrollContainer = commentsList.closest('.modal-scrollable-content');
+  if (scrollContainer) {
+    scrollContainer.scrollTop = scrollContainer.scrollHeight;
+  }
 }
 
 let commentsInitialized = false;

--- a/crunevo/templates/components/comment_modal.html
+++ b/crunevo/templates/components/comment_modal.html
@@ -5,7 +5,7 @@
 <!-- Modal de Comentarios -->
 <div class="modal fade" id="commentsModal-{{ post.id }}" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="commentsModalLabel-{{ post.id }}" aria-hidden="true" style="display: none;">
   <div class="modal-dialog modal-lg modal-dialog-centered modal-fullscreen-sm-down">
-    <div class="modal-content d-flex flex-column" style="height: 90vh; overflow: hidden;">
+    <div class="modal-content facebook-modal-info-panel" style="height: 90vh;">
       <h5 id="commentsModalLabel-{{ post.id }}" class="visually-hidden">Comentarios</h5>
 
       <!-- Header (non-scrollable) -->


### PR DESCRIPTION
## Summary
- prevent outer modal from scrolling by hiding overflow on `.modal-content`
- make info panel flex column with scrollable content and padded area
- auto-scroll comment panel after posting a comment

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688e80a55cb48325b667c351bbe984b7