### PR TITLE
Add placeholder migration to fix missing revision

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1196,3 +1196,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Restored `X-Frame-Options` security header.
 - Restored `/feed` URL after closing photo modal, added direct route cleanup and ensured back button closes modal (PR feed-modal-url-fix).
 - Updated all navigation links and cart scripts to use `/tienda` directly, replacing legacy `/store` paths that filtered out marketplace products. Cart badge and search results now call commerce endpoints. (PR navbar-store-direct)
+- Added placeholder migration cd14a01e631b to resolve missing revision during deployment.

--- a/migrations/versions/cd14a01e631b_placeholder.py
+++ b/migrations/versions/cd14a01e631b_placeholder.py
@@ -1,0 +1,23 @@
+"""Placeholder migration to satisfy missing revision
+
+Revision ID: cd14a01e631b
+Revises: 056ac5a1f108
+Create Date: 2025-08-06 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "cd14a01e631b"
+down_revision = "056ac5a1f108"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/migrations/versions/f0b41d2f9c3a_add_post_reaction.py
+++ b/migrations/versions/f0b41d2f9c3a_add_post_reaction.py
@@ -1,7 +1,7 @@
 """add post reaction table
 
 Revision ID: f0b41d2f9c3a
-Revises: 056ac5a1f108
+Revises: cd14a01e631b
 Create Date: 2025-07-01 00:00:00.000000
 """
 
@@ -16,7 +16,7 @@ def has_table(name: str, conn) -> bool:
 
 # revision identifiers, used by Alembic.
 revision = "f0b41d2f9c3a"
-down_revision = "056ac5a1f108"
+down_revision = "cd14a01e631b"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- add `cd14a01e631b` placeholder migration to satisfy Fly deployment
- re-chain post reaction migration to depend on placeholder

## Testing
- `pre-commit run --files migrations/versions/cd14a01e631b_placeholder.py migrations/versions/f0b41d2f9c3a_add_post_reaction.py AGENTS.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893c37ed30083258627e3435f883504