### PR TITLE
refactor: clean comment modal scroll and styles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1065,3 +1065,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Rebuilt post and comment modals with two-panel layout, fixed header and bottom comment form, and single scrollable info panel with responsive stacking (PR modal-two-panel-layout).
 - Resolved double scroll in Facebook-style modal by enforcing flexbox layout with a single scrollable content area, updating comment modal markup and scroll handling (PR modal-single-scroll-fix).
 - Eliminated remaining double scroll in comment modal by moving the comment form inside a single scrollable body, making it sticky at the bottom and removing inner comment list overflow (PR comment-modal-sticky-input).
+- Consolidated comment modal layout by placing the comment form outside the scrollable body, cleaning duplicate comment styles and reinforcing single-scroll behavior with sticky input (PR comment-modal-css-cleanup).

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -1021,77 +1021,6 @@ select:focus {
   }
 }
 
-/* Comments Modal Styles */
-.comment-item {
-  padding: 8px 0;
-}
-
-.comment-bubble {
-  background: var(--hover-bg);
-  border-radius: 16px;
-  padding: 8px 12px;
-  display: inline-block;
-  max-width: 100%;
-}
-
-.comment-author {
-  font-size: 13px;
-  color: var(--text-primary);
-  margin-bottom: 2px;
-}
-
-.comment-text {
-  font-size: 14px;
-  color: var(--text-primary);
-  line-height: 1.3;
-  margin: 0;
-}
-
-.comment-meta {
-  margin-left: 12px;
-  margin-top: 4px;
-}
-
-.comment-meta .btn-link {
-  font-size: 12px;
-  font-weight: 600;
-  text-decoration: none;
-}
-
-.comment-meta .btn-link:hover {
-  text-decoration: underline;
-}
-
-.comment-form .comment-input {
-  border-radius: 20px;
-  padding: 8px 45px 8px 12px;
-  border: 1px solid var(--border-color);
-  background: var(--hover-bg);
-}
-
-.comment-form .comment-input:focus {
-  outline: none;
-  border-color: var(--crunevo-primary);
-  box-shadow: 0 0 0 2px rgba(109, 40, 217, 0.1);
-}
-
-.post-content-modal {
-  border-bottom: 1px solid var(--border-color);
-  padding-bottom: 16px;
-}
-
-.post-content-modal p {
-  font-size: 15px;
-  line-height: 1.4;
-  color: var(--text-primary);
-  margin-bottom: 12px;
-}
-
-.comments-list {
-  max-height: 400px;
-  overflow-y: auto;
-}
-
 /* Interest/Not Interest Actions */
 .post-interest-actions {
   padding: 12px 16px;
@@ -1309,87 +1238,6 @@ select:focus {
   color: var(--crunevo-primary);
 }
 
-/* Modal Comments Section */
-.modal-comments-section {
-  padding: 0 20px;
-}
-
-.comments-list {
-  margin-bottom: 20px;
-}
-
-.comment-modal .comments-list {
-  max-height: none;
-  overflow: visible;
-}
-
-.comment-item {
-  padding: 8px 0;
-}
-
-.comment-bubble {
-  background: var(--hover-bg) !important;
-  border-radius: 16px !important;
-  padding: 8px 12px !important;
-  display: inline-block;
-  max-width: 100%;
-}
-
-[data-bs-theme="dark"] .comment-bubble {
-  background: #3A3B3C !important;
-}
-
-.comment-author {
-  font-size: 13px;
-  color: var(--text-primary);
-  margin-bottom: 2px;
-  font-weight: 600;
-}
-
-.comment-text {
-  font-size: 14px;
-  color: var(--text-primary);
-  line-height: 1.3;
-  margin: 0;
-}
-
-.comment-meta {
-  margin-left: 12px;
-  margin-top: 4px;
-}
-
-.comment-meta .btn-link {
-  font-size: 12px;
-  font-weight: 600;
-  text-decoration: none;
-  color: var(--text-secondary);
-}
-
-.comment-meta .btn-link:hover {
-  text-decoration: underline;
-  color: var(--text-primary);
-}
-
-/* Add Comment Form */
-.add-comment-form .comment-input {
-  border: 1px solid var(--border-color);
-  background: var(--hover-bg);
-  color: var(--text-primary);
-  font-size: 14px;
-  padding: 8px 45px 8px 12px;
-}
-
-.add-comment-form .comment-input:focus {
-  outline: none;
-  border-color: var(--crunevo-primary);
-  box-shadow: 0 0 0 2px rgba(109, 40, 217, 0.1);
-  background: var(--post-bg);
-}
-
-.add-comment-form .comment-input::placeholder {
-  color: var(--text-muted);
-}
-
 /* Responsive adjustments for modal gallery */
 @media (max-width: 768px) {
   .modal-dialog {
@@ -1414,11 +1262,6 @@ select:focus {
 
   .modal-gallery-overlay .overlay-text {
     font-size: 20px;
-  }
-
-  .modal-comments-section {
-    padding-left: 16px;
-    padding-right: 16px;
   }
 }
 

--- a/crunevo/static/css/photo-modal.css
+++ b/crunevo/static/css/photo-modal.css
@@ -141,7 +141,6 @@
 .comment-modal .modal-body {
   flex: 1;
   overflow-y: auto;
-  padding-bottom: 90px;
 }
 
 .comment-modal .comment-input-container {
@@ -150,6 +149,7 @@
   background-color: var(--crunevo-white);
   z-index: 10;
   border-top: 1px solid var(--crunevo-border);
+  flex-shrink: 0;
 }
 
 @media (max-width: 768px) {

--- a/crunevo/templates/components/comment_modal.html
+++ b/crunevo/templates/components/comment_modal.html
@@ -93,8 +93,8 @@
           </div>
           {% endif %}
         </div>
-
-        <div class="unified-comment-form-container compact-comment-form-container comment-input-container">
+      </div>
+      <div class="unified-comment-form-container compact-comment-form-container comment-input-container">
           {% if current_user.is_authenticated %}
           <form class="comment-form" data-post-id="{{ post.id }}" onsubmit="submitModalComment(event, '{{ post.id }}')">
             {{ csrf.csrf_field() }}
@@ -109,7 +109,6 @@
           {% else %}
             <!-- Mensaje de inicio de sesión -->
           {% endif %}
-        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- move modal comment form outside scrollable area for a single vertical scroll
- remove duplicated comment styles and padding to keep sticky input
- clean feed comment CSS to avoid conflicting rules

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688e97869adc8325adf57e5fb18dbb6b