### PR TITLE
fix: prevent None values in marketplace filters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1079,3 +1079,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Fixed indentation of marketplace and related blueprint imports in `app.py` to resolve deployment error (hotfix marketplace-import-indent).
 - Added missing marketplace utilities and models overhaul: created `utils/uploads` helper, simplified marketplace models, fixed conversation/message relations, updated routes and templates, and ensured CSRF tokens in forms (PR marketplace-fixes).
 - Added migration to create marketplace tables and product fields and rolled back DB session before logging errors to avoid aborted transactions (PR marketplace-subcategory-fix).
+- Handled `None` values in marketplace filter inputs to prevent invalid numeric field values (hotfix marketplace-filter-none).

--- a/crunevo/routes/marketplace_routes.py
+++ b/crunevo/routes/marketplace_routes.py
@@ -158,7 +158,7 @@ def become_seller():
         description = request.form.get("description")
         contact_email = request.form.get("contact_email")
         contact_phone = request.form.get("contact_phone")
-        address = request.form.get("address")
+        address = request.form.get("location")
 
         # Validar datos
         if not store_name or not description or not contact_email:

--- a/crunevo/templates/marketplace/index.html
+++ b/crunevo/templates/marketplace/index.html
@@ -47,7 +47,7 @@
                                 <div class="mb-3">
                                     <label for="search" class="form-label">Buscar</label>
                                     <div class="input-group">
-                                        <input type="text" class="form-control" id="search" name="search" value="{{ filters.search }}" placeholder="Buscar productos...">
+                                        <input type="text" class="form-control" id="search" name="search" value="{{ filters.search or '' }}" placeholder="Buscar productos...">
                                         <button class="btn btn-outline-primary" type="submit">
                                             <i class="bi bi-search"></i>
                                         </button>
@@ -94,10 +94,10 @@
                                     <label class="form-label">Rango de precio</label>
                                     <div class="row g-2">
                                         <div class="col">
-                                            <input type="number" class="form-control" name="precio_min" placeholder="Min" value="{{ filters.precio_min }}">
+                                            <input type="number" class="form-control" name="precio_min" placeholder="Min" value="{{ filters.precio_min or '' }}">
                                         </div>
                                         <div class="col">
-                                            <input type="number" class="form-control" name="precio_max" placeholder="Max" value="{{ filters.precio_max }}">
+                                            <input type="number" class="form-control" name="precio_max" placeholder="Max" value="{{ filters.precio_max or '' }}">
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
## Summary
- avoid rendering `None` in marketplace search and price filters
- ensure seller registration captures location correctly
- document marketplace fix in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688f77e7201c8325aa1cdf663545a422