### PR TITLE
feat: unify product view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1087,3 +1087,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Restricted store index and related product queries to `is_official=True` so only official products appear (PR store-official-filter).
 - Marketplace now displays a badge for official products and includes them alongside seller listings (PR marketplace-official-badge).
 - Unified `Product` model across store and marketplace: removed duplicate favorite/purchase queries and enforced `is_official` filter in views `store.store_index`, `store.view_product`, `store.redeem_product`, `store.buy_product`, `store.add_to_cart`, `store.view_cart`, `store.checkout`, `store.toggle_favorite` and `marketplace.marketplace_index`.
+- Added unified product route `/producto/<id>` with conditional template and redirects from legacy store and marketplace paths (PR product-view-unify).

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -332,6 +332,7 @@ def create_app():
     )
     from .routes.store_routes import store_bp
     from .routes.marketplace_routes import marketplace_bp
+    from .routes.product_routes import product_bp
     from .routes.chat_routes import chat_bp
     from .routes.search_routes import search_bp
     from .routes.ia_routes import ia_bp
@@ -471,6 +472,7 @@ def create_app():
             view_func=api_search_courses,
         )
         app.register_blueprint(store_bp)
+        app.register_blueprint(product_bp)
         app.register_blueprint(chat_bp)
         app.register_blueprint(search_bp)
         app.register_blueprint(ia_bp)

--- a/crunevo/routes/marketplace_routes.py
+++ b/crunevo/routes/marketplace_routes.py
@@ -110,42 +110,8 @@ def marketplace_index():
 @marketplace_bp.route("/product/<int:product_id>")
 @activated_required
 def view_product(product_id):
-    """Ver detalle de un producto del marketplace."""
-    product = Product.query.get_or_404(product_id)
-
-    # Incrementar contador de vistas
-    product.views_count += 1
-    db.session.commit()
-
-    # Obtener información del vendedor
-    seller = Seller.query.get(product.seller_id) if product.seller_id else None
-
-    # Obtener productos relacionados
-    related_products = (
-        Product.query.filter(
-            Product.category == product.category, Product.id != product.id
-        )
-        .limit(4)
-        .all()
-    )
-
-    # Verificar si el usuario ha comprado el producto
-    has_purchased = False
-    if current_user.is_authenticated:
-        has_purchased = (
-            Purchase.query.filter_by(
-                user_id=current_user.id, product_id=product_id
-            ).first()
-            is not None
-        )
-
-    return render_template(
-        "marketplace/view_product.html",
-        product=product,
-        seller=seller,
-        related_products=related_products,
-        has_purchased=has_purchased,
-    )
+    """Redirect legacy marketplace product path to unified product view."""
+    return redirect(url_for("product.view_product", product_id=product_id))
 
 
 @marketplace_bp.route("/become-seller", methods=["GET", "POST"])

