### PR TITLE
fix: center comment modal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1066,3 +1066,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Resolved double scroll in Facebook-style modal by enforcing flexbox layout with a single scrollable content area, updating comment modal markup and scroll handling (PR modal-single-scroll-fix).
 - Eliminated remaining double scroll in comment modal by moving the comment form inside a single scrollable body, making it sticky at the bottom and removing inner comment list overflow (PR comment-modal-sticky-input).
 - Consolidated comment modal layout by placing the comment form outside the scrollable body, cleaning duplicate comment styles and reinforcing single-scroll behavior with sticky input (PR comment-modal-css-cleanup).
+- Centered comment modal horizontally on desktop, added responsive full-width behavior on mobile, and preserved sticky comment form (PR comment-modal-center).

--- a/crunevo/static/css/photo-modal.css
+++ b/crunevo/static/css/photo-modal.css
@@ -128,7 +128,24 @@
 .comment-modal .modal-dialog {
   height: 100vh;
   max-height: 100vh;
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+@media (min-width: 769px) {
+  .comment-modal .modal-dialog {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 600px;
+  }
+}
+
+@media (max-width: 768px) {
+  .comment-modal .modal-dialog {
+    width: 100%;
+    margin-left: 0;
+    margin-right: 0;
+  }
 }
 
 .comment-modal .modal-content {

--- a/crunevo/templates/components/comment_modal.html
+++ b/crunevo/templates/components/comment_modal.html
@@ -4,7 +4,7 @@
 
 <!-- Modal de Comentarios -->
 <div class="modal fade comment-modal" id="commentsModal-{{ post.id }}" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="commentsModalLabel-{{ post.id }}" aria-hidden="true" style="display: none;">
-  <div class="modal-dialog modal-lg modal-dialog-centered modal-fullscreen-sm-down">
+  <div class="modal-dialog modal-lg modal-dialog-centered modal-fullscreen-sm-down tw-mx-auto tw-w-full">
     <div class="modal-content facebook-modal-info-panel">
       <h5 id="commentsModalLabel-{{ post.id }}" class="visually-hidden">Comentarios</h5>
 


### PR DESCRIPTION
## Summary
- center comment modal on desktop and allow full width on mobile
- document change in AGENTS

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688eb0d89e648325a972665d7dbda55a