### PR TITLE
Guard migration against missing users table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1200,3 +1200,5 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 
 - Guarded `complete_missing_models` migration against absent tables and aligned
   saved courses table name, preventing `NoSuchTableError` on deployments.
+- Guarded `add_user_career_interests` migration against missing `users` table
+  by checking for table existence before altering.

--- a/migrations/versions/4c29ad8b8c1a_add_user_career_interests.py
+++ b/migrations/versions/4c29ad8b8c1a_add_user_career_interests.py
@@ -1,7 +1,7 @@
 """add career and interests fields to user
 
 Revision ID: 4c29ad8b8c1a
-Revises: 018c30955e14
+Revises: add_api_key
 Create Date: 2025-07-08 00:00:00.000000
 """
 
@@ -11,6 +11,8 @@ import sqlalchemy as sa
 
 def has_col(table: str, column: str, conn) -> bool:
     inspector = sa.inspect(conn)
+    if not inspector.has_table(table):
+        return False
     return any(c["name"] == column for c in inspector.get_columns(table))
 
 
@@ -23,6 +25,9 @@ depends_on = None
 
 def upgrade():
     conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if not inspector.has_table("users"):
+        return
     with op.batch_alter_table("users", schema=None) as batch_op:
         if not has_col("users", "career", conn):
             batch_op.add_column(

--- a/migrations/versions/cd14a01e631b_placeholder.py
+++ b/migrations/versions/cd14a01e631b_placeholder.py
@@ -5,8 +5,8 @@ Revises: 056ac5a1f108
 Create Date: 2025-08-06 00:00:00.000000
 """
 
-from alembic import op
-import sqlalchemy as sa
+from alembic import op  # noqa: F401
+import sqlalchemy as sa  # noqa: F401
 
 # revision identifiers, used by Alembic.
 revision = "cd14a01e631b"


### PR DESCRIPTION
## Summary
- Guard `add_user_career_interests` migration against missing `users` table
- Silence unused-import warnings in placeholder migration
- Document deployment fix in AGENTS

## Testing
- `make fmt`
- `make test` *(fails: would reformat crunevo/routes/auth_routes.py)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893d061dcec83259449231c25ef8b46