### PR TITLE
fix: improve profile dark mode and lazy loading

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1227,3 +1227,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Registrado `event_bp` también en modo admin para habilitar la gestión de eventos.
 - Optimized settings page navigation by auto-initializing scripts and moving animations CSS to template for faster load (PR settings-init-fix).
 - Provided default user statistics in personal space settings view to prevent 500 errors and added view tests for main personal space pages. (PR personal-space-settings-fix)
+- Improved profile dark mode and lazy image handling; added Tailwind dark variants, backdrop-filter fallback and IntersectionObserver fixes to mitigate console warnings. (PR perfil-darkmode-console-fix)

--- a/crunevo/static/css/perfil.css
+++ b/crunevo/static/css/perfil.css
@@ -34,6 +34,7 @@
   top: 16px;
   right: 16px;
   background: rgba(255, 255, 255, 0.9);
+  -webkit-backdrop-filter: blur(10px);
   backdrop-filter: blur(10px);
   color: #8B5CF6;
   border: none;
@@ -45,6 +46,13 @@
   transform: translateY(-10px);
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   cursor: pointer;
+}
+
+@supports not ((backdrop-filter: blur(0))) {
+  .profile-banner-edit {
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+  }
 }
 
 .profile-header-bg:hover .profile-banner-edit {
@@ -60,6 +68,11 @@
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   position: relative;
   overflow: hidden;
+}
+
+[data-bs-theme="dark"] .stat-item {
+  background: linear-gradient(135deg, rgba(139, 92, 246, 0.15), rgba(159, 122, 234, 0.15));
+  border-color: rgba(139, 92, 246, 0.3);
 }
 
 .stat-item::before {
@@ -98,6 +111,10 @@
   color: var(--crunevo-gray-600);
   font-weight: 500;
   margin-top: 4px;
+}
+
+[data-bs-theme="dark"] .stat-label {
+  color: var(--gray-300);
 }
 
 .achievements-section,
@@ -196,6 +213,11 @@
   border-radius: 8px;
   padding: 0.75rem 1rem;
   font-size: 0.9rem;
+}
+
+[data-bs-theme="dark"] .profile-stats {
+  background: var(--gray-800);
+  color: var(--bs-light);
 }
 
 .avatar-edit-btn {

--- a/crunevo/static/js/enhanced-ui.js
+++ b/crunevo/static/js/enhanced-ui.js
@@ -108,35 +108,42 @@ function initStoryRings() {
 function initImageGalleryEnhancements() {
     // Enhanced image gallery interactions
     const galleryImages = document.querySelectorAll('.gallery-img');
+
+    const loadImage = img => {
+        if (img.dataset.src) {
+            img.src = img.dataset.src;
+            img.removeAttribute('data-src');
+        }
+    };
+
+    const observer = 'IntersectionObserver' in window ?
+        new IntersectionObserver((entries, obs) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    loadImage(entry.target);
+                    obs.unobserve(entry.target);
+                }
+            });
+        }) : null;
+
     galleryImages.forEach((img, index) => {
         img.addEventListener('click', function() {
             const postId = this.closest('[data-post-id]')?.dataset.postId;
             openImageModal(this.src, index, postId);
         });
-        
-        // Add loading placeholder
+
         img.addEventListener('load', function() {
             this.classList.add('loaded');
         });
-        
-        // Lazy loading intersection observer
-        if ('IntersectionObserver' in window) {
-            const imageObserver = new IntersectionObserver((entries, observer) => {
-                entries.forEach(entry => {
-                    if (entry.isIntersecting) {
-                        const img = entry.target;
-                        if (img.dataset.src) {
-                            img.src = img.dataset.src;
-                            img.removeAttribute('data-src');
-                            observer.unobserve(img);
-                        }
-                    }
-                });
-            });
-            
-            if (img.dataset.src) {
-                imageObserver.observe(img);
-            }
+
+        img.addEventListener('error', function() {
+            loadImage(this);
+        });
+
+        if (observer && img.dataset.src) {
+            observer.observe(img);
+        } else {
+            loadImage(img);
         }
     });
 }

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -23,7 +23,7 @@
       <div class="card border-0 shadow-sm mb-4 profile-header">
         <div class="position-relative">
           <div class="profile-header-bg position-relative" style="height: 200px;">
