### PR TITLE
Fix seller product edit and delete actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1093,3 +1093,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Implemented pagination in seller_products view, passing pagination context and guarding template to avoid undefined errors (hotfix seller-products-pagination).
 - Fixed marketplace messages link to use `marketplace.marketplace_index` and guarded optional image upload routes to avoid BuildError (hotfix marketplace-messages-link).
 - Marketplace product detail view now renders `marketplace/view_product.html` with seller info, related products and CSRF macro (PR marketplace-product-detail-template).
+- Fixed seller product editing by including unread message count in edit view and replaced delete links with POST forms and CSRF to enable product removal from seller panel (hotfix seller-product-actions).

--- a/crunevo/routes/marketplace_routes.py
+++ b/crunevo/routes/marketplace_routes.py
@@ -437,11 +437,17 @@ def edit_product(product_id):
     # Obtener categorías para el formulario
     from crunevo.constants import STORE_CATEGORIES
 
+    # Obtener mensajes no leídos para el sidebar
+    unread_messages_count = MarketplaceMessage.query.filter_by(
+        receiver_id=current_user.id, is_read=False
+    ).count()
+
     return render_template(
         "marketplace/edit_product.html",
         seller=seller,
         product=product,
         categories=STORE_CATEGORIES,
+        unread_messages_count=unread_messages_count,
     )
 
 

--- a/crunevo/templates/marketplace/seller_products.html
+++ b/crunevo/templates/marketplace/seller_products.html
@@ -160,7 +160,10 @@
                                                             </div>
                                                             <div class="modal-footer">
                                                                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-                                                                <a href="{{ url_for('marketplace.delete_product', product_id=product.id) }}" class="btn btn-danger">Eliminar</a>
+                                                                <form method="post" action="{{ url_for('marketplace.delete_product', product_id=product.id) }}" class="d-inline">
+                                                                    {{ csrf_field() }}
+                                                                    <button type="submit" class="btn btn-danger">Eliminar</button>
+                                                                </form>
                                                             </div>
                                                         </div>
                                                     </div>


### PR DESCRIPTION
## Summary
- include unread message count when rendering seller product edit view
- switch delete action to POST with CSRF and button in seller products template

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890528c473c83259eccc2badc4c648a