### PR TITLE
Fix profile sidebar text colors for dark mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1229,3 +1229,5 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Provided default user statistics in personal space settings view to prevent 500 errors and added view tests for main personal space pages. (PR personal-space-settings-fix)
 - Improved profile dark mode and lazy image handling; added Tailwind dark variants, backdrop-filter fallback and IntersectionObserver fixes to mitigate console warnings. (PR perfil-darkmode-console-fix)
 - Added slug-based template application endpoint and modernized personal space template cards with badges, dark mode, and accessible preview buttons; updated JS fetch error handling and tests. (PR personal-template-apply)
+
+- Adjusted profile sidebar username and career text to inherit theme colors, ensuring readability on light and dark backgrounds. (PR perfil-sidebar-text-color)

--- a/crunevo/templates/components/sidebar_left_feed.html
+++ b/crunevo/templates/components/sidebar_left_feed.html
@@ -1,4 +1,4 @@
-<div class="sidebar-left bg-white dark:bg-gray-800 rounded-4 shadow-sm border-0 h-100">
+<div class="sidebar-left bg-white rounded-4 shadow-sm border-0 h-100">
   <div class="p-4">
     <!-- User Profile Section -->
     <div class="user-profile-section mb-4 pb-4 border-bottom">
@@ -9,8 +9,8 @@
                width="56"
                height="56" loading="lazy">
         <div class="flex-grow-1">
-            <h6 class="mb-1 fw-bold text-dark dark:text-gray-100 username">{{ current_user.username }}</h6>
-            <p class="small text-muted dark:text-gray-400 mb-0">{{ current_user.career or 'Estudiante' }}</p>
+            <h6 class="mb-1 fw-bold username">{{ current_user.username }}</h6>
+            <p class="small text-muted mb-0">{{ current_user.career or 'Estudiante' }}</p>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- ensure profile sidebar username and career text inherit theme colors for visibility on light and dark backgrounds
- log the update in AGENTS.md

## Testing
- `make fmt`
- `make test` *(fails: ruff reported unused imports and f-string issues in unrelated scripts)*

------
https://chatgpt.com/codex/tasks/task_e_689515adecb48325be5a131e26c6f6b2