### PR TITLE
fix: update profile links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1170,3 +1170,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
   - Categorización de eventos (taller, seminario, feria, conferencia, etc.)
   - Acceso a eventos desde el menú de navegación del panel administrativo
 - Created template `tienda/publish_product.html` for publishing or editing products with form fields and image upload.
+- Replaced `auth.profile_by_username` links with `auth.view_profile` across templates to resolve navbar BuildError (hotfix profile-link).

--- a/crunevo/routes/admin_routes.py
+++ b/crunevo/routes/admin_routes.py
@@ -38,8 +38,6 @@ from crunevo.models import (
     PrintRequest,
     ProductRequest,
     SystemErrorLog,
-    Event,
-    EventParticipation,
 )
 from crunevo.utils.helpers import admin_required
 from crunevo.utils.credits import add_credit

--- a/crunevo/routes/feed/api.py
+++ b/crunevo/routes/feed/api.py
@@ -27,25 +27,33 @@ def get_post_comments(post_id):
     """Get comments for a post"""
     post = Post.query.get_or_404(post_id)
     comments = post.comments
-    
+
     # Formatear los comentarios para la respuesta JSON
     formatted_comments = []
     for comment in comments:
         formatted_comment = {
-            'id': comment.id,
-            'body': comment.body,
-            'timestamp_text': comment.timestamp.strftime('%d/%m/%Y %H:%M') if comment.timestamp else '',
-            'author': {
-                'username': comment.author.username if comment.author else 'Usuario eliminado',
-                'avatar_url': comment.author.avatar_url if comment.author else url_for('static', filename='img/default.png')
-            }
+            "id": comment.id,
+            "body": comment.body,
+            "timestamp_text": (
+                comment.timestamp.strftime("%d/%m/%Y %H:%M")
+                if comment.timestamp
+                else ""
+            ),
+            "author": {
+                "username": (
+                    comment.author.username if comment.author else "Usuario eliminado"
+                ),
+                "avatar_url": (
+                    comment.author.avatar_url
+                    if comment.author
+                    else url_for("static", filename="img/default.png")
+                ),
+            },
         }
         formatted_comments.append(formatted_comment)
-    
-    return jsonify({
-        'post_id': post_id,
-        'comments': formatted_comments
-    })
+
+    return jsonify({"post_id": post_id, "comments": formatted_comments})
+
 
 @feed_bp.route("/like/<int:post_id>", methods=["POST"])
 @activated_required

--- a/crunevo/routes/feed/views.py
+++ b/crunevo/routes/feed/views.py
@@ -106,11 +106,12 @@ def view_feed():
     template = "feed/feed.html"
     # Obtener datos para el sidebar derecho
     top_ranked, recent_achievements = get_weekly_ranking(limit=3)
-    
+
     # Añadir datetime.now() para cálculos de tiempo relativo
     from datetime import datetime
+
     now = datetime.utcnow()
