### PR TITLE
feat: add price credits macro

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1189,3 +1189,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Wrapped profile purchases tab price credits with defined check and "No disponible" fallback.
 - Replaced `product.price_credits or ''` with `product.price_credits if product.price_credits is defined else ''` in `admin/manage_store.html`.
 - Replaced `product.price_credits if product else ''` with `product.price_credits if product and product.price_credits is defined else ''` in `admin/add_edit_product.html`.
+- Added Jinja macro `render_price_credits` in `components/price_credits.html` to display price credits or 'No disponible'; replaced templates to use it and set `Product.price_credits` default to 0. Use `render_price_credits(obj)` for future displays.

--- a/crunevo/models/product.py
+++ b/crunevo/models/product.py
@@ -7,7 +7,7 @@ class Product(db.Model):
     name = db.Column(db.String(140), nullable=False)
     description = db.Column(db.Text)
     price = db.Column(db.Numeric(10, 2), nullable=False)
-    price_credits = db.Column(db.Integer)
+    price_credits = db.Column(db.Integer, default=0)
     image = db.Column(db.String(200))
     image_urls = db.Column(db.JSON)
     stock = db.Column(db.Integer, default=0)

--- a/crunevo/templates/admin/manage_store.html
+++ b/crunevo/templates/admin/manage_store.html
@@ -1,4 +1,5 @@
 {% extends 'admin/base_admin.html' %}
+{% from 'components/price_credits.html' import render_price_credits %}
 {% block admin_content %}
 <h2 class="page-title mb-4">Administrar Tienda</h2>
 {% if current_user.role == 'admin' %}
@@ -48,7 +49,7 @@
           {% endif %}
         </td>
         <td>{{ '%.2f'|format(product.price) }}</td>
-        <td>{{ product.price_credits if product.price_credits is defined else '' }}</td>
+        <td>{{ render_price_credits(product) }}</td>
         <td>{{ product.stock }}</td>
         <td class="text-end">
           <div class="dropdown position-relative">

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% import 'components/csrf.html' as csrf %}
+{% from 'components/price_credits.html' import render_price_credits %}
 
 {% block head_extra %}
 {{ super() }}
@@ -346,10 +347,8 @@
                   <p class="card-text text-muted">Comprado el {{ compra.timestamp.strftime('%d/%m/%Y') }}</p>
                   {% if compra.price_soles %}
                   <p class="card-text text-primary">S/ {{ '%.2f'|format(compra.price_soles) }}</p>
-                  {% elif compra.price_credits is defined and compra.price_credits %}
-                  <p class="card-text text-warning">{{ compra.price_credits }} crolars</p>
                   {% else %}
-                  <p class="card-text text-warning">No disponible</p>
+                  <p class="card-text text-warning">{{ render_price_credits(compra) }}</p>
                   {% endif %}
                   <a href="{{ url_for('store.download_receipt', purchase_id=compra.id) }}" class="btn btn-outline-secondary btn-sm me-2">Descargar comprobante</a>
                   {% if compra.product.download_url %}

--- a/crunevo/templates/components/price_credits.html
+++ b/crunevo/templates/components/price_credits.html
@@ -1,0 +1,7 @@
+{% macro render_price_credits(item) -%}
+  {%- if item and item.price_credits is defined and item.price_credits -%}
+    {{ item.price_credits }} Crolars
+  {%- else -%}
+    No disponible
+  {%- endif -%}
+{%- endmacro %}

--- a/crunevo/templates/store/_product_cards.html
+++ b/crunevo/templates/store/_product_cards.html
@@ -1,4 +1,5 @@
 {% import 'components/csrf.html' as csrf %}
+{% from 'components/price_credits.html' import render_price_credits %}
 {% for product in products %}
 <div class="product-card" data-category="{{ product.category }}" data-price="{{ product.price }}" data-credits="{{ product.price_credits if product.price_credits is defined else 0 }}">
   <div class="product-image-container">
@@ -33,11 +34,7 @@
       {% if product.price > 0 %}
       <div class="price-soles"><i class="bi bi-currency-dollar"></i><span>S/ {{ "%.2f"|format(product.price|float) }}</span></div>
       {% endif %}
