### PR TITLE
Fix profile achievement progress calculation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1207,3 +1207,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Defaulted `verification_level` to 0 in profile logic and templates to prevent 500 errors when user records store NULL values.
 - Guarded profile note statistics against missing ratings to avoid `/perfil/<username>` 500 errors.
 - Filtered non-numeric note ratings and averaged safely to prevent division errors on profile; added tests for profiles with and without notes (PR profile-average-rating-fix).
+- Fixed achievement progress on profile by counting unlocked achievements and avoiding list/int division; added test for logros tab (PR perfil-achievements-fix).

--- a/crunevo/routes/auth_routes.py
+++ b/crunevo/routes/auth_routes.py
@@ -396,6 +396,9 @@ def view_profile(username):
         else:
             locked_achievements.append((code, info))
 
+    unlocked_count = len(unlocked_achievements)
+    locked_count = len(locked_achievements)
+
     misiones = None
     progresos = None
     group_missions = None
@@ -529,7 +532,9 @@ def view_profile(username):
             user_achievements_map=user_achievements_map,
             user_achievements=all_user_achievements,
             unlocked_achievements=unlocked_achievements,
+            unlocked_count=unlocked_count,
             locked_achievements=locked_achievements,
+            locked_count=locked_count,
             user_notes=user_notes,
             user_posts=user_posts,
             total_downloads=total_downloads,

--- a/crunevo/templates/profile/tabs/logros.html
+++ b/crunevo/templates/profile/tabs/logros.html
@@ -9,12 +9,12 @@
             <div class="card-body">
               <div class="d-flex align-items-center justify-content-between mb-3">
                 <h6 class="mb-0">Progreso de Logros</h6>
-                <span class="badge bg-primary">{{ unlocked_achievements }}/{{ total_achievements }}</span>
+                <span class="badge bg-primary">{{ unlocked_count }}/{{ total_achievements }}</span>
               </div>
               <div class="progress" style="height: 8px;">
                 <div class="progress-bar bg-gradient" role="progressbar" 
-                     style="width: {{ (unlocked_achievements / total_achievements * 100) if total_achievements > 0 else 0 }}%"
-                     aria-valuenow="{{ unlocked_achievements }}" 
+                     style="width: {{ (unlocked_count / total_achievements * 100) if total_achievements > 0 else 0 }}%"
+                     aria-valuenow="{{ unlocked_count }}"
                      aria-valuemin="0" 
                      aria-valuemax="{{ total_achievements }}">
                 </div>
@@ -24,7 +24,7 @@
         </div>
 
         <!-- Logros obtenidos -->
-        {% if unlocked_achievements > 0 %}
+        {% if unlocked_count > 0 %}
           <div class="achievements-unlocked mb-4">
             <h6 class="mb-3"><i class="fas fa-trophy text-warning me-2"></i>Logros Obtenidos</h6>
             <div class="row g-3">
@@ -50,7 +50,7 @@
         {% endif %}
 
         <!-- Logros bloqueados -->
-        {% if locked_achievements > 0 %}
+        {% if locked_count > 0 %}
           <div class="achievements-locked">
             <h6 class="mb-3"><i class="fas fa-lock text-muted me-2"></i>Logros por Desbloquear</h6>
             <div class="row g-3">

--- a/tests/test_view_profile_route.py
+++ b/tests/test_view_profile_route.py
@@ -69,3 +69,16 @@ def test_view_profile_with_note_ratings(client, db_session, app):
         assert resp.status_code == 200
         template, context = templates[0]
         assert context["average_rating"] == 4.5
+
+
+def test_view_profile_achievements_progress(client, db_session, app):
+    user = create_user("eve", "eve@example.com")
+    db_session.add(user)
+    db_session.commit()
+
+    client.post("/login", data={"username": "eve", "password": "pass"})
+    with captured_templates(app) as templates:
+        resp = client.get("/perfil/eve?tab=logros")
+        assert resp.status_code == 200
+        template, context = templates[0]
+        assert context["unlocked_count"] == 0


### PR DESCRIPTION
## Summary
- Avoid list/int division on profile achievements by counting unlocked and locked
- Update logros tab to use counts for progress and empty checks
- Test achievements tab renders without progress errors

## Testing
- `pytest` *(fails: ConnectionError to /login)*
- `pytest tests/test_view_profile_route.py`


------
https://chatgpt.com/codex/tasks/task_e_68943ad0fe708325aaeeec24361cbb43