### PR TITLE
Render marketplace product details with dedicated template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1092,3 +1092,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Registered `timeago` and `date` template filters and imported CSRF macro in marketplace templates to prevent undefined filter errors and ensure proper form protection (hotfix marketplace-filters-csrf).
 - Implemented pagination in seller_products view, passing pagination context and guarding template to avoid undefined errors (hotfix seller-products-pagination).
 - Fixed marketplace messages link to use `marketplace.marketplace_index` and guarded optional image upload routes to avoid BuildError (hotfix marketplace-messages-link).
+- Marketplace product detail view now renders `marketplace/view_product.html` with seller info, related products and CSRF macro (PR marketplace-product-detail-template).

--- a/crunevo/routes/product_routes.py
+++ b/crunevo/routes/product_routes.py
@@ -78,15 +78,28 @@ def view_product(product_id: int):
             recommended_products=recommended_products,
         )
     # marketplace product
+    has_purchased_flag = (
+        has_purchased(current_user.id, product.id)
+        if current_user.is_authenticated
+        else False
+    )
+    related_products = (
+        Product.query.filter(
+            Product.id != product.id,
+            Product.is_official.is_(False),
+            Product.category == product.category,
+        )
+        .order_by(func.random())
+        .limit(4)
+        .all()
+    )
+    seller = product.seller
     product.views_count = (product.views_count or 0) + 1
     db.session.commit()
     return render_template(
-        "store/view_product.html",
+        "marketplace/view_product.html",
         product=product,
-        is_favorite=False,
-        purchased=False,
-        avg_rating=0,
-        reviews=[],
-        questions=[],
-        recommended_products=[],
+        seller=seller,
+        related_products=related_products,
+        has_purchased=has_purchased_flag,
     )

--- a/crunevo/templates/marketplace/view_product.html
+++ b/crunevo/templates/marketplace/view_product.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "components/csrf.html" import csrf_field %}
 
 {% block title %}{{ product.name }} | Marketplace Crunevo{% endblock %}
 


### PR DESCRIPTION
## Summary
- Use `marketplace/view_product.html` for non-official product pages
- Import CSRF macro in marketplace product template
- Document change in AGENTS log

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68904041d69483259a8d32319ade8366