-  <img src="{{ user.banner_url or url_for('static', filename='img/default.png') }}" class="profile-banner w-100 h-100 object-fit-cover" alt="Banner">
+  <img src="{{ user.banner_url or url_for('static', filename='img/default.png') }}" class="profile-banner w-100 h-100 object-fit-cover" alt="Banner" loading="lazy">
 
   {% if current_user.id == user.id %}
   <button type="button" class="profile-banner-edit">
@@ -39,7 +39,7 @@
               <div class="profile-avatar-container text-center position-relative" style="margin-top: -60px;">
                 <img src="{{ (user.avatar_url|cl_url(120,120,'thumb')) if user.avatar_url else url_for('static', filename='img/default.png') }}"
                      class="rounded-circle border border-white shadow avatar-img"
-                     id="avatarPreview" width="120" height="120" alt="Avatar">
+                     id="avatarPreview" width="120" height="120" alt="Avatar" loading="lazy">
 
                 {% if current_user.id == user.id %}
                 <button class="avatar-edit-btn" id="editAvatarBtn" aria-label="Editar avatar">
@@ -134,24 +134,24 @@
         <div class="card-body p-0">
           <ul class="nav nav-tabs nav-fill border-0 bg-light rounded-top" id="profileTabs" role="tablist" style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%) !important;">
             <li class="nav-item" role="presentation">
-              <button class="nav-link text-white {% if not tab or tab == 'publicaciones' %}active bg-white text-primary{% endif %}" 
-                      id="publicaciones-tab" data-bs-toggle="tab" data-bs-target="#publicaciones" 
+              <button class="nav-link text-white dark:text-gray-200 {% if not tab or tab == 'publicaciones' %}active bg-white text-primary dark:bg-gray-800 dark:text-gray-100{% endif %}"
+                      id="publicaciones-tab" data-bs-toggle="tab" data-bs-target="#publicaciones"
                       type="button" role="tab" aria-controls="publicaciones" aria-selected="true"
                       style="border: none; transition: all 0.3s ease;">
                 <i class="fas fa-newspaper me-2"></i>Publicaciones
               </button>
             </li>
             <li class="nav-item" role="presentation">
-              <button class="nav-link text-white {% if tab == 'apuntes' %}active bg-white text-primary{% endif %}" 
-                      id="apuntes-tab" data-bs-toggle="tab" data-bs-target="#apuntes" 
+              <button class="nav-link text-white dark:text-gray-200 {% if tab == 'apuntes' %}active bg-white text-primary dark:bg-gray-800 dark:text-gray-100{% endif %}"
+                      id="apuntes-tab" data-bs-toggle="tab" data-bs-target="#apuntes"
                       type="button" role="tab" aria-controls="apuntes" aria-selected="false"
                       style="border: none; transition: all 0.3s ease;">
                 <i class="fas fa-book me-2"></i>Apuntes
               </button>
             </li>
             <li class="nav-item" role="presentation">
-              <button class="nav-link text-white {% if tab == 'logros' %}active bg-white text-primary{% endif %}" 
-                      id="logros-tab" data-bs-toggle="tab" data-bs-target="#logros" 
+              <button class="nav-link text-white dark:text-gray-200 {% if tab == 'logros' %}active bg-white text-primary dark:bg-gray-800 dark:text-gray-100{% endif %}"
+                      id="logros-tab" data-bs-toggle="tab" data-bs-target="#logros"
                       type="button" role="tab" aria-controls="logros" aria-selected="false"
                       style="border: none; transition: all 0.3s ease;">
                 <i class="fas fa-trophy me-2"></i>Logros
@@ -159,8 +159,8 @@
             </li>
             {% if user.mostrar_tienda_perfil %}
             <li class="nav-item" role="presentation">
