### PR TITLE
Restrict feed image uploads and streamline comment permission

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1233,3 +1233,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Adjusted profile sidebar username and career text to inherit theme colors, ensuring readability on light and dark backgrounds. (PR perfil-sidebar-text-color)
 - Fixed avatar edit button opening file dialog twice by removing duplicate listener and handling upload through the existing input. (PR perfil-avatar-dialog-fix)
 - Validated feed post uploads by limiting files to safe extensions and 5MB max size, updated toast templates for flash categories and added tests. (PR feed-upload-validation)
+- Limited feed post uploads to images only, enforced 5MB max per file, rejected more than 10 images and read `comment_permission` once. (PR feed-upload-limits)


### PR DESCRIPTION
## Summary
- limit feed uploads to images with max size 5MB and max 10 files
- read `comment_permission` once and pass to `Post`
- document feed upload limits in `AGENTS.md`

## Testing
- `make test` *(fails: ruff check .)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689538f8cce08325bd96e9870995fdc0