-      {% if product.price_credits is defined and product.price_credits %}
-      <div class="price-crolars"><i class="bi bi-coin"></i><span>{{ product.price_credits }} Crolars</span></div>
-      {% else %}
-      <div class="price-crolars"><i class="bi bi-coin"></i><span>No disponible</span></div>
-      {% endif %}
+      <div class="price-crolars"><i class="bi bi-coin"></i><span>{{ render_price_credits(product) }}</span></div>
       {% if product.price == 0 and not (product.price_credits is defined and product.price_credits) %}
       <div class="price-free"><i class="bi bi-gift"></i><span>GRATIS</span></div>
       {% endif %}

--- a/crunevo/templates/store/carrito.html
+++ b/crunevo/templates/store/carrito.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% from 'components/price_credits.html' import render_price_credits %}
 {% block content %}
 <div class="container mt-5">
   <h2 class="mb-4"><i class="bi bi-cart-fill me-2"></i>Tu carrito</h2>
@@ -33,13 +34,7 @@
               </div>
             </td>
               <td class="text-end">S/ {{ '%.2f'|format(item.product.price or 0) }}</td>
-            <td class="text-end">
-              {% if item.product.price_credits is defined and item.product.price_credits is not none %}
-                {{ item.product.price_credits }}
-              {% else %}
-                —
-              {% endif %}
-            </td>
+            <td class="text-end">{{ render_price_credits(item.product) }}</td>
             <td class="text-end">
               <a href="{{ url_for('store.remove_item', product_id=item.product.id) }}" class="btn btn-sm btn-outline-danger">
                 <i class="bi bi-trash"></i>

--- a/crunevo/templates/store/compras.html
+++ b/crunevo/templates/store/compras.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% from 'components/price_credits.html' import render_price_credits %}
 {% block content %}
 <div class="container mt-4">
   <h2 class="mb-4">Mis compras</h2>
@@ -20,10 +21,8 @@
             <p class="card-text text-muted">Comprado el {{ compra.timestamp.strftime('%d/%m/%Y') }}</p>
             {% if compra.price_soles %}
               <p class="card-text text-primary">S/ {{ '%.2f'|format(compra.price_soles) }}</p>
-            {% elif compra.price_credits is defined and compra.price_credits %}
-              <p class="card-text text-warning">{{ compra.price_credits }} crolars</p>
             {% else %}
-              <p class="card-text text-warning">No disponible</p>
+              <p class="card-text text-warning">{{ render_price_credits(compra) }}</p>
             {% endif %}
             {% if compra.shipping_address %}
               <p class="card-text tw-mb-1"><strong>Envío a:</strong> {{ compra.shipping_address }}</p>

--- a/crunevo/templates/store/favorites.html
+++ b/crunevo/templates/store/favorites.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% import 'components/button.html' as btn %}
 {% import 'components/csrf.html' as csrf %}
+{% from 'components/price_credits.html' import render_price_credits %}
 {% block head_extra %}
   <link rel="stylesheet" href="{{ url_for('static', filename='css/store.css') }}">
 {% endblock %}
@@ -56,11 +57,7 @@
                       {% if product.price > 0 %}
                         <p class="mb-1 text-primary fw-bold">S/ {{ '%.2f' | format(product.price) }}</p>
                       {% endif %}
-                    {% if product.price_credits is defined and product.price_credits %}
-                      <p class="mb-1 text-warning fw-bold">{{ product.price_credits }} crolars</p>
-                    {% else %}
-                      <p class="mb-1 text-warning fw-bold">No disponible</p>
-                    {% endif %}
+                    <p class="mb-1 text-warning fw-bold">{{ render_price_credits(product) }}</p>
                     <div class="mb-2">
                       {% if product.is_new %}<span class="badge bg-success">Nuevo</span>{% endif %}
                       {% if product.is_popular %}<span class="badge bg-danger">Popular</span>{% endif %}

--- a/crunevo/templates/store/product_card.html
+++ b/crunevo/templates/store/product_card.html
@@ -1,5 +1,6 @@
 {% import 'components/button.html' as btn %}
 {% import 'components/csrf.html' as csrf %}
