### PR TITLE
Guard profile route against missing data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1203,3 +1203,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Guarded `add_user_career_interests` migration against missing `users` table
   by checking for table existence before altering.
 - Computed cart totals server-side and guarded price display to prevent /tienda/cart 500 errors.
+- Logged missing profile users and returned 404 instead of 500; wrapped profile queries in try/except to handle absent tables gracefully (PR perfil-500-fix).

--- a/crunevo/templates/profile/tabs/apuntes.html
+++ b/crunevo/templates/profile/tabs/apuntes.html
@@ -58,7 +58,7 @@
           <div class="d-flex align-items-center justify-content-between mb-3">
             <h6 class="mb-0"><i class="fas fa-book me-2"></i>Apuntes Subidos</h6>
             {% if is_own_profile %}
-              <a href="{{ url_for('notes.upload') }}" class="btn btn-sm btn-primary">
+              <a href="{{ url_for('notes.upload_note') if 'notes.upload_note' in url_for.__globals__.get('current_app', {}).view_functions else '/notes/upload' }}" class="btn btn-sm btn-primary">
                 <i class="fas fa-plus me-1"></i>Subir Apunte
               </a>
             {% endif %}
@@ -74,7 +74,7 @@
           
           {% if user_notes|length >= 12 %}
             <div class="text-center mt-4">
-              <a href="{{ url_for('notes.list', user_id=user.id) }}" class="btn btn-outline-primary">
+              <a href="{{ url_for('feed.user_notes', user_id=user.id) if 'feed.user_notes' in url_for.__globals__.get('current_app', {}).view_functions else '/feed/user-notes/' ~ user.id }}" class="btn btn-outline-primary">
                 <i class="fas fa-eye me-2"></i>Ver todos los apuntes
               </a>
             </div>
@@ -101,10 +101,10 @@
           </p>
           {% if is_own_profile %}
             <div class="mt-4">
-              <a href="{{ url_for('notes.upload') }}" class="btn btn-primary me-2">
+              <a href="{{ url_for('notes.upload_note') if 'notes.upload_note' in url_for.__globals__.get('current_app', {}).view_functions else '/notes/upload' }}" class="btn btn-primary me-2">
                 <i class="fas fa-upload me-2"></i>Subir Primer Apunte
               </a>
-              <a href="{{ url_for('notes.list') }}" class="btn btn-outline-primary">
+              <a href="{{ url_for('notes.list_notes') if 'notes.list_notes' in url_for.__globals__.get('current_app', {}).view_functions else '/notes' }}" class="btn btn-outline-primary">
                 <i class="fas fa-search me-2"></i>Explorar Apuntes
               </a>
             </div>

--- a/crunevo/templates/profile/tabs/logros.html
+++ b/crunevo/templates/profile/tabs/logros.html
@@ -83,7 +83,7 @@
           <p class="text-muted">¡Pronto lo hará! Los logros aparecerán aquí cuando complete diferentes actividades.</p>
           {% if user.id == current_user.id %}
             <div class="mt-4">
-              <a href="{{ url_for('misiones.index') }}" class="btn btn-primary me-2">
+              <a href="{{ url_for('auth.view_profile', username=current_user.username, tab='misiones') if 'auth.view_profile' in url_for.__globals__.get('current_app', {}).view_functions else '/misiones' }}" class="btn btn-primary me-2">
                 <i class="fas fa-tasks me-2"></i>Ver Misiones
               </a>
               <a href="{{ url_for('feed.view_feed') }}" class="btn btn-outline-primary">

--- a/tests/test_view_profile_route.py
+++ b/tests/test_view_profile_route.py
@@ -1,0 +1,27 @@
+from crunevo.models import User
+
+
+def create_user(username, email):
+    user = User(username=username, email=email, activated=True, avatar_url="a")
+    user.set_password("pass")
+    return user
+
+
+def test_view_profile_existing_user(client, db_session):
+    user = create_user("alice", "alice@example.com")
+    db_session.add(user)
+    db_session.commit()
+    client.post("/login", data={"username": "alice", "password": "pass"})
+    resp = client.get("/perfil/alice")
+    assert resp.status_code == 200
+
+
+def test_view_profile_not_found(client, db_session, caplog):
+    viewer = create_user("bob", "bob@example.com")
+    db_session.add(viewer)
+    db_session.commit()
+    client.post("/login", data={"username": "bob", "password": "pass"})
+    with caplog.at_level("WARNING"):
+        resp = client.get("/perfil/missing")
+    assert resp.status_code == 404
+    assert "User missing not found" in caplog.text


### PR DESCRIPTION
## Summary
- harden profile view to log missing users and tolerate absent tables
- prevent BuildErrors in profile tabs by guarding notes and missions links
- cover profile retrieval with new tests

## Testing
- `pre-commit run --files crunevo/routes/auth_routes.py tests/test_view_profile_route.py AGENTS.md crunevo/templates/profile/tabs/apuntes.html crunevo/templates/profile/tabs/logros.html`
- `pytest` *(fails: tests/test_migrations.py::test_alembic_upgrade)*

------
https://chatgpt.com/codex/tasks/task_e_68940cdb4c7083259a14d982229b27f3