### PR TITLE
Guard product price_credits in view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1183,3 +1183,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Wrapped favorite product price credits section with defined check and "No disponible" fallback to handle missing values.
 - Wrapped product detail crolars price block with defined check and "No disponible" fallback (hotfix product-crolars-fallback).
 - Guarded cart price credits display and total calculation with defined check and fallback placeholder in `carrito.html`.
+- Wrapped product price credits in `store/view_product.html` with defined checks, added "No disponible" fallbacks and disabled actions when missing.

--- a/crunevo/templates/store/view_product.html
+++ b/crunevo/templates/store/view_product.html
@@ -125,14 +125,19 @@
           </div>
           {% endif %}
 
-          {% if product.price_credits %}
+          {% if product.price_credits is defined and product.price_credits %}
           <div class="price-crolars-large">
             <i class="bi bi-coin"></i>
             <span>{{ product.price_credits }} Crolars</span>
           </div>
+          {% else %}
+          <div class="price-crolars-large">
+            <i class="bi bi-coin"></i>
+            <span>No disponible</span>
+          </div>
           {% endif %}
 
-          {% if product.price == 0 and not product.price_credits %}
+          {% if product.price == 0 and not (product.price_credits is defined and product.price_credits) %}
           <div class="price-free-large">
             <i class="bi bi-gift"></i>
             <span>GRATIS</span>
@@ -159,7 +164,7 @@
         {% if product.is_official %}
         <div class="purchase-actions">
           {% if product.stock > 0 and not purchased %}
-            {% if product.price_credits and (not product.credits_only or product.price == 0) %}
+            {% if product.price_credits is defined and product.price_credits and (not product.credits_only or product.price == 0) %}
             <form method="post" action="{{ url_for('store.redeem_product', product_id=product.id) }}" class="action-form-large">
               {{ csrf.csrf_field() }}
               <button type="submit" class="btn-crolars-large"{% if current_user.credits < product.price_credits %} disabled{% endif %}>
@@ -171,6 +176,11 @@
                 {% endif %}
               </button>
             </form>
+            {% else %}
+            <button class="btn-crolars-large" disabled>
+              <i class="bi bi-coin"></i>
+              No disponible
+            </button>
             {% endif %}
 
             {% if product.price > 0 and not product.credits_only %}
@@ -191,7 +201,7 @@
             </form>
             {% endif %}
 
-            {% if product.price == 0 and not product.price_credits %}
+            {% if product.price == 0 and not (product.price_credits is defined and product.price_credits) %}
             <a href="{{ product.download_url or '#' }}" class="btn-free-large">
               <i class="bi bi-download"></i>
               Obtener gratis


### PR DESCRIPTION
## Summary
- guard product credit price display with defined checks and fallback
- disable credit redemption when product has no price_credits
- document view_product price credits handling in AGENTS.md

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_689183309f448325be73299220624967