--- a/crunevo/routes/product_routes.py
+++ b/crunevo/routes/product_routes.py
@@ -1,0 +1,92 @@
+from flask import Blueprint, render_template
+from flask_login import current_user
+from sqlalchemy import func
+
+from crunevo.extensions import db
+from crunevo.models import (
+    Product,
+    ProductLog,
+    Purchase,
+    FavoriteProduct,
+    Review,
+    Question,
+)
+
+product_bp = Blueprint("product", __name__)
+
+
+def has_purchased(user_id: int, product_id: int) -> bool:
+    return (
+        Purchase.query.filter_by(user_id=user_id, product_id=product_id).first()
+        is not None
+    )
+
+
+@product_bp.route("/producto/<int:product_id>")
+def view_product(product_id: int):
+    """Unified product view for store and marketplace."""
+    product = Product.query.get_or_404(product_id)
+    if product.is_official:
+        is_favorite = (
+            FavoriteProduct.query.filter_by(
+                user_id=current_user.id, product_id=product.id
+            ).first()
+            is not None
+            if current_user.is_authenticated
+            else False
+        )
+        purchased = (
+            has_purchased(current_user.id, product.id)
+            if current_user.is_authenticated
+            else False
+        )
+        avg_rating = (
+            db.session.query(func.avg(Review.rating))
+            .filter_by(product_id=product.id)
+            .scalar()
+        )
+        reviews = (
+            Review.query.filter_by(product_id=product.id)
+            .options(db.joinedload(Review.user))
+            .order_by(Review.timestamp.desc())
+            .all()
+        )
+        questions = (
+            Question.query.filter_by(product_id=product.id)
+            .options(db.joinedload(Question.user))
+            .order_by(Question.timestamp.desc())
+            .all()
+        )
+        recommended_products = (
+            Product.query.filter(
+                Product.id != product.id, Product.category == product.category
+            )
+            .order_by(func.random())
+            .limit(4)
+            .all()
+        )
+        db.session.add(ProductLog(product_id=product.id, action="view"))
+        db.session.commit()
+        return render_template(
+            "store/view_product.html",
+            product=product,
+            is_favorite=is_favorite,
+            purchased=purchased,
+            avg_rating=avg_rating or 0,
+            reviews=reviews,
+            questions=questions,
+            recommended_products=recommended_products,
+        )
+    # marketplace product
+    product.views_count = (product.views_count or 0) + 1
+    db.session.commit()
+    return render_template(
+        "store/view_product.html",
+        product=product,
+        is_favorite=False,
+        purchased=False,
+        avg_rating=0,
+        reviews=[],
+        questions=[],
+        recommended_products=[],
+    )

--- a/crunevo/routes/store_routes.py
+++ b/crunevo/routes/store_routes.py
@@ -147,57 +147,8 @@ def store_index():
 @store_bp.route("/product/<int:product_id>")
 @activated_required
 def view_product(product_id):
-    """Show detailed information for a single product."""
-    product = Product.query.filter_by(id=product_id, is_official=True).first_or_404()
-    is_favorite = (
-        FavoriteProduct.query.filter_by(
-            user_id=current_user.id, product_id=product.id
-        ).first()
-        is not None
-    )
-    purchased = has_purchased(current_user.id, product.id)
-    from sqlalchemy import func
-
-    avg_rating = (
-        db.session.query(func.avg(Review.rating))
-        .filter_by(product_id=product.id)
-        .scalar()
-    )
-    reviews = (
-        Review.query.filter_by(product_id=product.id)
-        .options(db.joinedload(Review.user))
-        .order_by(Review.timestamp.desc())
-        .all()
-    )
-    questions = (
-        Question.query.filter_by(product_id=product.id)
-        .options(db.joinedload(Question.user))
-        .order_by(Question.timestamp.desc())
-        .all()
-    )
-    # Suggest products from the same category to show in the sidebar
-    from sqlalchemy import func
-
-    recommended_products = (
-        Product.query.filter(
-            Product.id != product.id, Product.category == product.category
-        )
-        .order_by(func.random())
-        .limit(4)
-        .all()
-    )
-    db.session.add(ProductLog(product_id=product.id, action="view"))
-    db.session.commit()
-    return render_template(
-        "store/view_product.html",
-        product=product,
-        is_favorite=is_favorite,
-        purchased=purchased,
-        avg_rating=avg_rating or 0,
-        reviews=reviews,
-        questions=questions,
-        recommended_products=recommended_products,
-    )
+    """Redirect legacy store product path to unified product view."""
+    return redirect(url_for("product.view_product", product_id=product_id))
 
 
 @store_bp.route("/product/<int:product_id>/review", methods=["POST"])

--- a/crunevo/templates/store/view_product.html
+++ b/crunevo/templates/store/view_product.html
@@ -1,11 +1,18 @@
 {% extends 'base.html' %}
 {% import 'components/csrf.html' as csrf %}
 
-{% block title %}{{ product.name }} - Tienda CRUNEVO{% endblock %}
+{% block title %}
+  {{ product.name }} -
+  {% if product.is_official %}Tienda CRUNEVO{% else %}Marketplace CRUNEVO{% endif %}
+{% endblock %}
 
 {% block head_extra %}