+{% from 'components/price_credits.html' import render_price_credits %}
 <div class="card h-100 border border-primary p-2 position-relative">
   <a href="{{ url_for('store.view_product', product_id=product.id) }}">
     <img loading="lazy" src="{{ (product.first_image|cl_url(400,300,'fill')) if product.first_image else '/static/img/producto-default.png' }}" class="card-img-top rounded mb-2 img-fluid" style="max-height: 180px; object-fit: cover;" alt="imagen">
@@ -23,11 +24,7 @@
       {% else %}
         S/ {{ '%.2f'|format(product.price) }}
       {% endif %}
-      {% if product.price_credits is defined and product.price_credits %}
-        <br><small class="text-muted">o {{ product.price_credits }} crolars</small>
-      {% else %}
-        <br><small class="text-muted">No disponible</small>
-      {% endif %}
+      <br><small class="text-muted">{{ render_price_credits(product) }}</small>
     </p>
     {% if product.stock > 0 %}
       <span class="badge bg-success mb-2">En stock</span>

--- a/crunevo/templates/store/store.html
+++ b/crunevo/templates/store/store.html
@@ -1,6 +1,7 @@
 
 {% extends 'base.html' %}
 {% import 'components/csrf.html' as csrf %}
+{% from 'components/price_credits.html' import render_price_credits %}
 
 {% block title %}🛍️ Marketplace CRUNEVO - Tienda Educativa{% endblock %}
 
@@ -261,21 +262,12 @@
                 </div>
                 {% endif %}
                 
-                {% if product.price_credits is defined and product.price_credits %}
                 <div class="price-row">
                   <span class="price-crolars">
                     <i class="bi bi-coin"></i>
-                    {{ product.price_credits }} Crolars
+                    {{ render_price_credits(product) }}
                   </span>
                 </div>
-                {% else %}
-                <div class="price-row">
-                  <span class="price-crolars">
-                    <i class="bi bi-coin"></i>
-                    No disponible
-                  </span>
-                </div>
-                {% endif %}
 
                 {% if product.price == 0 and not (product.price_credits is defined and product.price_credits) %}
                 <div class="price-row">
@@ -316,7 +308,7 @@
                             {% if current_user.credits < product.price_credits %}disabled{% endif %}>
                       <i class="bi bi-coin"></i>
                       {% if current_user.credits >= product.price_credits %}
-                      Canjear {{ product.price_credits }} Crolars
+                      Canjear {{ render_price_credits(product) }}
                       {% else %}
                       Crolars insuficientes
                       {% endif %}

--- a/crunevo/templates/store/view_product.html
+++ b/crunevo/templates/store/view_product.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% import 'components/csrf.html' as csrf %}
+{% from 'components/price_credits.html' import render_price_credits %}
 
 {% block title %}
   {{ product.name }} -
@@ -125,17 +126,10 @@
           </div>
           {% endif %}
 
-          {% if product.price_credits is defined and product.price_credits %}
           <div class="price-crolars-large">
             <i class="bi bi-coin"></i>
-            <span>{{ product.price_credits }} Crolars</span>
+            <span>{{ render_price_credits(product) }}</span>
           </div>
-          {% else %}
-          <div class="price-crolars-large">
-            <i class="bi bi-coin"></i>
-            <span>No disponible</span>
-          </div>
-          {% endif %}
 
           {% if product.price == 0 and not (product.price_credits is defined and product.price_credits) %}
           <div class="price-free-large">
@@ -170,7 +164,7 @@
               <button type="submit" class="btn-crolars-large"{% if current_user.credits < product.price_credits %} disabled{% endif %}>
                 <i class="bi bi-coin"></i>
                 {% if current_user.credits >= product.price_credits %}
-                Canjear con {{ product.price_credits }} Crolars
+                Canjear con {{ render_price_credits(product) }}
                 {% else %}
                 Crolars insuficientes (tienes {{ current_user.credits }})
                 {% endif %}
@@ -448,9 +442,7 @@
                     {% if related.price > 0 %}
                     <span class="price-soles">S/ {{ "%.2f"|format(related.price|float) }}</span>
                     {% endif %}
