### PR TITLE
Handle undefined price credits in cart

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1182,3 +1182,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Guarded crolars price rendering across store and commerce templates to prevent 500 errors when price is missing (PR store-crolars-undefined).
 - Wrapped favorite product price credits section with defined check and "No disponible" fallback to handle missing values.
 - Wrapped product detail crolars price block with defined check and "No disponible" fallback (hotfix product-crolars-fallback).
+- Guarded cart price credits display and total calculation with defined check and fallback placeholder in `carrito.html`.

--- a/crunevo/templates/store/carrito.html
+++ b/crunevo/templates/store/carrito.html
@@ -33,7 +33,13 @@
               </div>
             </td>
               <td class="text-end">S/ {{ '%.2f'|format(item.product.price or 0) }}</td>
-            <td class="text-end">{{ item.product.price_credits or '—' }}</td>
+            <td class="text-end">
+              {% if item.product.price_credits is defined and item.product.price_credits is not none %}
+                {{ item.product.price_credits }}
+              {% else %}
+                —
+              {% endif %}
+            </td>
             <td class="text-end">
               <a href="{{ url_for('store.remove_item', product_id=item.product.id) }}" class="btn btn-sm btn-outline-danger">
                 <i class="bi bi-trash"></i>
@@ -41,7 +47,11 @@
             </td>
           </tr>
             {% set total_soles = total_soles + (item.product.price or 0) %}
-          {% set total_credits = total_credits + (item.product.price_credits or 0) %}
+          {% if item.product.price_credits is defined and item.product.price_credits is not none %}
+            {% set total_credits = total_credits + item.product.price_credits %}
+          {% else %}
+            {% set total_credits = total_credits + 0 %}
+          {% endif %}
           {% endfor %}
         </tbody>
         <tfoot>


### PR DESCRIPTION
## Summary
- guard cart price_credits display and total when missing
- document change in AGENTS log

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6891817a36f4832587cb9aac0f331a6e