### PR TITLE
Add marketplace product columns and fix error logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1078,3 +1078,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Recalculated navbar height on DOMContentLoaded and window load to prevent fixed navbar from covering content on mobile and desktop (PR navbar-height-recalc).
 - Fixed indentation of marketplace and related blueprint imports in `app.py` to resolve deployment error (hotfix marketplace-import-indent).
 - Added missing marketplace utilities and models overhaul: created `utils/uploads` helper, simplified marketplace models, fixed conversation/message relations, updated routes and templates, and ensured CSRF tokens in forms (PR marketplace-fixes).
+- Added migration to create marketplace tables and product fields and rolled back DB session before logging errors to avoid aborted transactions (PR marketplace-subcategory-fix).

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -525,6 +525,7 @@ def create_app():
     @app.errorhandler(Exception)
     def log_exception(e):
         try:
+            db.session.rollback()
             err = SystemErrorLog(
                 ruta=request.path,
                 mensaje=str(e),

--- a/crunevo/forms/marketplace_forms.py
+++ b/crunevo/forms/marketplace_forms.py
@@ -1,135 +1,209 @@
 from flask_wtf import FlaskForm
 from flask_wtf.file import FileField, FileAllowed, FileRequired
-from wtforms import StringField, TextAreaField, FloatField, IntegerField, BooleanField, SelectField, SubmitField, HiddenField
-from wtforms.validators import DataRequired, Length, Email, NumberRange, Optional, ValidationError
+from wtforms import (
+    StringField,
+    TextAreaField,
+    FloatField,
+    IntegerField,
+    BooleanField,
+    SelectField,
+    SubmitField,
+    HiddenField,
+)
+from wtforms.validators import DataRequired, Length, NumberRange, Optional
 from crunevo.models.product import ProductCategory, ProductSubcategory
+
 
 class SellerRegistrationForm(FlaskForm):
     """Form for seller registration"""
-    store_name = StringField('Store Name', validators=[
-        DataRequired(),
-        Length(min=3, max=100, message='Store name must be between 3 and 100 characters')
-    ])
-    description = TextAreaField('Store Description', validators=[
-        DataRequired(),
-        Length(min=10, max=1000, message='Description must be between 10 and 1000 characters')
-    ])
-    phone = StringField('Phone Number', validators=[
-        DataRequired(),
-        Length(min=7, max=20, message='Phone number must be between 7 and 20 characters')
-    ])
-    location = StringField('Location', validators=[
-        DataRequired(),
-        Length(min=3, max=100, message='Location must be between 3 and 100 characters')
-    ])
-    logo_image = FileField('Store Logo', validators=[
-        FileRequired(),
-        FileAllowed(['jpg', 'jpeg', 'png'], 'Images only!')
-    ])
-    banner_image = FileField('Store Banner', validators=[
-        FileRequired(),
-        FileAllowed(['jpg', 'jpeg', 'png'], 'Images only!')
-    ])
-    terms_accepted = BooleanField('I accept the Terms and Conditions', validators=[
-        DataRequired(message='You must accept the terms and conditions')
-    ])
-    submit = SubmitField('Register as Seller')
+
+    store_name = StringField(
+        "Store Name",
+        validators=[
+            DataRequired(),
+            Length(
+                min=3,
+                max=100,
+                message="Store name must be between 3 and 100 characters",
+            ),
+        ],
+    )
+    description = TextAreaField(
+        "Store Description",
+        validators=[
+            DataRequired(),
+            Length(
+                min=10,
+                max=1000,
+                message="Description must be between 10 and 1000 characters",
+            ),
+        ],
+    )
+    phone = StringField(
+        "Phone Number",
+        validators=[
+            DataRequired(),
+            Length(
+                min=7,
+                max=20,
+                message="Phone number must be between 7 and 20 characters",
+            ),
+        ],
+    )
+    location = StringField(
+        "Location",
+        validators=[
+            DataRequired(),
+            Length(
+                min=3, max=100, message="Location must be between 3 and 100 characters"
+            ),
+        ],
+    )
+    logo_image = FileField(
+        "Store Logo",
+        validators=[
+            FileRequired(),
+            FileAllowed(["jpg", "jpeg", "png"], "Images only!"),
+        ],
+    )
+    banner_image = FileField(
+        "Store Banner",
+        validators=[
+            FileRequired(),
+            FileAllowed(["jpg", "jpeg", "png"], "Images only!"),
+        ],
+    )
+    terms_accepted = BooleanField(
+        "I accept the Terms and Conditions",
+        validators=[DataRequired(message="You must accept the terms and conditions")],
+    )
+    submit = SubmitField("Register as Seller")
 
 
 class ProductForm(FlaskForm):
     """Form for adding/editing products"""
-    name = StringField('Product Name', validators=[
-        DataRequired(),
-        Length(min=3, max=100, message='Product name must be between 3 and 100 characters')
-    ])
-    description = TextAreaField('Product Description', validators=[
-        DataRequired(),
-        Length(min=10, max=2000, message='Description must be between 10 and 2000 characters')
-    ])
-    price = FloatField('Price', validators=[
-        DataRequired(),
-        NumberRange(min=0.01, message='Price must be greater than 0')
-    ])
-    stock = IntegerField('Stock', validators=[
-        DataRequired(),
-        NumberRange(min=1, message='Stock must be at least 1')
-    ])
-    category_id = SelectField('Category', coerce=int, validators=[
-        DataRequired()
-    ])
-    subcategory_id = SelectField('Subcategory', coerce=int, validators=[
-        Optional()
-    ])
-    condition = SelectField('Condition', choices=[
-        ('new', 'New'),
-        ('used', 'Used'),
-        ('refurbished', 'Refurbished')
-    ], validators=[DataRequired()])
-    shipping_cost = FloatField('Shipping Cost', validators=[
-        NumberRange(min=0, message='Shipping cost must be 0 or greater')
-    ])
-    shipping_time = StringField('Shipping Time (e.g., 2-3 days)', validators=[
-        DataRequired(),
-        Length(max=50)
-    ])
-    free_shipping = BooleanField('Free Shipping')
-    warranty = StringField('Warranty', validators=[
-        Optional(),
-        Length(max=100)
-    ])
-    tags = StringField('Tags (comma separated)', validators=[
-        Optional(),
-        Length(max=255)
-    ])
-    submit = SubmitField('Save Product')
-    
+
+    name = StringField(
+        "Product Name",
+        validators=[
+            DataRequired(),
+            Length(
+                min=3,
+                max=100,
+                message="Product name must be between 3 and 100 characters",
+            ),
+        ],
+    )
+    description = TextAreaField(
+        "Product Description",
+        validators=[
+            DataRequired(),
+            Length(
+                min=10,
+                max=2000,
+                message="Description must be between 10 and 2000 characters",
+            ),
+        ],
+    )
+    price = FloatField(
+        "Price",
+        validators=[
+            DataRequired(),
+            NumberRange(min=0.01, message="Price must be greater than 0"),
+        ],
+    )
+    stock = IntegerField(
+        "Stock",
+        validators=[
+            DataRequired(),
+            NumberRange(min=1, message="Stock must be at least 1"),
+        ],
+    )
+    category_id = SelectField("Category", coerce=int, validators=[DataRequired()])
+    subcategory_id = SelectField("Subcategory", coerce=int, validators=[Optional()])
+    condition = SelectField(
+        "Condition",
+        choices=[("new", "New"), ("used", "Used"), ("refurbished", "Refurbished")],
+        validators=[DataRequired()],
+    )
+    shipping_cost = FloatField(
+        "Shipping Cost",
+        validators=[NumberRange(min=0, message="Shipping cost must be 0 or greater")],
+    )
+    shipping_time = StringField(
+        "Shipping Time (e.g., 2-3 days)", validators=[DataRequired(), Length(max=50)]
+    )
+    free_shipping = BooleanField("Free Shipping")
+    warranty = StringField("Warranty", validators=[Optional(), Length(max=100)])
+    tags = StringField(
+        "Tags (comma separated)", validators=[Optional(), Length(max=255)]
+    )
+    submit = SubmitField("Save Product")
+
     def __init__(self, *args, **kwargs):
         super(ProductForm, self).__init__(*args, **kwargs)
-        self.category_id.choices = [(c.id, c.name) for c in ProductCategory.query.order_by('name').all()]
-        self.subcategory_id.choices = [(0, 'Select a subcategory')] + [
-            (s.id, s.name) for s in ProductSubcategory.query.order_by('name').all()
+        self.category_id.choices = [
+            (c.id, c.name) for c in ProductCategory.query.order_by("name").all()
+        ]
+        self.subcategory_id.choices = [(0, "Select a subcategory")] + [
+            (s.id, s.name) for s in ProductSubcategory.query.order_by("name").all()
         ]
 
 
 class MessageForm(FlaskForm):
     """Form for sending messages"""
-    content = TextAreaField('Message', validators=[
-        DataRequired(),
-        Length(min=1, max=1000, message='Message must be between 1 and 1000 characters')
-    ])
-    product_id = HiddenField('Product ID')
-    seller_id = HiddenField('Seller ID')
-    submit = SubmitField('Send Message')
+
+    content = TextAreaField(
+        "Message",
+        validators=[
+            DataRequired(),
+            Length(
+                min=1, max=1000, message="Message must be between 1 and 1000 characters"
+            ),
+        ],
+    )
+    product_id = HiddenField("Product ID")
+    seller_id = HiddenField("Seller ID")
+    submit = SubmitField("Send Message")
 
 
 class ProductFilterForm(FlaskForm):
     """Form for filtering products"""
-    search = StringField('Search', validators=[Optional()])
-    category_id = SelectField('Category', coerce=int, validators=[Optional()])
-    subcategory_id = SelectField('Subcategory', coerce=int, validators=[Optional()])
-    min_price = FloatField('Min Price', validators=[Optional(), NumberRange(min=0)])
-    max_price = FloatField('Max Price', validators=[Optional(), NumberRange(min=0)])
-    condition = SelectField('Condition', choices=[
-        ('', 'All'),
-        ('new', 'New'),
-        ('used', 'Used'),
-        ('refurbished', 'Refurbished')
-    ], validators=[Optional()])
-    free_shipping = BooleanField('Free Shipping', validators=[Optional()])
-    verified_seller = BooleanField('Verified Seller Only', validators=[Optional()])
-    sort = SelectField('Sort By', choices=[
-        ('newest', 'Newest'),
-        ('price_asc', 'Price: Low to High'),
-        ('price_desc', 'Price: High to Low'),
-        ('popular', 'Most Popular')
-    ], validators=[Optional()])
-    submit = SubmitField('Apply Filters')
-    
+
+    search = StringField("Search", validators=[Optional()])
+    category_id = SelectField("Category", coerce=int, validators=[Optional()])
+    subcategory_id = SelectField("Subcategory", coerce=int, validators=[Optional()])
+    min_price = FloatField("Min Price", validators=[Optional(), NumberRange(min=0)])
+    max_price = FloatField("Max Price", validators=[Optional(), NumberRange(min=0)])
+    condition = SelectField(
+        "Condition",
+        choices=[
+            ("", "All"),
+            ("new", "New"),
+            ("used", "Used"),
+            ("refurbished", "Refurbished"),
+        ],
+        validators=[Optional()],
+    )
+    free_shipping = BooleanField("Free Shipping", validators=[Optional()])
+    verified_seller = BooleanField("Verified Seller Only", validators=[Optional()])
+    sort = SelectField(
+        "Sort By",
+        choices=[
+            ("newest", "Newest"),
+            ("price_asc", "Price: Low to High"),
+            ("price_desc", "Price: High to Low"),
+            ("popular", "Most Popular"),
+        ],
+        validators=[Optional()],
+    )
+    submit = SubmitField("Apply Filters")
+
     def __init__(self, *args, **kwargs):
         super(ProductFilterForm, self).__init__(*args, **kwargs)
-        self.category_id.choices = [(0, 'All Categories')] + [
-            (c.id, c.name) for c in ProductCategory.query.order_by('name').all()
+        self.category_id.choices = [(0, "All Categories")] + [
+            (c.id, c.name) for c in ProductCategory.query.order_by("name").all()
         ]
-        self.subcategory_id.choices = [(0, 'All Subcategories')] + [
-            (s.id, s.name) for s in ProductSubcategory.query.order_by('name').all()
+        self.subcategory_id.choices = [(0, "All Subcategories")] + [
+            (s.id, s.name) for s in ProductSubcategory.query.order_by("name").all()
         ]

--- a/crunevo/models/product.py
+++ b/crunevo/models/product.py
@@ -20,7 +20,7 @@ class Product(db.Model):
     download_url = db.Column(db.String(255))
     allow_multiple = db.Column(db.Boolean, default=True)
     is_approved = db.Column(db.Boolean, default=True)
-    
+
     # Campos para marketplace
     seller_id = db.Column(db.Integer, db.ForeignKey("seller.id"))
     condition = db.Column(db.String(20), default="new")  # new, used, refurbished
@@ -30,7 +30,9 @@ class Product(db.Model):
     tags = db.Column(db.JSON)  # Lista de etiquetas para búsqueda
     views_count = db.Column(db.Integer, default=0)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
-    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    updated_at = db.Column(
+        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
 
     @property
     def first_image(self) -> str | None:

--- a/crunevo/models/seller.py
+++ b/crunevo/models/seller.py
@@ -4,6 +4,7 @@ from crunevo.extensions import db
 
 class Seller(db.Model):
     """Modelo para vendedores en el marketplace."""
+
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
     store_name = db.Column(db.String(100), nullable=False)
@@ -18,11 +19,13 @@ class Seller(db.Model):
     total_sales = db.Column(db.Integer, default=0)
     is_verified = db.Column(db.Boolean, default=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
-    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
-    
+    updated_at = db.Column(
+        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
     # Relaciones
     user = db.relationship("User", backref=db.backref("seller", uselist=False))
     products = db.relationship("Product", backref="seller", lazy="dynamic")
-    
+
     def __repr__(self):
         return f"<Seller {self.store_name}>"

--- a/migrations/versions/9f1b5f2d0f90_add_marketplace_product_fields.py
+++ b/migrations/versions/9f1b5f2d0f90_add_marketplace_product_fields.py
@@ -1,0 +1,147 @@
+"""Add marketplace fields and tables"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+# revision identifiers, used by Alembic.
+revision = "9f1b5f2d0f90"
+down_revision = "forum_modernization_schema"
+branch_labels = None
+depends_on = None
+
+
+def has_table(name: str, conn) -> bool:
+    inspector = inspect(conn)
+    return name in inspector.get_table_names()
+
+
+def has_col(table: str, column: str, conn) -> bool:
+    inspector = inspect(conn)
+    return any(c["name"] == column for c in inspector.get_columns(table))
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    if not has_table("seller", conn):
+        op.create_table(
+            "seller",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "user_id", sa.Integer(), sa.ForeignKey("user.id"), nullable=False
+            ),
+            sa.Column("store_name", sa.String(length=100), nullable=False),
+            sa.Column("description", sa.Text()),
+            sa.Column("logo", sa.String(length=200)),
+            sa.Column("banner", sa.String(length=200)),
+            sa.Column("contact_email", sa.String(length=100)),
+            sa.Column("contact_phone", sa.String(length=20)),
+            sa.Column("address", sa.String(length=255)),
+            sa.Column("rating", sa.Float(), server_default="0"),
+            sa.Column("total_ratings", sa.Integer(), server_default="0"),
+            sa.Column("total_sales", sa.Integer(), server_default="0"),
+            sa.Column("is_verified", sa.Boolean(), server_default=sa.text("false")),
+            sa.Column("created_at", sa.DateTime(), server_default=sa.text("now()")),
+            sa.Column("updated_at", sa.DateTime(), server_default=sa.text("now()")),
+            if_not_exists=True,
+        )
+
+    if not has_table("marketplace_conversations", conn):
+        op.create_table(
+            "marketplace_conversations",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "user1_id", sa.Integer(), sa.ForeignKey("user.id"), nullable=False
+            ),
+            sa.Column(
+                "user2_id", sa.Integer(), sa.ForeignKey("user.id"), nullable=False
+            ),
+            sa.Column("product_id", sa.Integer()),
+            sa.Column(
+                "last_message_at", sa.DateTime(), server_default=sa.text("now()")
+            ),
+            sa.Column("created_at", sa.DateTime(), server_default=sa.text("now()")),
+            if_not_exists=True,
+        )
+
+    if not has_table("marketplace_messages", conn):
+        op.create_table(
+            "marketplace_messages",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "conversation_id",
+                sa.Integer(),
+                sa.ForeignKey("marketplace_conversations.id"),
+                nullable=False,
+            ),
+            sa.Column(
+                "sender_id", sa.Integer(), sa.ForeignKey("user.id"), nullable=False
+            ),
+            sa.Column(
+                "receiver_id", sa.Integer(), sa.ForeignKey("user.id"), nullable=False
+            ),
+            sa.Column("product_id", sa.Integer()),
+            sa.Column("content", sa.Text(), nullable=False),
+            sa.Column("is_read", sa.Boolean(), server_default=sa.text("false")),
+            sa.Column("created_at", sa.DateTime(), server_default=sa.text("now()")),
+            if_not_exists=True,
+        )
+
+    with op.batch_alter_table("product") as batch_op:
+        if not has_col("product", "category", conn):
+            batch_op.add_column(sa.Column("category", sa.String(length=50)))
+        if not has_col("product", "subcategory", conn):
+            batch_op.add_column(sa.Column("subcategory", sa.String(length=50)))
+        if not has_col("product", "download_url", conn):
+            batch_op.add_column(sa.Column("download_url", sa.String(length=255)))
+        if not has_col("product", "seller_id", conn):
+            batch_op.add_column(
+                sa.Column("seller_id", sa.Integer(), sa.ForeignKey("seller.id"))
+            )
+        if not has_col("product", "condition", conn):
+            batch_op.add_column(
+                sa.Column("condition", sa.String(length=20), server_default="new")
+            )
+        if not has_col("product", "shipping_cost", conn):
+            batch_op.add_column(
+                sa.Column("shipping_cost", sa.Numeric(10, 2), server_default="0")
+            )
+        if not has_col("product", "shipping_time", conn):
+            batch_op.add_column(sa.Column("shipping_time", sa.String(length=50)))
+        if not has_col("product", "warranty", conn):
+            batch_op.add_column(sa.Column("warranty", sa.String(length=100)))
+        if not has_col("product", "tags", conn):
+            batch_op.add_column(sa.Column("tags", sa.JSON()))
+        if not has_col("product", "views_count", conn):
+            batch_op.add_column(
+                sa.Column("views_count", sa.Integer(), server_default="0")
+            )
+        if not has_col("product", "created_at", conn):
+            batch_op.add_column(
+                sa.Column("created_at", sa.DateTime(), server_default=sa.text("now()"))
+            )
+        if not has_col("product", "updated_at", conn):
+            batch_op.add_column(
+                sa.Column("updated_at", sa.DateTime(), server_default=sa.text("now()"))
+            )
+
+
+def downgrade():
+    with op.batch_alter_table("product") as batch_op:
+        batch_op.drop_column("updated_at", if_exists=True)
+        batch_op.drop_column("created_at", if_exists=True)
+        batch_op.drop_column("views_count", if_exists=True)
+        batch_op.drop_column("tags", if_exists=True)
+        batch_op.drop_column("warranty", if_exists=True)
+        batch_op.drop_column("shipping_time", if_exists=True)
+        batch_op.drop_column("shipping_cost", if_exists=True)
+        batch_op.drop_column("condition", if_exists=True)
+        batch_op.drop_column("seller_id", if_exists=True)
+        batch_op.drop_column("download_url", if_exists=True)
+        batch_op.drop_column("subcategory", if_exists=True)
+        batch_op.drop_column("category", if_exists=True)
+
+    op.drop_table("marketplace_messages", if_exists=True)
+    op.drop_table("marketplace_conversations", if_exists=True)
+    op.drop_table("seller", if_exists=True)


### PR DESCRIPTION
## Summary
- add migration to create seller and messaging tables and populate missing product marketplace fields
- roll back session before logging exceptions to avoid failed transactions
- clean up marketplace forms imports

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688f725217e883258ea36fb12e3a055b