### PR TITLE
fix: recalc navbar height after load

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1074,3 +1074,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Refined mobile navbar: new purple blur style with circular buttons, forum icon now question mark, and search input opens a full-screen modal with live suggestions (PR mobile-navbar-enhance).
 - Mobile navbar badges and spacing fixed: icons spaced evenly, notification button links to full page with working badge, cart count now visible, and auto-hide/padding logic targets the mobile navbar (PR mobile-navbar-fixes).
 - Calculated navbar height dynamically with CSS variable, updated sidebar offset and scroll padding, and unified auto-hide logic to ensure content isn't covered on any page (PR navbar-overlap-fix).
+- Recalculated navbar height on DOMContentLoaded and window load to prevent fixed navbar from covering content on mobile and desktop (PR navbar-height-recalc).

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -867,8 +867,10 @@ document.addEventListener('DOMContentLoaded', () => {
       document.documentElement.style.setProperty('--navbar-height', `${nav.offsetHeight}px`);
     }
   }
-
+  // Recalculate after rendering and when resources load
   setNavbarHeight();
+  document.addEventListener('DOMContentLoaded', setNavbarHeight);
+  window.addEventListener('load', setNavbarHeight);
   window.addEventListener('resize', setNavbarHeight);
   if (window.NEW_ACHIEVEMENTS && window.NEW_ACHIEVEMENTS.length > 0) {
     showAchievementPopup(window.NEW_ACHIEVEMENTS[0]);


### PR DESCRIPTION
## Summary
- recalculate navbar height on DOMContentLoaded and window load to prevent overlap

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688f038eb0008325b997e528497a899f