### PR TITLE
Refactor profile pages to reuse feed components

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1213,3 +1213,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Fixed profile purchases tab by replacing obsolete `commerce.marketplace` link with `commerce.commerce_index`, updating product URLs to `commerce.view_product` and skipping purchases missing a product to avoid BuildError on `/perfil/<username>`.
 
 - Removed scroll-to-top button and associated styles and scripts, eliminating unused scroll event logic. (PR remove-scroll-top)
+- Updated private and public profile views to reuse feed's post creation input and post cards, syncing reaction and save data for a consistent feed-style experience. (PR perfil-feed-sync)

--- a/crunevo/templates/perfil_publico.html
+++ b/crunevo/templates/perfil_publico.html
@@ -85,24 +85,24 @@
 
   <div class="row g-4">
     <div class="col-lg-8 order-lg-2">
-      <div class="card border-0 shadow-sm mb-4">
-        <div class="card-body">
-          <h3 class="mb-3"><i class="bi bi-collection"></i> Publicaciones</h3>
-      {% if user.posts %}
-      <div class="row row-cols-1 g-3">
-        {% for p in user.posts|sort(attribute='created_at', reverse=True) %}
-        {% set item = {'data': p} %}
-        <div class="col">
-          {% include 'components/post_card.html' with context %}
-        </div>
+      {% include 'components/create_post_modal.html' %}
+
+      <div id="feedContainer">
+        {% if user_posts %}
+          {% for post in user_posts %}
+            {% set item = {'data': post} %}
+            {% include 'components/post_card.html' with context %}
+          {% endfor %}
         {% else %}
-        <p class="text-muted">Aún no ha publicado.</p>
-        {% endfor %}
-      </div>
-      {% else %}
-       <p class="text-muted">Aún no ha publicado.</p>
-       {% endif %}
-        </div>
+          <div class="empty-state text-center py-5">
+            <div class="empty-state-icon mb-3">📱</div>
+            <h4 class="text-muted mb-2">¡Este usuario aún no ha publicado!</h4>
+            {% if current_user.is_authenticated and current_user.id == user.id %}
+            <p class="text-muted mb-4">Sé el primero en compartir algo increíble con la comunidad educativa</p>
+            <button class="btn btn-primary rounded-pill post-creation-trigger">Crear publicación</button>
+            {% endif %}
+          </div>
+        {% endif %}
       </div>
     </div>
     <div class="col-lg-4 order-lg-1">

--- a/crunevo/templates/profile/tabs/publicaciones.html
+++ b/crunevo/templates/profile/tabs/publicaciones.html
@@ -2,55 +2,29 @@
 <div class="tab-pane fade {% if not tab or tab == 'publicaciones' %}show active{% endif %}" id="publicaciones" role="tabpanel">
   <div class="row">
     <div class="col-12">
-      {% if user_posts %}
-        <div class="posts-container">
+      {% include 'components/create_post_modal.html' %}
+
+      <div id="feedContainer">
+        {% if user_posts %}
           {% for post in user_posts %}
-            <div class="card border-0 shadow-sm mb-3">
-              <div class="card-body">
-                <div class="d-flex align-items-center mb-3">
-                  <img src="{{ (post.author.avatar_url|cl_url(40,40,'thumb')) if post.author.avatar_url else url_for('static', filename='img/default.png') }}" 
-                       class="rounded-circle me-3" width="40" height="40" alt="Avatar">
-                  <div>
-                    <h6 class="mb-0">{{ post.author.username }}</h6>
-                    <small class="text-muted">{{ post.created_at.strftime('%d %b %Y, %H:%M') }}</small>
-                  </div>
-                </div>
-                <div class="post-content">
-                  {{ post.content|safe }}
-                </div>
-                <div class="d-flex justify-content-between align-items-center mt-3">
-                  <div class="d-flex gap-3">
-                    <span class="text-muted"><i class="bi bi-heart"></i> {{ post.likes }}</span>
-                    <span class="text-muted"><i class="bi bi-chat"></i> {{ post.comments|length }}</span>
-                  </div>
-                  <small class="text-muted">{{ post.created_at.strftime('%d/%m/%Y') }}</small>
-                </div>
-              </div>
-            </div>
+            {% set item = {'data': post} %}
+            {% include 'components/post_card.html' with context %}
           {% endfor %}
-        </div>
-        
-        {% if user_posts|length >= 10 %}
-          <div class="text-center mt-4">
-            <button class="btn btn-outline-primary" id="loadMorePosts">
-              <i class="fas fa-plus me-2"></i>Cargar más publicaciones
+        {% else %}
+          <div class="empty-state text-center py-5">
+            <div class="empty-icon mb-3">
+              <i class="fas fa-pen-fancy fa-3x text-muted"></i>
+            </div>
+            <h5 class="text-muted mb-2">{% if is_own_profile %}Aún no has publicado nada{% else %}Este usuario aún no ha publicado nada{% endif %}</h5>
+            <p class="text-muted">Las publicaciones aparecerán aquí cuando {% if is_own_profile %}comiences{% else %}comience{% endif %} a compartir contenido.</p>
+            {% if is_own_profile %}
+            <button class="btn btn-primary mt-3 post-creation-trigger">
+              <i class="fas fa-plus me-2"></i>Crear primera publicación
             </button>
+            {% endif %}
           </div>
         {% endif %}
-      {% else %}
-        <div class="empty-state text-center py-5">
-          <div class="empty-icon mb-3">
-            <i class="fas fa-pen-fancy fa-3x text-muted"></i>
-          </div>
-          <h5 class="text-muted mb-2">{% if is_own_profile %}Aún no has publicado nada{% else %}Este usuario aún no ha publicado nada{% endif %}</h5>
-          <p class="text-muted">Las publicaciones aparecerán aquí cuando {% if is_own_profile %}comiences{% else %}comience{% endif %} a compartir contenido.</p>
-          {% if is_own_profile %}
-            <a href="{{ url_for('feed.view_feed') }}" class="btn btn-primary mt-3">
-              <i class="fas fa-plus me-2"></i>Crear primera publicación
-            </a>
-          {% endif %}
-        </div>
-      {% endif %}
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Reuse feed post creation modal and post cards in private and public profile views
- Load reaction counts and saved state for profile posts in view_profile route
- Document profile/feed sync in AGENTS.md

## Testing
- `pre-commit run --files crunevo/routes/auth_routes.py crunevo/templates/profile/tabs/publicaciones.html crunevo/templates/perfil_publico.html`
- `pytest` *(fails: ConnectionRefusedError while accessing /login)*
- `pytest tests/test_view_profile_route.py`


------
https://chatgpt.com/codex/tasks/task_e_689451dd85108325ab2eccd9ea727b5f