### PR TITLE
Guard migration against missing tables

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1197,3 +1197,6 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Restored `/feed` URL after closing photo modal, added direct route cleanup and ensured back button closes modal (PR feed-modal-url-fix).
 - Updated all navigation links and cart scripts to use `/tienda` directly, replacing legacy `/store` paths that filtered out marketplace products. Cart badge and search results now call commerce endpoints. (PR navbar-store-direct)
 - Added placeholder migration cd14a01e631b to resolve missing revision during deployment.
+
+- Guarded `complete_missing_models` migration against absent tables and aligned
+  saved courses table name, preventing `NoSuchTableError` on deployments.

--- a/migrations/versions/complete_missing_models.py
+++ b/migrations/versions/complete_missing_models.py
@@ -21,61 +21,71 @@ def upgrade():
     inspector = sa.inspect(conn)
 
     def has_col(table: str, column: str) -> bool:
-        return any(c["name"] == column for c in inspector.get_columns(table))
-
-    if not has_col("users", "pref_dark"):
-        op.add_column(
-            "users",
-            sa.Column("pref_dark", sa.Boolean(), server_default=sa.text("false")),
-        )
-    if not has_col("users", "bio"):
-        op.add_column("users", sa.Column("bio", sa.Text()))
-    if not has_col("users", "career"):
-        op.add_column("users", sa.Column("career", sa.String(100)))
-    if not has_col("users", "interests"):
-        op.add_column("users", sa.Column("interests", sa.Text()))
-
-    if not has_col("product", "active"):
-        op.add_column(
-            "product",
-            sa.Column("active", sa.Boolean(), server_default=sa.text("true")),
-        )
-    if not has_col("product", "popularity_score"):
-        op.add_column(
-            "product",
-            sa.Column("popularity_score", sa.Integer(), server_default="0"),
+        return inspector.has_table(table) and any(
+            c["name"] == column for c in inspector.get_columns(table)
         )
 
-    op.create_table(
-        "club_member",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("user_id", sa.Integer(), nullable=False),
-        sa.Column("club_id", sa.Integer(), nullable=False),
-        sa.Column("role", sa.String(20), server_default="member"),
-        sa.Column("joined_at", sa.DateTime(), server_default=sa.text("now()")),
-        sa.ForeignKeyConstraint(["club_id"], ["club.id"]),
-        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
-        sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("user_id", "club_id"),
-        if_not_exists=True,
-    )
+    if inspector.has_table("users"):
+        if not has_col("users", "pref_dark"):
+            op.add_column(
+                "users",
+                sa.Column("pref_dark", sa.Boolean(), server_default=sa.text("false")),
+            )
+        if not has_col("users", "bio"):
+            op.add_column("users", sa.Column("bio", sa.Text()))
+        if not has_col("users", "career"):
+            op.add_column("users", sa.Column("career", sa.String(100)))
+        if not has_col("users", "interests"):
+            op.add_column("users", sa.Column("interests", sa.Text()))
 
-    op.create_table(
-        "saved_course",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("user_id", sa.Integer(), nullable=False),
-        sa.Column("course_id", sa.Integer(), nullable=False),
-        sa.Column("saved_at", sa.DateTime(), server_default=sa.text("now()")),
-        sa.ForeignKeyConstraint(["course_id"], ["courses.id"]),
-        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
-        sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("user_id", "course_id"),
-        if_not_exists=True,
-    )
+    if inspector.has_table("product"):
+        if not has_col("product", "active"):
+            op.add_column(
+                "product",
+                sa.Column("active", sa.Boolean(), server_default=sa.text("true")),
+            )
+        if not has_col("product", "popularity_score"):
+            op.add_column(
+                "product",
+                sa.Column("popularity_score", sa.Integer(), server_default="0"),
+            )
+
+    if inspector.has_table("users") and inspector.has_table("club"):
+        op.create_table(
+            "club_member",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("user_id", sa.Integer(), nullable=False),
+            sa.Column("club_id", sa.Integer(), nullable=False),
+            sa.Column("role", sa.String(20), server_default="member"),
+            sa.Column("joined_at", sa.DateTime(), server_default=sa.text("now()")),
+            sa.ForeignKeyConstraint(["club_id"], ["club.id"]),
+            sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("user_id", "club_id"),
+            if_not_exists=True,
+        )
+
+    if (
+        inspector.has_table("users")
+        and inspector.has_table("courses")
+        and not inspector.has_table("saved_courses")
+    ):
+        op.create_table(
+            "saved_courses",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("user_id", sa.Integer(), nullable=False),
+            sa.Column("course_id", sa.Integer(), nullable=False),
+            sa.Column("saved_at", sa.DateTime(), server_default=sa.text("now()")),
+            sa.ForeignKeyConstraint(["course_id"], ["courses.id"]),
+            sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("user_id", "course_id"),
+            if_not_exists=True,
+        )
 
 
 def downgrade():
-    op.drop_table("saved_course", if_exists=True)
+    op.drop_table("saved_courses", if_exists=True)
     op.drop_table("club_member", if_exists=True)
     op.drop_column("product", "popularity_score", if_exists=True)
     op.drop_column("product", "active", if_exists=True)


### PR DESCRIPTION
## Summary
- make migration resilient when tables are missing and align saved courses table name

## Testing
- `pre-commit run --files migrations/versions/complete_missing_models.py AGENTS.md`
- `pytest` *(interrupted: 54 passed, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6893c89e24308325857f04024053b16a