### PR TITLE
Fix marketplace seller registration CSRF error

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1079,3 +1079,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Fixed indentation of marketplace and related blueprint imports in `app.py` to resolve deployment error (hotfix marketplace-import-indent).
 - Added missing marketplace utilities and models overhaul: created `utils/uploads` helper, simplified marketplace models, fixed conversation/message relations, updated routes and templates, and ensured CSRF tokens in forms (PR marketplace-fixes).
 - Added migration to create marketplace tables and product fields and rolled back DB session before logging errors to avoid aborted transactions (PR marketplace-subcategory-fix).
+- Fixed seller registration page 500 error by importing csrf macro and sanitized marketplace price filters to avoid "None" in numeric inputs (hotfix marketplace-become-seller).

--- a/crunevo/templates/marketplace/become_seller.html
+++ b/crunevo/templates/marketplace/become_seller.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from 'components/csrf.html' import csrf_field %}
 
 {% block title %}Conviértete en Vendedor | Marketplace Crunevo{% endblock %}
 

--- a/crunevo/templates/marketplace/index.html
+++ b/crunevo/templates/marketplace/index.html
@@ -94,10 +94,10 @@
                                     <label class="form-label">Rango de precio</label>
                                     <div class="row g-2">
                                         <div class="col">
-                                            <input type="number" class="form-control" name="precio_min" placeholder="Min" value="{{ filters.precio_min }}">
+                                            <input type="number" class="form-control" name="precio_min" placeholder="Min" value="{{ filters.precio_min|default('') }}">
                                         </div>
                                         <div class="col">
-                                            <input type="number" class="form-control" name="precio_max" placeholder="Max" value="{{ filters.precio_max }}">
+                                            <input type="number" class="form-control" name="precio_max" placeholder="Max" value="{{ filters.precio_max|default('') }}">
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
## Summary
- import `csrf_field` macro on become seller template to avoid 500 error
- avoid rendering "None" in marketplace price filters to prevent console warnings

## Testing
- `pytest` *(83 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688f77e7201c8325aa1cdf663545a422