### PR TITLE
Limit store to official products

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1084,3 +1084,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Fixed seller dashboard 500 by providing required context variables and timestamp alias for messages (hotfix seller-dashboard-context).
 - Guarded seller dashboard template against missing product or sender references to prevent runtime errors (hotfix seller-dashboard-template-guards).
 - Added `is_official` field to `Product` model with default `False` and migration to support official products (PR add-product-is_official).
+- Restricted store index and related product queries to `is_official=True` so only official products appear (PR store-official-filter).


### PR DESCRIPTION
## Summary
- limit store index and supporting queries to official products only
- document store filter change

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688fbff9b14c83259dce7f01ab6582d7