### PR TITLE
fix: guard profile purchases links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1209,3 +1209,5 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Filtered non-numeric note ratings and averaged safely to prevent division errors on profile; added tests for profiles with and without notes (PR profile-average-rating-fix).
 - Fixed achievement progress on profile by counting unlocked achievements and avoiding list/int division; added test for logros tab (PR perfil-achievements-fix).
 - Added fallback `rating` property on `Note` and strengthened profile stats calculations with numeric checks and safe queries to prevent `/perfil/<username>` 500 errors.
+
+- Fixed profile purchases tab by replacing obsolete `commerce.marketplace` link with `commerce.commerce_index`, updating product URLs to `commerce.view_product` and skipping purchases missing a product to avoid BuildError on `/perfil/<username>`.

--- a/crunevo/templates/profile/tabs/compras.html
+++ b/crunevo/templates/profile/tabs/compras.html
@@ -15,6 +15,7 @@
   {% if purchases %}
     <div class="row g-3">
       {% for purchase in purchases %}
+        {% if purchase.product %}
         <div class="col-12">
           <div class="card border-0 shadow-sm">
             <div class="card-body">
@@ -52,13 +53,13 @@
                 </div>
                 <div class="col-md-2 text-end">
                   <div class="btn-group-vertical btn-group-sm">
-                    <a href="{{ url_for('commerce.product_detail', id=purchase.product.id) }}" 
+                    <a href="{{ url_for('commerce.view_product', product_id=purchase.product.id) }}"
                        class="btn btn-outline-primary btn-sm">
                       <i class="fas fa-eye me-1"></i>Ver producto
                     </a>
                     {% if purchase.product.type == 'digital' and purchase.download_url %}
-                      <a href="{{ purchase.download_url }}" 
-                         class="btn btn-success btn-sm" 
+                      <a href="{{ purchase.download_url }}"
+                         class="btn btn-success btn-sm"
                          target="_blank">
                         <i class="fas fa-download me-1"></i>Descargar
                       </a>
@@ -69,6 +70,7 @@
             </div>
           </div>
         </div>
+        {% endif %}
       {% endfor %}
     </div>
 
@@ -97,7 +99,7 @@
       </div>
       <h5 class="text-muted mb-2">No tienes compras aún</h5>
       <p class="text-muted mb-4">¡Explora nuestra tienda y encuentra productos increíbles!</p>
-      <a href="{{ url_for('commerce.marketplace') }}" class="btn btn-primary">
+      <a href="{{ url_for('commerce.commerce_index') }}" class="btn btn-primary">
         <i class="fas fa-store me-2"></i>Ir a la tienda
       </a>
     </div>


### PR DESCRIPTION
## Summary
- prevent BuildError on profile purchases tab by skipping entries without products
- replace outdated commerce URLs with valid endpoints

## Testing
- `pre-commit run --files AGENTS.md crunevo/templates/profile/tabs/compras.html`
- `pytest` *(fails: HTTPConnectionPool(host='localhost', port=5000) [Errno 111] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689446ee7ba483259702d1b06e05cfbd