### PR TITLE
Guard purchases crolars price

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1185,3 +1185,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Guarded cart price credits display and total calculation with defined check and fallback placeholder in `carrito.html`.
 - Wrapped product price credits in `store/view_product.html` with defined checks, added "No disponible" fallbacks and disabled actions when missing.
 - Guarded product card price credits with defined check, added "No disponible" fallbacks and defaulted data-credits to 0 when undefined.
+- Wrapped purchase price credits section with defined check and "No disponible" fallback in `compras.html`.

--- a/crunevo/templates/store/compras.html
+++ b/crunevo/templates/store/compras.html
@@ -20,8 +20,10 @@
             <p class="card-text text-muted">Comprado el {{ compra.timestamp.strftime('%d/%m/%Y') }}</p>
             {% if compra.price_soles %}
               <p class="card-text text-primary">S/ {{ '%.2f'|format(compra.price_soles) }}</p>
-            {% elif compra.price_credits %}
+            {% elif compra.price_credits is defined and compra.price_credits %}
               <p class="card-text text-warning">{{ compra.price_credits }} crolars</p>
+            {% else %}
+              <p class="card-text text-warning">No disponible</p>
             {% endif %}
             {% if compra.shipping_address %}
               <p class="card-text tw-mb-1"><strong>Envío a:</strong> {{ compra.shipping_address }}</p>


### PR DESCRIPTION
## Summary
- guard compras price_credits check to verify defined value and add 'No disponible' fallback
- log the update in AGENTS

## Testing
- `pre-commit run --files crunevo/templates/store/compras.html AGENTS.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689187a6839c832587271909b4a845ab