+{% if product.is_official %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/store.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/store_detail.css') }}">
+{% else %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/marketplace.css') }}">
+{% endif %}
 {% endblock %}
 
 {% block content %}
@@ -15,13 +22,13 @@
     <nav class="breadcrumb-nav">
       <ol class="breadcrumb">
         <li class="breadcrumb-item">
-          <a href="{{ url_for('store.store_index') }}">
-            <i class="bi bi-shop"></i> Tienda
+          <a href="{{ url_for('store.store_index') if product.is_official else url_for('marketplace.marketplace_index') }}">
+            <i class="bi bi-shop"></i> {{ 'Tienda' if product.is_official else 'Marketplace' }}
           </a>
         </li>
         {% if product.category %}
         <li class="breadcrumb-item">
-          <a href="{{ url_for('store.store_index', categoria=product.category) }}">
+          <a href="{{ url_for('store.store_index', categoria=product.category) if product.is_official else url_for('marketplace.marketplace_index', categoria=product.category) }}">
             {{ product.category }}
           </a>
         </li>
@@ -41,6 +48,11 @@
 
           <!-- Product Badges -->
           <div class="product-badges">
+            {% if product.is_official %}
+            <span class="badge tw-bg-purple-600 tw-text-white">Oficial</span>
+            {% else %}
+            <span class="badge tw-bg-emerald-600 tw-text-white">Marketplace</span>
+            {% endif %}
             {% if product.is_new %}
             <span class="badge badge-new">NUEVO</span>
             {% endif %}
@@ -56,12 +68,14 @@
           </div>
 
           <!-- Favorite Button -->
+          {% if product.is_official %}
           <form method="post" action="{{ url_for('store.toggle_favorite', product_id=product.id) }}" class="favorite-form">
             {{ csrf.csrf_field() }}
             <button type="submit" class="favorite-btn-large {{ 'active' if is_favorite else '' }}" title="Agregar a favoritos">
               <i class="bi bi-heart{{ '-fill' if is_favorite else '' }}"></i>
             </button>
           </form>
+          {% endif %}
         </div>
 
         <!-- Thumbnail Gallery -->
@@ -142,13 +156,13 @@
         </div>
 
         <!-- Purchase Actions -->
+        {% if product.is_official %}
         <div class="purchase-actions">
           {% if product.stock > 0 and not purchased %}
             {% if product.price_credits and (not product.credits_only or product.price == 0) %}
             <form method="post" action="{{ url_for('store.redeem_product', product_id=product.id) }}" class="action-form-large">
               {{ csrf.csrf_field() }}
-              <button type="submit" class="btn-crolars-large" 
-                      {% if current_user.credits < product.price_credits %}disabled{% endif %}>
+              <button type="submit" class="btn-crolars-large"{% if current_user.credits < product.price_credits %} disabled{% endif %}>
                 <i class="bi bi-coin"></i>
                 {% if current_user.credits >= product.price_credits %}
                 Canjear con {{ product.price_credits }} Crolars
@@ -206,6 +220,11 @@
           </div>
           {% endif %}
         </div>
+        {% else %}
+        <div class="purchase-actions">
+          <p class="tw-text-center">Contacta al vendedor para comprar este producto.</p>
+        </div>
+        {% endif %}
 
         <!-- Product Features -->
         <div class="product-features">
@@ -243,6 +262,7 @@
       </div>
     </div>
 
+    {% if product.is_official %}
     <!-- Product Tabs -->
     <div class="product-tabs-section">
       <ul class="nav nav-tabs product-tabs" role="tablist">
@@ -440,6 +460,11 @@
         </div>
       </div>
     </div>
+    {% else %}
+    <div class="tw-text-center tw-mt-8">
+      <p>Este producto es parte del marketplace y no admite reseñas ni preguntas.</p>
+    </div>
+    {% endif %}
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- add product blueprint with `/producto/<id>` handling official and marketplace items
- redirect legacy store and marketplace product routes
- merge product templates with `is_official` conditionals and document in AGENTS

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688fda06d5d88325b03fc970be4585b6