-              <button class="nav-link text-white {% if tab == 'tienda' %}active bg-white text-primary{% endif %}" 
-                      id="tienda-tab" data-bs-toggle="tab" data-bs-target="#tienda" 
+              <button class="nav-link text-white dark:text-gray-200 {% if tab == 'tienda' %}active bg-white text-primary dark:bg-gray-800 dark:text-gray-100{% endif %}"
+                      id="tienda-tab" data-bs-toggle="tab" data-bs-target="#tienda"
                       type="button" role="tab" aria-controls="tienda" aria-selected="false"
                       style="border: none; transition: all 0.3s ease;">
                 <i class="fas fa-store me-2"></i>Tienda
@@ -169,24 +169,24 @@
             {% endif %}
             {% if is_own_profile %}
             <li class="nav-item" role="presentation">
-              <button class="nav-link text-white {% if tab == 'misiones' %}active bg-white text-primary{% endif %}" 
-                      id="misiones-tab" data-bs-toggle="tab" data-bs-target="#misiones" 
+              <button class="nav-link text-white dark:text-gray-200 {% if tab == 'misiones' %}active bg-white text-primary dark:bg-gray-800 dark:text-gray-100{% endif %}"
+                      id="misiones-tab" data-bs-toggle="tab" data-bs-target="#misiones"
                       type="button" role="tab" aria-controls="misiones" aria-selected="false"
                       style="border: none; transition: all 0.3s ease;">
                 <i class="fas fa-bullseye me-2"></i>Misiones
               </button>
             </li>
             <li class="nav-item" role="presentation">
-              <button class="nav-link text-white {% if tab == 'compras' %}active bg-white text-primary{% endif %}" 
-                      id="compras-tab" data-bs-toggle="tab" data-bs-target="#compras" 
+              <button class="nav-link text-white dark:text-gray-200 {% if tab == 'compras' %}active bg-white text-primary dark:bg-gray-800 dark:text-gray-100{% endif %}"
+                      id="compras-tab" data-bs-toggle="tab" data-bs-target="#compras"
                       type="button" role="tab" aria-controls="compras" aria-selected="false"
                       style="border: none; transition: all 0.3s ease;">
                 <i class="fas fa-shopping-cart me-2"></i>Compras
               </button>
             </li>
             <li class="nav-item" role="presentation">
-              <button class="nav-link text-white {% if tab == 'referidos' %}active bg-white text-primary{% endif %}" 
-                      id="referidos-tab" data-bs-toggle="tab" data-bs-target="#referidos" 
+              <button class="nav-link text-white dark:text-gray-200 {% if tab == 'referidos' %}active bg-white text-primary dark:bg-gray-800 dark:text-gray-100{% endif %}"
+                      id="referidos-tab" data-bs-toggle="tab" data-bs-target="#referidos"
                       type="button" role="tab" aria-controls="referidos" aria-selected="false"
                       style="border: none; transition: all 0.3s ease;">
                 <i class="fas fa-users me-2"></i>Referidos
@@ -243,27 +243,27 @@
             <!-- Stats Grid -->
             <div class="row g-2 mb-3">
               <div class="col-6">
-                <div class="text-center p-2 bg-white bg-opacity-20 rounded">
+                <div class="text-center p-2 bg-white bg-opacity-20 dark:bg-gray-800 dark:bg-opacity-40 rounded dark:text-gray-100">
                   <div class="h5 fw-bold mb-0">{{ user_level }}</div>
-                  <small class="opacity-75">Nivel</small>
+                  <small class="opacity-75 dark:text-gray-300">Nivel</small>
                 </div>
               </div>
               <div class="col-6">
-                <div class="text-center p-2 bg-white bg-opacity-20 rounded">
+                <div class="text-center p-2 bg-white bg-opacity-20 dark:bg-gray-800 dark:bg-opacity-40 rounded dark:text-gray-100">
                   <div class="h5 fw-bold mb-0">{{ participation_percentage }}%</div>
-                  <small class="opacity-75">Participación</small>
+                  <small class="opacity-75 dark:text-gray-300">Participación</small>
                 </div>
               </div>
               <div class="col-6">
