### PR TITLE
Validate feed uploads and improve flash messaging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1232,3 +1232,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 
 - Adjusted profile sidebar username and career text to inherit theme colors, ensuring readability on light and dark backgrounds. (PR perfil-sidebar-text-color)
 - Fixed avatar edit button opening file dialog twice by removing duplicate listener and handling upload through the existing input. (PR perfil-avatar-dialog-fix)
+- Validated feed post uploads by limiting files to safe extensions and 5MB max size, updated toast templates for flash categories and added tests. (PR feed-upload-validation)

--- a/crunevo/routes/feed/views.py
+++ b/crunevo/routes/feed/views.py
@@ -57,7 +57,32 @@ def create_post():
         return redirect(url_for("feed.view_feed"))
 
     urls = []
+    allowed_exts = {
+        ".jpg",
+        ".jpeg",
+        ".png",
+        ".gif",
+        ".webp",
+        ".mp4",
+        ".webm",
+        ".mov",
+        ".mp3",
+        ".wav",
+        ".ogg",
+    }
+    max_size = 5 * 1024 * 1024
     for f in valid_files:
+        ext = os.path.splitext(f.filename)[1].lower()
+        f.seek(0, os.SEEK_END)
+        size = f.tell()
+        f.seek(0)
+        if ext not in allowed_exts or size > max_size:
+            flash(
+                "Archivo no permitido o excede el tamaño máximo de 5 MB",
+                "danger",
+            )
+            return redirect(url_for("feed.view_feed"))
+
         cloud_url = current_app.config.get("CLOUDINARY_URL")
         try:
             if cloud_url:

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -82,11 +82,11 @@
         <div class="container-fluid px-md-5 pb-5 pt-2">
             <!-- Toast notifications -->
             {% import 'components/toast.html' as toast %}
-            {% with messages = get_flashed_messages() %}
+            {% with messages = get_flashed_messages(with_categories=True) %}
               {% if messages %}
                 <div class="toast-container position-fixed top-0 start-0 end-0 z-50 d-flex flex-column align-items-center gap-2 mt-5" style="z-index: 1080;">
-                  {% for msg in messages %}
-                    {{ toast.toast(msg) }}
+                  {% for category, msg in messages %}
+                    {{ toast.toast(msg, category) }}
                   {% endfor %}
                 </div>
               {% endif %}

--- a/crunevo/templates/components/toast.html
+++ b/crunevo/templates/components/toast.html
@@ -1,5 +1,5 @@
-{% macro toast(message) %}
-<div class="toast align-items-center text-bg-primary border-0" role="alert" aria-live="assertive" aria-atomic="true" data-bs-delay="3000" data-autoshow="true">
+{% macro toast(message, category='primary') %}
+<div class="toast align-items-center text-bg-{{ category }} border-0" role="alert" aria-live="assertive" aria-atomic="true" data-bs-delay="3000" data-autoshow="true">
   <div class="d-flex">
     <div class="toast-body">
       {{ message }}


### PR DESCRIPTION
## Summary
- verify feed file uploads for allowed extensions and 5MB max size before Cloudinary or local storage
- show flash messages with categories via updated toast component
- add regression tests for invalid extension and oversize uploads

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6895366386e483259445196f364bfbf3