### PR TITLE
Fix mobile navbar badges and auto-hide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1072,3 +1072,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Migrated mobile "NotBar" component to "MobileNavbar", renamed template and CSS class `.notbar` to `.mobile-navbar` and updated includes (PR mobile-navbar-rename).
 - Documented mobile navigation bar usage and noted replacement of bottom nav (PR mobile-navbar-docs).
 - Refined mobile navbar: new purple blur style with circular buttons, forum icon now question mark, and search input opens a full-screen modal with live suggestions (PR mobile-navbar-enhance).
+- Mobile navbar badges and spacing fixed: icons spaced evenly, notification button links to full page with working badge, cart count now visible, and auto-hide/padding logic targets the mobile navbar (PR mobile-navbar-fixes).

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -817,7 +817,8 @@ html[data-bs-theme="dark"] footer a {
 }
 
 /* Mobile search modal styles */
-.mobile-navbar .notification-badge {
+.mobile-navbar .notification-badge,
+.mobile-navbar #mobileCartBadge {
   font-size: 0.6rem;
   min-width: 16px;
   height: 16px;

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -849,7 +849,10 @@ document.addEventListener('DOMContentLoaded', () => {
   if (navigator.hardwareConcurrency && navigator.hardwareConcurrency <= 4) {
     document.body.classList.add('no-anim');
   }
-  const fixedNav = document.querySelector('.navbar.fixed-top');
+  const mobileNav = document.querySelector('.mobile-navbar.fixed-top');
+  const fixedNav = mobileNav && window.getComputedStyle(mobileNav).display !== 'none'
+    ? mobileNav
+    : document.querySelector('.navbar.fixed-top');
   if (fixedNav) {
     document.body.style.paddingTop = fixedNav.offsetHeight + 'px';
   }
@@ -1183,7 +1186,10 @@ document.addEventListener('DOMContentLoaded', () => {
   // Enhanced Auto hide navbar on scroll for all viewports
   let lastScrollTop = 0;
   let scrollTimeout = null;
-  const navbar = document.querySelector('.navbar-crunevo');
+  const mobileNavbar = document.querySelector('.mobile-navbar');
+  const navbar = mobileNavbar && window.getComputedStyle(mobileNavbar).display !== 'none'
+    ? mobileNavbar
+    : document.querySelector('.navbar-crunevo');
   const isMobileUA = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
   const isTablet = window.innerWidth >= 576 && window.innerWidth <= 1024;
   
@@ -1267,7 +1273,7 @@ document.addEventListener('DOMContentLoaded', () => {
 function updateCartBadge(count) {
   document.querySelectorAll('#cartBadge, #cartBadgeDesktop, #mobileCartBadge').forEach((b) => {
     b.textContent = count;
-    b.classList.toggle('tw-hidden', count === 0);
+    b.style.display = count === 0 ? 'none' : 'flex';
   });
 }
 

--- a/crunevo/templates/components/mobile_navbar.html
+++ b/crunevo/templates/components/mobile_navbar.html
@@ -34,23 +34,10 @@
       })
       .catch(() => {});
   }
-  
-  // Enhanced mobile notifications with dropdown sync
-  function syncMobileNotifications() {
-    const mobileList = document.getElementById('mobile-notifications-list');
-    const desktopList = document.getElementById('notifications-list');
-    if (mobileList && desktopList) {
-      mobileList.innerHTML = desktopList.innerHTML;
-    }
-  }
-  
+
   if (document.getElementById('mobileNotificationBadge')) {
     updateMobileNotificationBadge();
-    syncMobileNotifications();
-    setInterval(() => {
-      updateMobileNotificationBadge();
-      syncMobileNotifications();
-    }, 30000);
+    setInterval(updateMobileNotificationBadge, 30000);
   }
   
   // Optimize touch interactions for mobile navbar

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -37,7 +37,7 @@
           <li class="nav-item d-none d-lg-block position-relative">
             <a class="nav-link" href="{{ url_for('store.view_cart') }}">
               <i class="bi bi-cart-fill"></i>
-              <span id="cartBadgeDesktop" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger tw-hidden">0</span>
+              <span id="cartBadgeDesktop" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" style="display:none">0</span>
             </a>
           </li>
           {% endif %}

--- a/crunevo/templates/components/navbar_links.html
+++ b/crunevo/templates/components/navbar_links.html
@@ -31,7 +31,7 @@
 
 <!-- Mobile Quick Links (used in mobile_navbar.html) -->
 {% macro mobile_quick_links() %}
-<div class="d-flex align-items-center gap-1">
+<div class="d-flex align-items-center justify-content-end gap-2">
   <a href="{{ url_for('feed.feed_home') if 'feed.feed_home' in url_for.__globals__.get('current_app', {}).view_functions else '/' }}" class="btn btn-link text-white p-1" aria-label="Feed principal">
     <i class="bi bi-house{{ '-fill' if request.endpoint == 'feed.feed_home' else '' }}"></i>
   </a>
@@ -44,21 +44,13 @@
   <a href="{{ url_for('notes.list_notes') if 'notes.list_notes' in url_for.__globals__.get('current_app', {}).view_functions else '/notes'}}" class="btn btn-link text-white p-1" aria-label="Mis apuntes">
     <i class="bi bi-journal-text"></i>
   </a>
-  <div class="dropdown">
-    <a class="btn btn-link text-white position-relative p-1" href="#" id="mobileNotificationsDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false" aria-label="Notificaciones">
-      <i class="bi bi-bell-fill"></i>
-      <span id="mobileNotificationBadge" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger notification-badge" style="display:none"></span>
-    </a>
-    <ul class="dropdown-menu dropdown-menu-end notification-menu" style="width: 280px; max-height: 400px; overflow-y: auto;">
-      <li><h6 class="dropdown-header">Notificaciones</h6></li>
-      <li id="mobile-notifications-list"><span class="dropdown-item-text text-muted">No hay notificaciones</span></li>
-      <li><hr class="dropdown-divider"></li>
-      <li><a class="dropdown-item text-center" href="{{ url_for('noti.ver_notificaciones') }}">Ver todas</a></li>
-    </ul>
-  </div>
+  <a href="{{ url_for('noti.ver_notificaciones') }}" class="btn btn-link text-white position-relative p-1" aria-label="Notificaciones">
+    <i class="bi bi-bell-fill"></i>
+    <span id="mobileNotificationBadge" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger notification-badge" style="display:none"></span>
+  </a>
   <a href="{{ url_for('store.store_index') if 'store.store_index' in url_for.__globals__.get('current_app', {}).view_functions else '/store' }}" class="btn btn-link text-white position-relative p-1" aria-label="Tienda">
     <i class="bi bi-shop"></i>
-    <span id="mobileCartBadge" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger tw-hidden">0</span>
+    <span id="mobileCartBadge" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" style="display:none">0</span>
   </a>
 </div>
 {% endmacro %}


### PR DESCRIPTION
## Summary
- Align mobile quick links and switch notifications icon to link directly to the notifications page with visible badges for alerts and cart items
- Style mobile cart badge consistently and poll notification counts on mobile
- Target the visible navbar for padding and scroll-hiding to prevent overlap and hide it on mobile scroll

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688eec4e43848325bcfed6bfd2ae7d1b