### PR TITLE
Handle null verification_level in profile view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1204,3 +1204,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
   by checking for table existence before altering.
 - Computed cart totals server-side and guarded price display to prevent /tienda/cart 500 errors.
 - Logged missing profile users and returned 404 instead of 500; wrapped profile queries in try/except to handle absent tables gracefully (PR perfil-500-fix).
+- Defaulted `verification_level` to 0 in profile logic and templates to prevent 500 errors when user records store NULL values.

--- a/crunevo/routes/auth_routes.py
+++ b/crunevo/routes/auth_routes.py
@@ -238,7 +238,9 @@ def view_profile(username):
         completed_missions_count = 0
 
     # Academic level and participation metrics
-    user_level = min(10, (user.points or 0) // 100 + user.verification_level)
+    user_level = min(
+        10, (user.points or 0) // 100 + (user.verification_level or 0)
+    )
     try:
         notes_count = Note.query.filter_by(user_id=user.id).count()
     except (ProgrammingError, OperationalError):

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -64,7 +64,7 @@
                 <div class="mt-3 d-none d-lg-block">
                   <h3 class="fw-bold mb-1">
                     {{ user.username }}
-                    {% if user.verification_level >= 2 %}
+                    {% if user.verification_level|default(0) >= 2 %}
                       <span class="badge verified-badge" data-bs-toggle="tooltip" title="Cuenta verificada">
                         <i class="bi bi-check-circle-fill"></i>
                       </span>
@@ -98,7 +98,7 @@
             <div class="d-flex justify-content-start align-items-center mb-2 px-3">
               <h3 class="fw-bold mb-0 me-2">
                 {{ user.username }}
-                {% if user.verification_level >= 2 %}
+                {% if user.verification_level|default(0) >= 2 %}
                   <span class="badge verified-badge">
                     <i class="bi bi-check-circle-fill"></i>
                   </span>

--- a/crunevo/templates/club/detail.html
+++ b/crunevo/templates/club/detail.html
@@ -174,7 +174,7 @@
                 <div class="flex-grow-1">
                   <div class="d-flex align-items-center gap-2 mb-2">
                     <h6 class="fw-bold mb-0">{{ post.author.username }}</h6>
-                    {% if post.author.verification_level > 0 %}
+                    {% if post.author.verification_level|default(0) > 0 %}
                     <i class="bi bi-patch-check-fill text-primary"></i>
                     {% endif %}
                     <span class="text-muted small">{{ post.created_at.strftime('%d %b %Y, %H:%M') }}</span>
@@ -287,7 +287,7 @@
                          class="rounded-circle" 
                          width="24" height="24" style="object-fit: cover;">
                     <span class="text-muted">{{ club.creator.username }}</span>
-                    {% if club.creator.verification_level > 0 %}
+                    {% if club.creator.verification_level|default(0) > 0 %}
                     <i class="bi bi-patch-check-fill text-primary"></i>
                     {% endif %}
                   </div>

--- a/crunevo/templates/components/note_card.html
+++ b/crunevo/templates/components/note_card.html
@@ -41,7 +41,7 @@
       <img src="{{ author.avatar_url if author else url_for('static', filename='img/default.png') }}" alt="{{ author.username if author else 'Usuario' }}">
       {% if author %}
       <a href="{{ url_for('auth.view_profile', username=author.username) }}" class="text-decoration-none">{{ author.username }}</a>
-      {% if author and author.verification_level >= 2 %}
+      {% if author and author.verification_level|default(0) >= 2 %}
       <span class="ms-1" style="color: var(--bs-primary);" data-bs-toggle="tooltip" title="Usuario Verificado">
         <i class="bi bi-patch-check-fill"></i>
       </span>

--- a/crunevo/templates/components/post_card.html
+++ b/crunevo/templates/components/post_card.html
@@ -25,7 +25,7 @@
         <span class="deleted-user">Usuario eliminado</span>
         {% endif %}
         
-        {% if author and author.verification_level >= 2 %}
+        {% if author and author.verification_level|default(0) >= 2 %}
         <span class="verified-badge" title="Usuario verificado">
           <i class="bi bi-check-circle-fill"></i>
         </span>

--- a/crunevo/templates/configuracion/verificacion.html
+++ b/crunevo/templates/configuracion/verificacion.html
@@ -5,9 +5,9 @@
     </div>
     <div class="card-body">
       <p class="text-muted">Estado de verificación:
-        {% if current_user.verification_level >= 2 %}Verificado{% elif current_user.verification_level == 1 %}En revisión{% else %}No verificado{% endif %}
+        {% if current_user.verification_level|default(0) >= 2 %}Verificado{% elif current_user.verification_level|default(0) == 1 %}En revisión{% else %}No verificado{% endif %}
       </p>
-      {% if current_user.verification_level == 0 %}
+      {% if current_user.verification_level|default(0) == 0 %}
       <form class="settings-form" method="post" action="{{ url_for('settings.submit_verification') }}">
         {{ csrf.csrf_field() }}
         <div class="mb-3">
@@ -16,7 +16,7 @@
         </div>
         <button type="submit" class="btn btn-primary">Enviar solicitud</button>
       </form>
-      {% elif current_user.verification_level == 1 %}
+      {% elif current_user.verification_level|default(0) == 1 %}
       <p class="text-muted mt-2"><i>Tu solicitud está en revisión.</i></p>
       {% endif %}
     </div>

--- a/crunevo/templates/perfil_publico.html
+++ b/crunevo/templates/perfil_publico.html
@@ -24,7 +24,7 @@
           <div class="mt-3 d-none d-lg-block">
             <h3 class="fw-bold mb-1">
               {{ user.username }}
-              {% if user.verification_level >= 2 %}
+              {% if user.verification_level|default(0) >= 2 %}
               <span class="badge verified-badge" data-bs-toggle="tooltip" title="Cuenta verificada">
                 <i class="bi bi-check-circle-fill"></i>
               </span>
@@ -65,7 +65,7 @@
         <div class="d-flex justify-content-start align-items-center mb-2 px-3">
           <h3 class="fw-bold mb-0 me-2">
             {{ user.username }}
-            {% if user.verification_level >= 2 %}
+            {% if user.verification_level|default(0) >= 2 %}
             <span class="badge verified-badge">
               <i class="bi bi-check-circle-fill"></i>
             </span>

--- a/crunevo/templates/ranking/index.html
+++ b/crunevo/templates/ranking/index.html
@@ -426,7 +426,7 @@
               </small>
               <div>
                 <span class="badge bg-primary">{{ user.points or 0 }} pts</span>
-                {% if user.verification_level >= 2 %}
+                {% if user.verification_level|default(0) >= 2 %}
                 <span class="badge bg-success">✓ Verificado</span>
                 {% endif %}
               </div>

--- a/tests/test_view_profile_route.py
+++ b/tests/test_view_profile_route.py
@@ -25,3 +25,13 @@ def test_view_profile_not_found(client, db_session, caplog):
         resp = client.get("/perfil/missing")
     assert resp.status_code == 404
     assert "User missing not found" in caplog.text
+
+
+def test_view_profile_null_verification_level(client, db_session):
+    user = create_user("charlie", "charlie@example.com")
+    user.verification_level = None
+    db_session.add(user)
+    db_session.commit()
+    client.post("/login", data={"username": "charlie", "password": "pass"})
+    resp = client.get("/perfil/charlie")
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- avoid TypeError in profile route by defaulting `verification_level` to 0
- guard template checks for `verification_level` with default filter
- add regression test for profiles with null `verification_level`

## Testing
- `make fmt` *(fails: Local variable `data` is assigned to but never used)*
- `make test` *(fails: unused imports and F541 f-string without placeholders)*

------
https://chatgpt.com/codex/tasks/task_e_68942e652d708325bf0e963ed92c9fe1