### PR TITLE
Guard price credits field in admin product form

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1188,3 +1188,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Wrapped purchase price credits section with defined check and "No disponible" fallback in `compras.html`.
 - Wrapped profile purchases tab price credits with defined check and "No disponible" fallback.
 - Replaced `product.price_credits or ''` with `product.price_credits if product.price_credits is defined else ''` in `admin/manage_store.html`.
+- Replaced `product.price_credits if product else ''` with `product.price_credits if product and product.price_credits is defined else ''` in `admin/add_edit_product.html`.

--- a/crunevo/templates/admin/add_edit_product.html
+++ b/crunevo/templates/admin/add_edit_product.html
@@ -14,7 +14,7 @@
     <input type="number" step="0.01" name="price" class="form-control" placeholder="Precio" required value="{{ product.price if product else '' }}">
   </div>
   <div class="mb-3">
-    <input type="number" name="price_credits" class="form-control" placeholder="Precio en crolars" value="{{ product.price_credits if product else '' }}">
+    <input type="number" name="price_credits" class="form-control" placeholder="Precio en crolars" value="{{ product.price_credits if product and product.price_credits is defined else '' }}">
   </div>
   <div class="mb-3">
     <input type="number" name="stock" class="form-control" placeholder="Stock" value="{{ product.stock if product else 0 }}">


### PR DESCRIPTION
## Summary
- Handle undefined `price_credits` when editing products in admin panel
- Log template update in `AGENTS.md`

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68918c52203c832599d9d3593813af7e