### PR TITLE
Fix cart totals to prevent 500

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1202,3 +1202,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
   saved courses table name, preventing `NoSuchTableError` on deployments.
 - Guarded `add_user_career_interests` migration against missing `users` table
   by checking for table existence before altering.
+- Computed cart totals server-side and guarded price display to prevent /tienda/cart 500 errors.

--- a/crunevo/routes/commerce_routes.py
+++ b/crunevo/routes/commerce_routes.py
@@ -391,11 +391,24 @@ def remove_item(product_id):
 def view_cart():
     cart = get_cart()
     cart_items = []
+    subtotal = 0
+    shipping_total = 0
     for pid, qty in cart.items():
         product = Product.query.filter_by(id=int(pid)).first()
         if product:
             cart_items.append({"product": product, "quantity": qty})
-    return render_template("tienda/carrito.html", cart_items=cart_items)
+            price = product.price or 0
+            shipping_cost = getattr(product, "shipping_cost", 0) or 0
+            subtotal += price * qty
+            shipping_total += shipping_cost * qty
+    total = subtotal + shipping_total
+    return render_template(
+        "tienda/carrito.html",
+        cart_items=cart_items,
+        subtotal=subtotal,
+        shipping_total=shipping_total,
+        total=total,
+    )
 
 
 @commerce_bp.route("/api/cart_count")

--- a/crunevo/templates/tienda/carrito.html
+++ b/crunevo/templates/tienda/carrito.html
@@ -57,10 +57,13 @@
                                 <div class="col-md-4">
                                     <div class="d-flex justify-content-between align-items-center">
                                         <div>
-                                            {% if item.product.price > 0 %}
-                                            <span class="fs-5 fw-bold text-primary">S/ {{ "%.2f"|format(item.product.price) }}</span>
-                                            {% else %}
+                                            {% set price = item.product.price %}
+                                            {% if price is not none and price > 0 %}
+                                            <span class="fs-5 fw-bold text-primary">S/ {{ "%.2f"|format(price) }}</span>
+                                            {% elif price is not none %}
                                             <span class="fs-5 fw-bold text-success">Gratis</span>
+                                            {% else %}
+                                            <span class="fs-5 fw-bold text-muted">Precio no disponible</span>
                                             {% endif %}
                                             <span class="badge bg-warning ms-1">{{ render_price_credits(item.product) }}</span>
                                         </div>
@@ -93,9 +96,11 @@
                                     </div>
                                     
                                     <!-- Subtotal -->
+                                    {% if price is not none %}
                                     <div class="text-end mt-2">
-                                        <span class="text-muted">Subtotal: S/ {{ "%.2f"|format(item.product.price * item.quantity) }}</span>
+                                        <span class="text-muted">Subtotal: S/ {{ "%.2f"|format(price * item.quantity) }}</span>
                                     </div>
+                                    {% endif %}
                                 </div>
                             </div>
                         </div>
@@ -113,22 +118,19 @@
                     
                     <div class="d-flex justify-content-between mb-2">
                         <span>Subtotal</span>
-                        <span>S/ {{ "%.2f"|format(cart_items|sum(attribute='product.price * quantity')) }}</span>
+                        <span>S/ {{ "%.2f"|format(subtotal) }}</span>
                     </div>
-                    
+
                     <div class="d-flex justify-content-between mb-2">
                         <span>Envío</span>
-                        <span>S/ {{ "%.2f"|format(cart_items|sum(attribute='product.shipping_cost * quantity')) }}</span>
+                        <span>S/ {{ "%.2f"|format(shipping_total) }}</span>
                     </div>
-                    
+
                     <hr>
-                    
+
                     <div class="d-flex justify-content-between mb-3">
                         <span class="fw-bold">Total</span>
-                        <span class="fw-bold">S/ {{ "%.2f"|format(
-                            cart_items|sum(attribute='product.price * quantity') + 
-                            cart_items|sum(attribute='product.shipping_cost * quantity')
-                        ) }}</span>
+                        <span class="fw-bold">S/ {{ "%.2f"|format(total) }}</span>
                     </div>
                     
                     <a href="{{ url_for('commerce.checkout') }}" class="btn btn-primary w-100">Proceder al pago</a>


### PR DESCRIPTION
## Summary
- Compute cart totals in backend and pass subtotal, shipping, and total to template
- Guard cart price display to handle missing values gracefully

## Testing
- `pytest` *(fails: tests/test_migrations.py::test_alembic_upgrade, tests/test_user_verification.py::test_badge_visible, tests/test_user_verification.py::test_admin_can_approve)*

------
https://chatgpt.com/codex/tasks/task_e_6893ef5063ec83259b61f19888519a77