### PR TITLE
Fix missing filters in marketplace templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1089,3 +1089,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Unified `Product` model across store and marketplace: removed duplicate favorite/purchase queries and enforced `is_official` filter in views `store.store_index`, `store.view_product`, `store.redeem_product`, `store.buy_product`, `store.add_to_cart`, `store.view_cart`, `store.checkout`, `store.toggle_favorite` and `marketplace.marketplace_index`.
 - Added unified product route `/producto/<id>` with conditional template and redirects from legacy store and marketplace paths (PR product-view-unify).
 - Added error handling and missing context for marketplace seller and message views to prevent 500 errors (hotfix marketplace-route-errors).
+- Registered `timeago` and `date` template filters and imported CSRF macro in marketplace templates to prevent undefined filter errors and ensure proper form protection (hotfix marketplace-filters-csrf).

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -12,6 +12,9 @@ from flask_login import current_user
 import logging
 from logging.handlers import RotatingFileHandler
 import os
+from datetime import datetime
+from markupsafe import Markup
+from humanize import naturaltime
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
@@ -155,6 +158,19 @@ def create_app():
     from .cache.link_preview import extract_first_url, get_preview
 
     app.jinja_env.filters["timesince"] = timesince
+
+    @app.template_filter("timeago")
+    def timeago_filter(dt):
+        if not dt:
+            return ""
+        return Markup(naturaltime(datetime.utcnow() - dt))
+
+    @app.template_filter("date")
+    def format_date(value, format="%d/%m/%Y"):
+        if not value:
+            return ""
+        return value.strftime(format)
+
     app.jinja_env.filters["cl_url"] = optimize_url
 
     def link_preview(text):

--- a/crunevo/templates/marketplace/add_product.html
+++ b/crunevo/templates/marketplace/add_product.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "components/csrf.html" import csrf_field %}
 
 {% block title %}Añadir Producto | Marketplace Crunevo{% endblock %}
 

--- a/crunevo/templates/marketplace/messages.html
+++ b/crunevo/templates/marketplace/messages.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "components/csrf.html" import csrf_field %}
 
 {% block title %}Mensajes | Marketplace Crunevo{% endblock %}
 

--- a/crunevo/templates/marketplace/seller.html
+++ b/crunevo/templates/marketplace/seller.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "components/csrf.html" import csrf_field %}
 
 {% block title %}{{ seller.store_name }} | Marketplace Crunevo{% endblock %}
 

--- a/crunevo/templates/marketplace/view_conversation.html
+++ b/crunevo/templates/marketplace/view_conversation.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "components/csrf.html" import csrf_field %}
 
 {% block title %}Conversación con {{ other_user.username }} | Marketplace Crunevo{% endblock %}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,3 +44,4 @@ Authlib==1.2.1
 bleach==6.1.0
 flask
 PyJWT==2.8.0
+humanize==4.12.3


### PR DESCRIPTION
## Summary
- register `timeago` and `date` filters in app factory
- import CSRF macro in marketplace templates
- add humanize dependency

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68903694a47c8325a63edafd21bafae2