### PR TITLE
fix: correct app blueprint import indentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1076,3 +1076,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Calculated navbar height dynamically with CSS variable, updated sidebar offset and scroll padding, and unified auto-hide logic to ensure content isn't covered on any page (PR navbar-overlap-fix).
 - Reapplied navbar height on load and resize, setting body padding and scroll offset to prevent content being hidden by fixed navbars (PR navbar-padding-load).
 - Recalculated navbar height on DOMContentLoaded and window load to prevent fixed navbar from covering content on mobile and desktop (PR navbar-height-recalc).
+- Fixed indentation of marketplace and related blueprint imports in `app.py` to resolve deployment error (hotfix marketplace-import-indent).

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -331,10 +331,10 @@ def create_app():
         api_search_courses,
     )
     from .routes.store_routes import store_bp
-from .routes.marketplace_routes import marketplace_bp
-from .routes.chat_routes import chat_bp
-from .routes.search_routes import search_bp
-from .routes.ia_routes import ia_bp
+    from .routes.marketplace_routes import marketplace_bp
+    from .routes.chat_routes import chat_bp
+    from .routes.search_routes import search_bp
+    from .routes.ia_routes import ia_bp
     from .routes.admin_routes import admin_bp
     from .routes.admin_blocker import admin_blocker_bp
     from .routes.admin.email_routes import admin_email_bp


### PR DESCRIPTION
## Summary
- fix indentation for marketplace and related blueprint imports in app.py so application loads correctly
- document fix in AGENTS instructions

## Testing
- `make fmt`
- `make test` (fails: F401 unused imports in marketplace modules)
- `python -m py_compile crunevo/app.py`


------
https://chatgpt.com/codex/tasks/task_e_688f67c7a9d08325882b2294bf895803