### PR TITLE
fix: prevent navbar overlap and improve autohide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1073,3 +1073,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Documented mobile navigation bar usage and noted replacement of bottom nav (PR mobile-navbar-docs).
 - Refined mobile navbar: new purple blur style with circular buttons, forum icon now question mark, and search input opens a full-screen modal with live suggestions (PR mobile-navbar-enhance).
 - Mobile navbar badges and spacing fixed: icons spaced evenly, notification button links to full page with working badge, cart count now visible, and auto-hide/padding logic targets the mobile navbar (PR mobile-navbar-fixes).
+- Calculated navbar height dynamically with CSS variable, updated sidebar offset and scroll padding, and unified auto-hide logic to ensure content isn't covered on any page (PR navbar-overlap-fix).

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -16,17 +16,21 @@ html {
   color: #f8f9fa;
 }
 
+:root {
+  --navbar-height: 64px;
+}
+
 body {
   background: linear-gradient(135deg, #E3F2FD 0%, #F3E5F5 100%);
-  padding-top: 64px;
+  padding-top: var(--navbar-height);
   font-family: "Inter", system-ui, sans-serif;
   min-height: 100vh;
 }
 
 /* Enhanced responsive spacing for different screen sizes */
 @media (max-width: 575.98px) {
-  body {
-    padding-top: 56px;
+  :root {
+    --navbar-height: 56px;
   }
   main {
     margin-top: 0;
@@ -40,8 +44,8 @@ body {
 }
 
 @media (min-width: 576px) and (max-width: 767.98px) {
-  body {
-    padding-top: 60px;
+  :root {
+    --navbar-height: 60px;
   }
   main {
     margin-top: 0;
@@ -51,8 +55,8 @@ body {
 }
 
 @media (min-width: 768px) and (max-width: 991.98px) {
-  body {
-    padding-top: 64px;
+  :root {
+    --navbar-height: 64px;
   }
   main {
     margin-top: 0;
@@ -62,8 +66,8 @@ body {
 }
 
 @media (min-width: 992px) {
-  body {
-    padding-top: 64px;
+  :root {
+    --navbar-height: 64px;
   }
   main {
     margin-top: 0;
@@ -74,7 +78,7 @@ body {
 
 .sidebar {
   position: sticky;
-  top: 80px;
+  top: calc(var(--navbar-height) + 16px);
 }
 
 [data-bs-theme="dark"] .sidebar .username {
@@ -519,7 +523,7 @@ body > .navbar {
 }
 
 html {
-  scroll-padding-top: 0 !important;
+  scroll-padding-top: var(--navbar-height) !important;
 }
 
 [data-bs-theme="dark"] .navbar,

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -849,13 +849,27 @@ document.addEventListener('DOMContentLoaded', () => {
   if (navigator.hardwareConcurrency && navigator.hardwareConcurrency <= 4) {
     document.body.classList.add('no-anim');
   }
-  const mobileNav = document.querySelector('.mobile-navbar.fixed-top');
-  const fixedNav = mobileNav && window.getComputedStyle(mobileNav).display !== 'none'
-    ? mobileNav
-    : document.querySelector('.navbar.fixed-top');
-  if (fixedNav) {
-    document.body.style.paddingTop = fixedNav.offsetHeight + 'px';
+
+  const getVisibleNavbar = () => {
+    const mobileNav = document.querySelector('.mobile-navbar');
+    if (mobileNav && window.getComputedStyle(mobileNav).display !== 'none') {
+      return mobileNav;
+    }
+    const desktopNav = document.querySelector('.navbar-crunevo');
+    return desktopNav && window.getComputedStyle(desktopNav).display !== 'none'
+      ? desktopNav
+      : null;
+  };
+
+  function setNavbarHeight() {
+    const nav = getVisibleNavbar();
+    if (nav) {
+      document.documentElement.style.setProperty('--navbar-height', `${nav.offsetHeight}px`);
+    }
   }
+
+  setNavbarHeight();
+  window.addEventListener('resize', setNavbarHeight);
   if (window.NEW_ACHIEVEMENTS && window.NEW_ACHIEVEMENTS.length > 0) {
     showAchievementPopup(window.NEW_ACHIEVEMENTS[0]);
   }
@@ -1186,66 +1200,66 @@ document.addEventListener('DOMContentLoaded', () => {
   // Enhanced Auto hide navbar on scroll for all viewports
   let lastScrollTop = 0;
   let scrollTimeout = null;
-  const mobileNavbar = document.querySelector('.mobile-navbar');
-  const navbar = mobileNavbar && window.getComputedStyle(mobileNavbar).display !== 'none'
-    ? mobileNavbar
-    : document.querySelector('.navbar-crunevo');
   const isMobileUA = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
   const isTablet = window.innerWidth >= 576 && window.innerWidth <= 1024;
-  
+
   function handleScroll() {
+    const navbar = getVisibleNavbar();
     if (!navbar) return;
-    
+
     const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
     const scrollThreshold = isMobileUA ? 30 : 50; // Lower threshold for mobile
-    
-    // Clear any existing timeout
+
     if (scrollTimeout) {
       clearTimeout(scrollTimeout);
     }
-    
-    // Only hide/show after scrolling past threshold
+
     if (Math.abs(scrollTop - lastScrollTop) > scrollThreshold) {
       if (scrollTop > lastScrollTop && scrollTop > 100) {
-        // Scrolling down and past 100px - hide navbar
         navbar.classList.add('navbar-hidden');
       } else if (scrollTop < lastScrollTop) {
-        // Scrolling up - show navbar
         navbar.classList.remove('navbar-hidden');
       }
       lastScrollTop = scrollTop <= 0 ? 0 : scrollTop;
     }
-    
-    // Auto-show navbar after scroll stops (especially useful on mobile)
+
     scrollTimeout = setTimeout(() => {
       if (scrollTop === (window.pageYOffset || document.documentElement.scrollTop)) {
-        navbar.classList.remove('navbar-hidden');
+        const nav = getVisibleNavbar();
+        if (nav) {
+          nav.classList.remove('navbar-hidden');
+        }
       }
     }, 1500);
   }
 
-  // Use passive listeners for better performance
   window.addEventListener('scroll', handleScroll, { passive: true });
-  
+
   if (isMobileUA || isTablet) {
     window.addEventListener('touchmove', handleScroll, { passive: true });
     window.addEventListener('touchend', () => {
-      // Show navbar briefly on touch end for easier access
-      setTimeout(() => {
-        navbar.classList.remove('navbar-hidden');
-      }, 500);
+      const nav = getVisibleNavbar();
+      if (nav) {
+        setTimeout(() => {
+          nav.classList.remove('navbar-hidden');
+        }, 500);
+      }
     }, { passive: true });
   }
-  
-  // Show navbar on window resize (responsive behavior)
+
   window.addEventListener('resize', () => {
-    navbar.classList.remove('navbar-hidden');
+    const nav = getVisibleNavbar();
+    if (nav) {
+      nav.classList.remove('navbar-hidden');
+    }
   });
-  
-  // Show navbar when focus is on form elements (accessibility)
+
   document.addEventListener('focusin', (e) => {
     if (e.target.matches('input, textarea, select')) {
-      navbar.classList.remove('navbar-hidden');
+      const nav = getVisibleNavbar();
+      if (nav) {
+        nav.classList.remove('navbar-hidden');
+      }
     }
   });
 


### PR DESCRIPTION
## Summary
- compute navbar height dynamically and apply padding via CSS variable
- adjust sidebar and scroll padding to respect navbar height
- unify auto-hide logic to detect visible navbar on scroll

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688ef781433083259529e9ec3e80d73e