### PR TITLE
fix: remove comment modal double scroll

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1064,3 +1064,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Removed nested scroll by stripping overflow and height limits from `.modal-comments-section`, consolidating scrolling to the parent container (PR modal-comments-scroll-fix).
 - Rebuilt post and comment modals with two-panel layout, fixed header and bottom comment form, and single scrollable info panel with responsive stacking (PR modal-two-panel-layout).
 - Resolved double scroll in Facebook-style modal by enforcing flexbox layout with a single scrollable content area, updating comment modal markup and scroll handling (PR modal-single-scroll-fix).
+- Removed nested scroll from comment modal by making modal body the only scrollable area and sticking the comment form to the bottom (PR comment-modal-scroll-unification).

--- a/crunevo/static/css/photo-modal.css
+++ b/crunevo/static/css/photo-modal.css
@@ -111,13 +111,40 @@
   padding: 16px;
 }
 
-.modal-post-header,
-.unified-comment-form-container {
+.modal-post-header {
   flex-shrink: 0;
 }
 
 .modal-content {
   overflow: hidden;
+}
+
+/* Comment modal layout */
+.comment-modal .modal-dialog {
+  height: 100vh;
+  max-height: 100vh;
+}
+
+.comment-modal .modal-content {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.comment-modal .modal-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  padding-bottom: 90px;
+}
+
+.comment-modal .comment-input-container {
+  position: sticky;
+  bottom: 0;
+  background: var(--crunevo-white);
+  z-index: 10;
+  border-top: 1px solid var(--crunevo-border);
 }
 
 @media (max-width: 768px) {

--- a/crunevo/templates/components/comment_modal.html
+++ b/crunevo/templates/components/comment_modal.html
@@ -3,9 +3,9 @@
 {% set saved_posts = saved_posts if saved_posts is defined else {} %}
 
 <!-- Modal de Comentarios -->
-<div class="modal fade" id="commentsModal-{{ post.id }}" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="commentsModalLabel-{{ post.id }}" aria-hidden="true" style="display: none;">
+<div class="modal fade comment-modal" id="commentsModal-{{ post.id }}" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="commentsModalLabel-{{ post.id }}" aria-hidden="true" style="display: none;">
   <div class="modal-dialog modal-lg modal-dialog-centered modal-fullscreen-sm-down">
-    <div class="modal-content facebook-modal-info-panel" style="height: 90vh;">
+    <div class="modal-content facebook-modal-info-panel">
       <h5 id="commentsModalLabel-{{ post.id }}" class="visually-hidden">Comentarios</h5>
 
       <!-- Header (non-scrollable) -->
@@ -23,7 +23,7 @@
       </div>
 
       <!-- Scrollable Content -->
-      <div class="modal-scrollable-content">
+      <div class="modal-body modal-scrollable-content">
         {% if post.content %}
         <div class="modal-post-content">
           <p class="modal-post-text">{{ post.content }}</p>
@@ -95,24 +95,24 @@
           </div>
           {% endif %}
         </div>
-      </div>
 
-      <!-- Footer fijo con el input -->
-      <div class="unified-comment-form-container compact-comment-form-container">
-        {% if current_user.is_authenticated %}
-        <form class="comment-form" data-post-id="{{ post.id }}" onsubmit="submitModalComment(event, '{{ post.id }}')">
-          {{ csrf.csrf_field() }}
-          <div class="compact-comment-form-group">
-            <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" alt="{{ current_user.username }}" class="compact-comment-form-avatar">
-            <div class="compact-comment-input-wrapper">
-              <textarea class="compact-comment-input comment-input" name="body" rows="1" placeholder="Escribe un comentario..." oninput="this.style.height = 'auto'; this.style.height = this.scrollHeight + 'px'"></textarea>
-              <button type="submit" class="compact-comment-submit-btn comment-submit-btn" disabled><i class="bi bi-send-fill"></i></button>
+        <!-- Footer fijo con el input -->
+        <div class="comment-input-container unified-comment-form-container compact-comment-form-container">
+          {% if current_user.is_authenticated %}
+          <form class="comment-form" data-post-id="{{ post.id }}" onsubmit="submitModalComment(event, '{{ post.id }}')">
+            {{ csrf.csrf_field() }}
+            <div class="compact-comment-form-group">
+              <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" alt="{{ current_user.username }}" class="compact-comment-form-avatar">
+              <div class="compact-comment-input-wrapper">
+                <textarea class="compact-comment-input comment-input" name="body" rows="1" placeholder="Escribe un comentario..." oninput="this.style.height = 'auto'; this.style.height = this.scrollHeight + 'px'"></textarea>
+                <button type="submit" class="compact-comment-submit-btn comment-submit-btn" disabled><i class="bi bi-send-fill"></i></button>
+              </div>
             </div>
-          </div>
-        </form>
-        {% else %}
-          <!-- Mensaje de inicio de sesión -->
-        {% endif %}
+          </form>
+          {% else %}
+            <!-- Mensaje de inicio de sesión -->
+          {% endif %}
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- make comment modal body the single scroll area and move comment form inside it
- stick comment input to bottom to mimic Facebook behavior
- add repo notes for scroll unification

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e8e1316a48325b7afcd75b658ac73