### PR TITLE
fix: optimize settings init

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1225,3 +1225,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Evitado comparación con `None` en `profile/tabs/compras.html` verificando precios definidos.
 - Corregidos filtros de búsqueda utilizando `Product.is_approved` y removiendo `Post.is_deleted`.
 - Registrado `event_bp` también en modo admin para habilitar la gestión de eventos.
+- Optimized settings page navigation by auto-initializing scripts and moving animations CSS to template for faster load (PR settings-init-fix).

--- a/crunevo/static/js/settings.js
+++ b/crunevo/static/js/settings.js
@@ -201,28 +201,6 @@ function initSettingsPage() {
   }
 }
 
-// Agregar estilos para animaciones
-const style = document.createElement('style');
-style.textContent = `
-  .spin {
-    animation: spin 1s linear infinite;
-  }
-  
-  @keyframes spin {
-    from { transform: rotate(0deg); }
-    to { transform: rotate(360deg); }
-  }
-  
-  .settings-section {
-    animation: fadeIn 0.3s ease-in-out;
-  }
-  
-  @keyframes fadeIn {
-    from { opacity: 0; transform: translateY(10px); }
-    to { opacity: 1; transform: translateY(0); }
-  }
-`;
-document.head.appendChild(style);
-
 window.initSettingsPage = initSettingsPage;
+document.addEventListener('DOMContentLoaded', initSettingsPage);
 

--- a/crunevo/templates/configuracion/index.html
+++ b/crunevo/templates/configuracion/index.html
@@ -101,6 +101,8 @@
 .settings-section {
   padding: 2rem;
   border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+  display: none;
+  animation: fadeIn 0.3s ease-in-out;
 }
 
 .settings-section:last-child {
@@ -109,6 +111,30 @@
 
 [data-bs-theme="dark"] .settings-section {
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.spin {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .section-title {


### PR DESCRIPTION
## Summary
- auto-init settings page after DOM ready
- move animation CSS to template and hide sections until shown
- document settings optimization in AGENTS log

## Testing
- `make fmt`
- `make test` *(fails: F401 `os` imported but unused)*

------
https://chatgpt.com/codex/tasks/task_e_6894e73d98ac8325819d36a9568ec713