### PR TITLE
docs: document mobile navbar usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1070,3 +1070,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Optimized comment modal input with full-width auto-expanding textarea and minimal send button for better mobile usability (PR comment-input-opt).
 - Fixed navbar macros: consolidated user auth conditional and guarded current_user usage to resolve TemplateSyntaxError and test failures (PR navbar-auth-conditional).
 - Migrated mobile "NotBar" component to "MobileNavbar", renamed template and CSS class `.notbar` to `.mobile-navbar` and updated includes (PR mobile-navbar-rename).
+- Documented mobile navigation bar usage and noted replacement of bottom nav (PR mobile-navbar-docs).

--- a/NAVBAR_IMPROVEMENTS.md
+++ b/NAVBAR_IMPROVEMENTS.md
@@ -4,6 +4,12 @@
 
 Se ha realizado una refactorización completa del sistema de navegación para crear una experiencia superior y completamente responsiva en todos los dispositivos.
 
+## Barra de navegación móvil
+
+La barra de navegación móvil proporciona una versión compacta del navbar para pantallas pequeñas.
+Se muestra en dispositivos con un ancho menor a 992px y reemplaza a la antigua navegación inferior.
+Cuando está activa, oculta la barra de escritorio y reutiliza sus enlaces principales en un formato optimizado.
+
 ## 🚀 Características Principales
 
 ### 1. Diseño Completamente Responsivo

--- a/crunevo/templates/components/mobile_navbar.html
+++ b/crunevo/templates/components/mobile_navbar.html
@@ -1,3 +1,4 @@
+<!-- Navbar móvil para pantallas pequeñas; reemplaza la antigua navegación inferior -->
 <nav class="navbar mobile-navbar fixed-top d-lg-none text-white navbar-crunevo">
   <div class="container-fluid d-flex align-items-center justify-content-between gap-1 px-2">
     <a class="p-0" href="{{ url_for('main.index') }}" aria-label="Ir a inicio">


### PR DESCRIPTION
## Summary
- document mobile navigation bar purpose and relation to desktop navbar
- note mobile navbar component for small screens, replacing old bottom nav
- log documentation update in AGENTS guide

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688ee59b621883259079a34dbffaf3ee