### PR TITLE
Fix personal space settings view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1226,3 +1226,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Corregidos filtros de búsqueda utilizando `Product.is_approved` y removiendo `Post.is_deleted`.
 - Registrado `event_bp` también en modo admin para habilitar la gestión de eventos.
 - Optimized settings page navigation by auto-initializing scripts and moving animations CSS to template for faster load (PR settings-init-fix).
+- Provided default user statistics in personal space settings view to prevent 500 errors and added view tests for main personal space pages. (PR personal-space-settings-fix)

--- a/crunevo/routes/personal_space_routes.py
+++ b/crunevo/routes/personal_space_routes.py
@@ -531,7 +531,25 @@ def templates_view():
 @activated_required
 def settings_view():
     """Settings view for personal space"""
-    return render_template("personal_space/views/settings_view.html")
+    # Basic user statistics to avoid template errors when no data exists
+    blocks = Block.query.filter_by(user_id=current_user.id).all()
+    goals_completed = sum(
+        1
+        for b in blocks
+        if b.type == "objetivo" and b.get_progress_percentage() == 100
+    )
+    created = getattr(current_user, "created_at", None)
+    days_active = (
+        (datetime.utcnow().date() - created.date()).days + 1 if created else 0
+    )
+    user_stats = {
+        "total_blocks": len(blocks),
+        "days_active": days_active,
+        "goals_completed": goals_completed,
+    }
+    return render_template(
+        "personal_space/views/settings_view.html", user_stats=user_stats
+    )
 
 
 @personal_space_bp.route("/buscar")

--- a/tests/test_personal_space_views.py
+++ b/tests/test_personal_space_views.py
@@ -1,0 +1,21 @@
+from crunevo.models import User
+
+
+def login(client, username, password="secret"):
+    return client.post("/login", data={"username": username, "password": password})
+
+
+def test_personal_space_views(client, test_user):
+    login(client, test_user.username)
+    paths = [
+        "/espacio-personal/",
+        "/espacio-personal/calendario",
+        "/espacio-personal/estadisticas",
+        "/espacio-personal/plantillas",
+        "/espacio-personal/configuracion",
+        "/espacio-personal/buscar",
+        "/espacio-personal/papelera",
+    ]
+    for path in paths:
+        resp = client.get(path, environ_overrides={"wsgi.url_scheme": "https"})
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- avoid 500 errors on personal space settings by supplying default user statistics
- cover core personal space pages with new view tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894ea436c808325b64a6431f0b301b3