### PR TITLE
fix: correct marketplace messages link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1090,3 +1090,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Added unified product route `/producto/<id>` with conditional template and redirects from legacy store and marketplace paths (PR product-view-unify).
 - Added error handling and missing context for marketplace seller and message views to prevent 500 errors (hotfix marketplace-route-errors).
 - Registered `timeago` and `date` template filters and imported CSRF macro in marketplace templates to prevent undefined filter errors and ensure proper form protection (hotfix marketplace-filters-csrf).
+- Fixed marketplace messages link to use `marketplace.marketplace_index` and guarded optional image upload routes to avoid BuildError (hotfix marketplace-messages-link).

--- a/crunevo/routes/marketplace_routes.py
+++ b/crunevo/routes/marketplace_routes.py
@@ -26,7 +26,7 @@ from crunevo.utils.uploads import save_image
 marketplace_bp = Blueprint("marketplace", __name__, url_prefix="/marketplace")
 
 
-@marketplace_bp.route("/")
+@marketplace_bp.route("/", endpoint="marketplace_index")
 @activated_required
 def marketplace_index():
     """Página principal del marketplace."""

--- a/crunevo/templates/marketplace/add_product.html
+++ b/crunevo/templates/marketplace/add_product.html
@@ -229,6 +229,7 @@
         // Initialize Dropzone for image uploads
         Dropzone.autoDiscover = false;
         
+        {% if 'marketplace.upload_product_image' in url_for.__globals__['current_app'].view_functions %}
         const myDropzone = new Dropzone("#product-images-dropzone", {
             url: "{{ url_for('marketplace.upload_product_image') }}",
             paramName: "file",
@@ -303,6 +304,7 @@
                 });
             }
         });
+        {% endif %}
     });
 </script>
 {% endblock %}

--- a/crunevo/templates/marketplace/become_seller.html
+++ b/crunevo/templates/marketplace/become_seller.html
@@ -305,7 +305,7 @@
     document.addEventListener('DOMContentLoaded', function() {
         // Initialize Dropzone for logo upload
         Dropzone.autoDiscover = false;
-        
+        {% if 'marketplace.upload_seller_image' in url_for.__globals__['current_app'].view_functions %}
         const logoDropzone = new Dropzone("#logo-dropzone", {
             url: "{{ url_for('marketplace.upload_seller_image') }}",
             paramName: "file",
@@ -343,7 +343,7 @@
                 });
             }
         });
-        
+
         // Initialize Dropzone for banner upload
         const bannerDropzone = new Dropzone("#banner-dropzone", {
             url: "{{ url_for('marketplace.upload_seller_image') }}",
@@ -382,6 +382,7 @@
                 });
             }
         });
+        {% endif %}
     });
 </script>
 {% endblock %}

--- a/crunevo/templates/marketplace/edit_product.html
+++ b/crunevo/templates/marketplace/edit_product.html
@@ -265,8 +265,9 @@
         // Initialize Dropzone for image uploads
         Dropzone.autoDiscover = false;
         
+        {% if 'marketplace.upload_product_image' in url_for.__globals__['current_app'].view_functions %}
         const maxFiles = 5 - {{ product.image_urls|length if product.image_urls else 0 }};
-        
+
         const myDropzone = new Dropzone("#product-images-dropzone", {
             url: "{{ url_for('marketplace.upload_product_image') }}",
             paramName: "file",
@@ -347,6 +348,7 @@
                 });
             }
         });
+        {% endif %}
         
         // Current images selection highlight
         const currentImageContainers = document.querySelectorAll('.current-image-container');

--- a/crunevo/templates/marketplace/messages.html
+++ b/crunevo/templates/marketplace/messages.html
@@ -246,7 +246,7 @@
                                 <i class="bi bi-chat-dots text-muted" style="font-size: 4rem;"></i>
                                 <h5 class="mt-3">No tienes mensajes</h5>
                                 <p class="text-muted text-center">Cuando contactes a un vendedor o alguien te contacte, tus conversaciones aparecerán aquí.</p>
-                                <a href="{{ url_for('marketplace.index') }}" class="btn btn-primary mt-3">
+                                <a href="{{ url_for('marketplace.marketplace_index') }}" class="btn btn-primary mt-3">
                                     <i class="bi bi-shop me-2"></i>Explorar Marketplace
                                 </a>
                             </div>


### PR DESCRIPTION
## Summary
- fix marketplace messages template to link back to `marketplace.marketplace_index`
- explicitly declare marketplace index endpoint
- guard optional marketplace upload routes so missing endpoints don't crash rendering

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68903ba434348325a28877cea7ff7693