-    
+
     return render_template(
         template,
         feed_items=data["feed_items"],

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -75,7 +75,7 @@
                 <span class="d-none d-lg-inline">{{ current_user.username }}</span>
               </a>
               <ul class="dropdown-menu dropdown-menu-end">
-                <li><a class="dropdown-item" href="{{ url_for('auth.profile_by_username', username=current_user.username) }}">
+                <li><a class="dropdown-item" href="{{ url_for('auth.view_profile', username=current_user.username) }}">
                   <i class="bi bi-person me-2"></i>Mi Perfil
                 </a></li>
                 <li><a class="dropdown-item" href="{{ url_for('saved.list_saved') }}">

--- a/crunevo/templates/components/note_card.html
+++ b/crunevo/templates/components/note_card.html
@@ -40,7 +40,7 @@
     <div class="note-author">
       <img src="{{ author.avatar_url if author else url_for('static', filename='img/default.png') }}" alt="{{ author.username if author else 'Usuario' }}">
       {% if author %}
-      <a href="{{ url_for('auth.profile_by_username', username=author.username) }}" class="text-decoration-none">{{ author.username }}</a>
+      <a href="{{ url_for('auth.view_profile', username=author.username) }}" class="text-decoration-none">{{ author.username }}</a>
       {% if author and author.verification_level >= 2 %}
       <span class="ms-1" style="color: var(--bs-primary);" data-bs-toggle="tooltip" title="Usuario Verificado">
         <i class="bi bi-patch-check-fill"></i>

--- a/crunevo/templates/components/post_card.html
+++ b/crunevo/templates/components/post_card.html
@@ -18,7 +18,7 @@
     <div class="post-user-info">
       <div class="user-name">
         {% if author %}
-        <a href="{{ url_for('auth.profile_by_username', username=author.username) }}" class="username-link">
+        <a href="{{ url_for('auth.view_profile', username=author.username) }}" class="username-link">
           {{ author.username }}
         </a>
         {% else %}

--- a/crunevo/templates/components/sidebar_left.html
+++ b/crunevo/templates/components/sidebar_left.html
@@ -1,5 +1,5 @@
 <div class="list-group sidebar">
-  <a class="list-group-item list-group-item-action" href="{{ url_for('auth.profile_by_username', username=current_user.username) }}"><i class="bi bi-person mr-2"></i>Mi perfil</a>
+  <a class="list-group-item list-group-item-action" href="{{ url_for('auth.view_profile', username=current_user.username) }}"><i class="bi bi-person mr-2"></i>Mi perfil</a>
   <a class="list-group-item list-group-item-action" href="{{ url_for('notes.list_notes') if 'notes.list_notes' in url_for.__globals__.get('current_app', {}).view_functions else '/notes' }}"><i class="bi bi-journal-text mr-2"></i>Mis apuntes</a>
   <a class="list-group-item list-group-item-action" href="{{ url_for('notes.upload_note') if 'notes.upload_note' in url_for.__globals__.get('current_app', {}).view_functions else '#' }}"><i class="bi bi-upload mr-2"></i>Subir apunte</a>
   <a class="list-group-item list-group-item-action" href="#"><i class="bi bi-star mr-2"></i>Favoritos</a>

--- a/crunevo/templates/feed/post_detail.html
+++ b/crunevo/templates/feed/post_detail.html
@@ -12,7 +12,7 @@
       {% set author = post.author %}
       {% if author %}
       <img loading="lazy" src="{{ author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="40" height="40" alt="avatar">
-      <a href="{{ url_for('auth.profile_by_username', username=author.username) }}" class="me-auto text-decoration-none">
+      <a href="{{ url_for('auth.view_profile', username=author.username) }}" class="me-auto text-decoration-none">
         <strong>{{ author.username }}</strong>
       </a>
       {% else %}
@@ -56,7 +56,7 @@
           <i class="bi bi-share"></i> Compartir
         </button>
         {% if author %}
-        <a href="{{ url_for('auth.profile_by_username', username=author.username) }}" class="btn btn-outline-info btn-sm">Ver perfil</a>
+        <a href="{{ url_for('auth.view_profile', username=author.username) }}" class="btn btn-outline-info btn-sm">Ver perfil</a>
         <a href="{{ url_for('feed.user_posts', user_id=author.id) }}" class="btn btn-outline-primary btn-sm">
           Ver más publicaciones de este usuario
         </a>
@@ -76,7 +76,7 @@
             <img loading="lazy" src="{{ c.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
             <div>
               <div class="small text-muted">
-                <a href="{{ url_for('auth.profile_by_username', username=c.author.username) }}" class="text-decoration-none">{{ c.author.username }}</a> • {{ c.timestamp.strftime('%Y-%m-%d %H:%M') }}
+                <a href="{{ url_for('auth.view_profile', username=c.author.username) }}" class="text-decoration-none">{{ c.author.username }}</a> • {{ c.timestamp.strftime('%Y-%m-%d %H:%M') }}
               </div>
               <div>{{ c.body }}</div>
             </div>

--- a/crunevo/templates/feed/trending.html
+++ b/crunevo/templates/feed/trending.html
@@ -658,7 +658,7 @@
                     </div>
                     <div class="item-info">
                       <div class="user-info">
-                        <a href="{{ url_for('auth.profile_by_username', username=q.author.username) }}" class="username">{{ q.author.username }}</a>
+                        <a href="{{ url_for('auth.view_profile', username=q.author.username) }}" class="username">{{ q.author.username }}</a>
                         {% if q.is_solved %}
                         <span class="status-badge badge-solved">Resuelto</span>
                         {% endif %}

--- a/crunevo/templates/notes/detalle.html
+++ b/crunevo/templates/notes/detalle.html
@@ -33,7 +33,7 @@
         {% endfor %}
       </select>
       {% endif %}
-      <p class="mb-1">por <a href="{{ url_for('auth.profile_by_username', username=note.author.username) }}">{{ note.author.username }}</a></p>
+      <p class="mb-1">por <a href="{{ url_for('auth.view_profile', username=note.author.username) }}">{{ note.author.username }}</a></p>
       {% if note.category %}<p class="mb-1"><span class="badge bg-info text-dark">{{ note.category }}</span></p>{% endif %}
       <div class="mb-2">
         {% for tag in (note.tags or '').split(',') %}
@@ -89,7 +89,7 @@
       <img loading="lazy" src="{{ c.author.avatar_url or url_for('static', filename='img/default.png') }}" class="rounded-circle me-2" width="32" height="32" alt="avatar">
       <div>
         <div class="small text-muted">
-          <a href="{{ url_for('auth.profile_by_username', username=c.author.username) }}" class="text-decoration-none">{{ c.author.username }}</a> • {{ c.created_at.strftime('%Y-%m-%d %H:%M') }}
+          <a href="{{ url_for('auth.view_profile', username=c.author.username) }}" class="text-decoration-none">{{ c.author.username }}</a> • {{ c.created_at.strftime('%Y-%m-%d %H:%M') }}
         </div>
         <div>{{ c.body }}</div>
       </div>

--- a/migrations/versions/add_system_error_log.py
+++ b/migrations/versions/add_system_error_log.py
@@ -31,7 +31,9 @@ def upgrade():
             sa.Column("ruta", sa.String(length=255), nullable=True),
             sa.Column("mensaje", sa.Text(), nullable=True),
             sa.Column("status_code", sa.Integer(), nullable=True),
-            sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=True),
+            sa.Column(
+                "user_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=True
+            ),
             sa.Column(
                 "resuelto", sa.Boolean(), nullable=True, server_default=sa.text("false")
             ),


### PR DESCRIPTION
## Summary
- replace outdated profile_by_username links with view_profile
- clean up unused imports in admin, commerce and event routes

## Testing
- `make fmt`
- `make test`
- `pytest -q` *(fails: Missing csrf_field in several templates, delete_account, comments pagination, streak routes, migrations, onboarding, pageviews)*

------
https://chatgpt.com/codex/tasks/task_e_689125b5312c8325817cc0736bbc84e3