### PR TITLE
Fix seller dashboard 500 by providing required context and message timestamp alias

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1081,3 +1081,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Added migration to create marketplace tables and product fields and rolled back DB session before logging errors to avoid aborted transactions (PR marketplace-subcategory-fix).
 - Fixed seller registration page 500 error by importing csrf macro and sanitized marketplace price filters to avoid "None" in numeric inputs (hotfix marketplace-become-seller).
 - Handled `None` values in marketplace filter inputs to prevent invalid numeric field values (hotfix marketplace-filter-none).
+- Fixed seller dashboard 500 by providing required context variables and timestamp alias for messages (hotfix seller-dashboard-context).

--- a/crunevo/models/marketplace_message.py
+++ b/crunevo/models/marketplace_message.py
@@ -49,5 +49,10 @@ class MarketplaceMessage(db.Model):
     sender = db.relationship("User", foreign_keys=[sender_id])
     receiver = db.relationship("User", foreign_keys=[receiver_id])
 
+    # Alias compatibilidad
+    @property
+    def timestamp(self):
+        return self.created_at
+
     def __repr__(self) -> str:
         return f"<MarketplaceMessage {self.id}>"


### PR DESCRIPTION
## Summary
- Build seller dashboard stats and recent activity, redirecting non-sellers and avoiding missing variable crashes
- Add timestamp property to marketplace messages for template compatibility

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f7d0d35e48325ae2826931e0f33cb