### PR TITLE
Fix profile note rating lookup causing 500

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1205,3 +1205,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Computed cart totals server-side and guarded price display to prevent /tienda/cart 500 errors.
 - Logged missing profile users and returned 404 instead of 500; wrapped profile queries in try/except to handle absent tables gracefully (PR perfil-500-fix).
 - Defaulted `verification_level` to 0 in profile logic and templates to prevent 500 errors when user records store NULL values.
+- Guarded profile note statistics against missing ratings to avoid `/perfil/<username>` 500 errors.

--- a/crunevo/routes/auth_routes.py
+++ b/crunevo/routes/auth_routes.py
@@ -238,9 +238,7 @@ def view_profile(username):
         completed_missions_count = 0
 
     # Academic level and participation metrics
-    user_level = min(
-        10, (user.points or 0) // 100 + (user.verification_level or 0)
-    )
+    user_level = min(10, (user.points or 0) // 100 + (user.verification_level or 0))
     try:
         notes_count = Note.query.filter_by(user_id=user.id).count()
     except (ProgrammingError, OperationalError):
@@ -463,14 +461,12 @@ def view_profile(username):
     )
 
     # Calcular estadísticas para las pestañas
-    total_downloads = sum(note.downloads for note in user_notes)
-    total_likes = sum(note.likes for note in user_notes)
-    average_rating = (
-        sum(note.rating for note in user_notes if note.rating)
-        / len([n for n in user_notes if n.rating])
-        if user_notes
-        else 0
-    )
+    total_downloads = sum(getattr(note, "downloads", 0) for note in user_notes)
+    total_likes = sum(getattr(note, "likes", 0) for note in user_notes)
+    ratings = [
+        getattr(note, "rating") for note in user_notes if getattr(note, "rating", None)
+    ]
+    average_rating = sum(ratings) / len(ratings) if ratings else 0
 
     # Datos de tienda si está habilitada
     user_products = []


### PR DESCRIPTION
## Summary
- Avoid AttributeError in `auth.view_profile` by computing note ratings only when present
- Document profile rating fix in AGENTS.md

## Testing
- `make fmt` *(fails: ruff check fixed errors; black check passes)*
- `make test` *(fails: ConnectionRefusedError in test_session.py)*

------
https://chatgpt.com/codex/tasks/task_e_6894323a025c83258587c0270176fb5d