### PR TITLE
Guard profile purchase credits fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1186,3 +1186,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Wrapped product price credits in `store/view_product.html` with defined checks, added "No disponible" fallbacks and disabled actions when missing.
 - Guarded product card price credits with defined check, added "No disponible" fallbacks and defaulted data-credits to 0 when undefined.
 - Wrapped purchase price credits section with defined check and "No disponible" fallback in `compras.html`.
+- Wrapped profile purchases tab price credits with defined check and "No disponible" fallback.

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -346,8 +346,10 @@
                   <p class="card-text text-muted">Comprado el {{ compra.timestamp.strftime('%d/%m/%Y') }}</p>
                   {% if compra.price_soles %}
                   <p class="card-text text-primary">S/ {{ '%.2f'|format(compra.price_soles) }}</p>
-                  {% elif compra.price_credits %}
+                  {% elif compra.price_credits is defined and compra.price_credits %}
                   <p class="card-text text-warning">{{ compra.price_credits }} crolars</p>
+                  {% else %}
+                  <p class="card-text text-warning">No disponible</p>
                   {% endif %}
                   <a href="{{ url_for('store.download_receipt', purchase_id=compra.id) }}" class="btn btn-outline-secondary btn-sm me-2">Descargar comprobante</a>
                   {% if compra.product.download_url %}


### PR DESCRIPTION
## Summary
- Guard profile purchases tab price credits with `is defined` and show a "No disponible" fallback
- Document change in AGENTS instructions

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6891892db054832582205915cc3c361d