### PR TITLE
fix: restore feed url after photo modal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1194,3 +1194,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Added accessible labels and hidden text to product card icon buttons to satisfy button accessibility checks.
 - Wrapped `backdrop-filter` usage in `store.css` with `@supports` fallbacks for broader browser compatibility.
 - Restored `X-Frame-Options` security header.
+- Restored `/feed` URL after closing photo modal, added direct route cleanup and ensured back button closes modal (PR feed-modal-url-fix).

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -780,6 +780,7 @@ class ModernFeedManager {
   // Initialize image modal
   initImageModal() {
     document.addEventListener('keydown', (e) => this.handleModalKeydown(e));
+    this.restoreFeedUrlIfPhotoPath();
   }
 
   handleModalKeydown(e) {
@@ -790,6 +791,13 @@ class ModernFeedManager {
       this.nextImage();
     } else if (e.key === 'ArrowLeft') {
       this.prevImage();
+    }
+  }
+
+  restoreFeedUrlIfPhotoPath() {
+    const path = window.location.pathname;
+    if (/^\/feed\/post\/\d+\/photo\/\d+/.test(path)) {
+      window.history.replaceState(null, '', '/feed');
     }
   }
 
@@ -812,9 +820,9 @@ class ModernFeedManager {
     this.currentImageIndex = index;
     this.currentPostId = postId;
     this.currentScale = 1;
-
-    this.prevUrlStack.push(window.location.href);
+    
     this.createImageModal(postId);
+    this.prevUrlStack.push(window.location.href);
     setTimeout(() => this.updateModalImage(), 50);
     window.history.pushState({ modal: true }, '', `/feed/post/${postId}/photo/${index + 1}`);
     if (this.prevUrlStack.length === 1) {
@@ -911,17 +919,15 @@ class ModernFeedManager {
   }
 
   handlePopState(e) {
-    if (e.state && e.state.modal) {
+    if (this.currentPostId) {
       this.closeModal(true);
     }
   }
 
   popModalHistory(fromPopState) {
     if (!fromPopState) {
-      const prevUrl = this.prevUrlStack.pop();
-      if (prevUrl) {
-        window.history.replaceState(null, '', prevUrl);
-      }
+      const prevUrl = this.prevUrlStack.pop() || '/feed';
+      window.history.replaceState(null, '', prevUrl);
     } else {
       this.prevUrlStack.pop();
     }


### PR DESCRIPTION
## Summary
- Ensure photo modal resets the browser URL back to `/feed` when closed
- Clean up photo routes on load and close modal via back button

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893a274cbe083259d5174275d1c1b9a