-                <div class="text-center p-2 bg-white bg-opacity-20 rounded">
+                <div class="text-center p-2 bg-white bg-opacity-20 dark:bg-gray-800 dark:bg-opacity-40 rounded dark:text-gray-100">
                   <div class="h5 fw-bold mb-0">{{ notes_count(user) }}</div>
-                  <small class="opacity-75">Apuntes</small>
+                  <small class="opacity-75 dark:text-gray-300">Apuntes</small>
                 </div>
               </div>
               <div class="col-6">
-                <div class="text-center p-2 bg-white bg-opacity-20 rounded">
+                <div class="text-center p-2 bg-white bg-opacity-20 dark:bg-gray-800 dark:bg-opacity-40 rounded dark:text-gray-100">
                   <div class="h5 fw-bold mb-0">{{ user.credits }}</div>
-                  <small class="opacity-75">Crolars</small>
+                  <small class="opacity-75 dark:text-gray-300">Crolars</small>
                 </div>
               </div>
             </div>
@@ -339,15 +339,15 @@
             </h6>
             <div class="row g-3">
               <div class="col-6">
-                <div class="text-center p-3 bg-white bg-opacity-20 rounded">
+                <div class="text-center p-3 bg-white bg-opacity-20 dark:bg-gray-800 dark:bg-opacity-40 rounded dark:text-gray-100">
                   <div class="h4 fw-bold mb-1">{{ achievements|length }}</div>
-                  <small class="opacity-75">Logros obtenidos</small>
+                  <small class="opacity-75 dark:text-gray-300">Logros obtenidos</small>
                 </div>
               </div>
               <div class="col-6">
-                <div class="text-center p-3 bg-white bg-opacity-20 rounded">
+                <div class="text-center p-3 bg-white bg-opacity-20 dark:bg-gray-800 dark:bg-opacity-40 rounded dark:text-gray-100">
                   <div class="h4 fw-bold mb-1">{{ ((achievements|length/10*100)|int) }}%</div>
-                  <small class="opacity-75">Progreso total</small>
+                  <small class="opacity-75 dark:text-gray-300">Progreso total</small>
                 </div>
               </div>
             </div>

--- a/crunevo/templates/components/sidebar_left_feed.html
+++ b/crunevo/templates/components/sidebar_left_feed.html
@@ -1,16 +1,16 @@
-<div class="sidebar-left bg-white rounded-4 shadow-sm border-0 h-100">
+<div class="sidebar-left bg-white dark:bg-gray-800 rounded-4 shadow-sm border-0 h-100">
   <div class="p-4">
     <!-- User Profile Section -->
     <div class="user-profile-section mb-4 pb-4 border-bottom">
       <div class="d-flex align-items-center gap-3 mb-3">
-        <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}" 
-             alt="Tu avatar" 
-             class="rounded-circle border-2 border-primary" 
-             width="56" 
-             height="56">
+          <img src="{{ current_user.avatar_url or url_for('static', filename='img/default.png') }}"
+               alt="Tu avatar"
+               class="rounded-circle border-2 border-primary"
+               width="56"
+               height="56" loading="lazy">
         <div class="flex-grow-1">
-          <h6 class="mb-1 fw-bold text-dark username">{{ current_user.username }}</h6>
-          <p class="small text-muted mb-0">{{ current_user.career or 'Estudiante' }}</p>
+            <h6 class="mb-1 fw-bold text-dark dark:text-gray-100 username">{{ current_user.username }}</h6>
+            <p class="small text-muted dark:text-gray-400 mb-0">{{ current_user.career or 'Estudiante' }}</p>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- refine profile tabs and stats with Tailwind dark classes and lazy-loaded images
- add dark theme support for sidebar profile info
- add backdrop-filter fallback and stronger lazy-loading via IntersectionObserver

## Testing
- `make fmt`
- `make test` *(fails: F401 unused imports in unrelated scripts)*

------
https://chatgpt.com/codex/tasks/task_e_6894f591ddc48325a68864192f16fac8