### PR TITLE
fix: restore store route

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1171,3 +1171,5 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
   - Acceso a eventos desde el menú de navegación del panel administrativo
 - Created template `tienda/publish_product.html` for publishing or editing products with form fields and image upload.
 - Replaced `auth.profile_by_username` links with `auth.view_profile` across templates to resolve navbar BuildError (hotfix profile-link).
+
+- Added legacy blueprints to redirect /store and /marketplace paths to /tienda, restoring /store access and preventing 404 errors.

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -353,7 +353,11 @@ def create_app():
         my_saved_courses,
         api_search_courses,
     )
-    from .routes.commerce_routes import commerce_bp
+    from .routes.commerce_routes import (
+        commerce_bp,
+        store_legacy_bp,
+        marketplace_legacy_bp,
+    )
     from .routes.product_routes import product_bp
     from .routes.chat_routes import chat_bp
     from .routes.search_routes import search_bp
@@ -403,6 +407,8 @@ def create_app():
         app.register_blueprint(auth_bp)
         app.register_blueprint(notes_bp)
         app.register_blueprint(commerce_bp)
+        app.register_blueprint(store_legacy_bp)
+        app.register_blueprint(marketplace_legacy_bp)
         app.add_url_rule(
             "/apuntes",
             endpoint="notes.list_notes_alias",


### PR DESCRIPTION
## Summary
- add legacy store and marketplace blueprints that redirect to unified commerce module
- register legacy blueprints to handle /store and /marketplace paths

## Testing
- `pytest` *(fails: 12 failed, 85 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68914a3990088325bae53fbd2b486302