-                    {% if related.price_credits %}
-                    <span class="price-crolars">{{ related.price_credits }} Crolars</span>
-                    {% endif %}
+                    <span class="price-crolars">{{ render_price_credits(related) }}</span>
                   </div>
                   <a href="{{ url_for('store.view_product', product_id=related.id) }}" class="btn-related">
                     Ver producto

--- a/crunevo/templates/tienda/_product_cards.html
+++ b/crunevo/templates/tienda/_product_cards.html
@@ -1,4 +1,5 @@
 {% import 'components/csrf.html' as csrf %}
+{% from 'components/price_credits.html' import render_price_credits %}
 {% for product in products %}
 <div class="col">
     <div class="card h-100 product-card shadow-hover">
@@ -68,11 +69,7 @@
                         {% else %}
                         <span class="fs-5 fw-bold text-success">Gratis</span>
                         {% endif %}
-                        {% if product.price_credits is defined and product.price_credits %}
-                        <span class="badge bg-warning ms-1">{{ product.price_credits }} Crolars</span>
-                        {% else %}
-                        <span class="badge bg-warning ms-1">No disponible</span>
-                        {% endif %}
+                        <span class="badge bg-warning ms-1">{{ render_price_credits(product) }}</span>
                     </div>
                     
                     <!-- Actions -->

--- a/crunevo/templates/tienda/carrito.html
+++ b/crunevo/templates/tienda/carrito.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% import 'components/csrf.html' as csrf %}
+{% from 'components/price_credits.html' import render_price_credits %}
 
 {% block title %}Carrito de compras - Tienda Crunevo{% endblock %}
 
@@ -61,11 +62,7 @@
                                             {% else %}
                                             <span class="fs-5 fw-bold text-success">Gratis</span>
                                             {% endif %}
-                                            {% if item.product.price_credits is defined and item.product.price_credits > 0 %}
-                                            <span class="badge bg-warning ms-1">{{ item.product.price_credits }} Crolars</span>
-                                            {% else %}
-                                            <span class="badge bg-warning ms-1">No disponible</span>
-                                            {% endif %}
+                                            <span class="badge bg-warning ms-1">{{ render_price_credits(item.product) }}</span>
                                         </div>
                                         
                                         <!-- Controles de cantidad -->

--- a/crunevo/templates/tienda/producto.html
+++ b/crunevo/templates/tienda/producto.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% import 'components/csrf.html' as csrf %}
+{% from 'components/price_credits.html' import render_price_credits %}
 
 {% block title %}{{ product.name }} - Tienda Crunevo{% endblock %}
 
@@ -103,11 +104,7 @@
                         {% else %}
                         <span class="fs-3 fw-bold text-success">Gratis</span>
                         {% endif %}
-                        {% if product.price_credits is defined and product.price_credits > 0 %}
-                        <span class="badge bg-warning ms-2">{{ product.price_credits }} Crolars</span>
-                        {% else %}
-                        <span class="badge bg-warning ms-2">No disponible</span>
-                        {% endif %}
+                        <span class="badge bg-warning ms-2">{{ render_price_credits(product) }}</span>
                     </div>
 
                     <!-- Stock -->

--- a/crunevo/templates/tienda/tienda.html
+++ b/crunevo/templates/tienda/tienda.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% include "csrf.html" %}
+{% from 'components/price_credits.html' import render_price_credits %}
 
 {% block title %}Tienda Crunevo{% endblock %}
 
@@ -181,11 +182,7 @@
                                                     {% else %}
                                                     <span class="fs-4 fw-bold text-success me-2">Gratis</span>
                                                     {% endif %}
-                                                    {% if product.price_credits is defined and product.price_credits > 0 %}
-                                                    <span class="badge bg-warning">{{ product.price_credits }} Crolars</span>
-                                                    {% else %}
-                                                    <span class="badge bg-warning">No disponible</span>
-                                                    {% endif %}
+                                                    <span class="badge bg-warning">{{ render_price_credits(product) }}</span>
                                                 </div>
                                                 <a href="{{ url_for('commerce.view_product', product_id=product.id) }}" class="btn btn-primary">Ver detalles</a>
                                             </div>


### PR DESCRIPTION
## Summary
- add `render_price_credits` macro for consistent price credits display
- default `Product.price_credits` to 0
- document macro usage for future templates

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68918d96b1348325af513034ce99aa76