### PR TITLE
Fix duplicate avatar file dialog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1231,3 +1231,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Added slug-based template application endpoint and modernized personal space template cards with badges, dark mode, and accessible preview buttons; updated JS fetch error handling and tests. (PR personal-template-apply)
 
 - Adjusted profile sidebar username and career text to inherit theme colors, ensuring readability on light and dark backgrounds. (PR perfil-sidebar-text-color)
+- Fixed avatar edit button opening file dialog twice by removing duplicate listener and handling upload through the existing input. (PR perfil-avatar-dialog-fix)

--- a/crunevo/static/js/enhanced-ui.js
+++ b/crunevo/static/js/enhanced-ui.js
@@ -39,23 +39,6 @@ function initFloatingButtons() {
         });
     }
     
-    // Profile edit buttons
-    const avatarEditBtns = document.querySelectorAll('.avatar-edit-btn');
-    avatarEditBtns.forEach(btn => {
-        btn.addEventListener('click', function(e) {
-            e.preventDefault();
-            e.stopPropagation();
-            // Trigger file input for avatar upload
-            const fileInput = document.createElement('input');
-            fileInput.type = 'file';
-            fileInput.accept = 'image/*';
-            fileInput.onchange = function(e) {
-                uploadAvatar(e.target.files[0]);
-            };
-            fileInput.click();
-        });
-    });
-    
     // Banner edit button
     const bannerEditBtn = document.querySelector('.profile-banner-edit');
     if (bannerEditBtn) {

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -1087,22 +1087,18 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   const profileInput = document.getElementById('avatarInput');
-  const profilePreview = document.getElementById('avatarPreview');
-  const profileSaveBtn = document.getElementById('saveAvatarBtn');
   const triggerBtn = document.getElementById('editAvatarBtn');
-  if (triggerBtn && profileInput && profilePreview && profileSaveBtn) {
-    triggerBtn.onclick = () => profileInput.click();
-    profileInput.onchange = () => {
+  if (triggerBtn && profileInput) {
+    triggerBtn.addEventListener('click', (e) => {
+      e.preventDefault();
+      profileInput.click();
+    });
+    profileInput.addEventListener('change', () => {
       const file = profileInput.files[0];
       if (file) {
-        const reader = new FileReader();
-        reader.onload = (e) => {
-          profilePreview.src = e.target.result;
-          profileSaveBtn.classList.remove('d-none');
-        };
-        reader.readAsDataURL(file);
+        uploadAvatar(file);
       }
-    };
+    });
   }
 
 

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -42,7 +42,7 @@
                      id="avatarPreview" width="120" height="120" alt="Avatar" loading="lazy">
 
                 {% if current_user.id == user.id %}
-                <button class="avatar-edit-btn" id="editAvatarBtn" aria-label="Editar avatar">
+                <button type="button" class="avatar-edit-btn" id="editAvatarBtn" aria-label="Editar avatar">
                   <i class="bi bi-camera"></i>
                 </button>
 


### PR DESCRIPTION
## Summary
- Prevent avatar edit button from spawning multiple file dialogs
- Simplify avatar upload to use existing input and AJAX upload
- Explicitly mark avatar edit button as type="button"

## Testing
- `make test` *(fails: F401, F541 errors in unrelated scripts)*


------
https://chatgpt.com/codex/tasks/task_e_68951d5d4bd083258193c057bdd77bf7