### PR TITLE
Improve forum responsiveness and theme support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1234,3 +1234,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Fixed avatar edit button opening file dialog twice by removing duplicate listener and handling upload through the existing input. (PR perfil-avatar-dialog-fix)
 - Validated feed post uploads by limiting files to safe extensions and 5MB max size, updated toast templates for flash categories and added tests. (PR feed-upload-validation)
 - Limited feed post uploads to images only, enforced 5MB max per file, rejected more than 10 images and read `comment_permission` once. (PR feed-upload-limits)
+- Improved forum question and answer pages with responsive layout, theme-aware card and badge colors, and dark/light compatible vote buttons. (PR forum-responsive-theme)

--- a/crunevo/static/css/forum_editor.css
+++ b/crunevo/static/css/forum_editor.css
@@ -489,7 +489,7 @@
 
 /* Vote Buttons */
 .vote-group {
-  background: #f8fafc;
+  background: var(--bs-light-bg-subtle);
   border-radius: 12px;
   padding: 0.5rem;
 }
@@ -500,6 +500,8 @@
   transition: all 0.3s ease;
   position: relative;
   overflow: hidden;
+  color: var(--bs-body-color);
+  background: transparent;
 }
 
 .vote-btn::before {
@@ -517,6 +519,19 @@
 .vote-btn:hover::before {
   width: 100px;
   height: 100px;
+}
+
+/* Theme adjustments */
+[data-bs-theme="dark"] .vote-group {
+  background: var(--bs-dark-bg-subtle);
+}
+
+[data-bs-theme="dark"] .vote-btn {
+  color: var(--bs-light);
+}
+
+[data-bs-theme="light"] .vote-btn {
+  color: var(--bs-body-color);
 }
 
 .vote-up:hover {

--- a/crunevo/templates/forum/partials/answer_card.html
+++ b/crunevo/templates/forum/partials/answer_card.html
@@ -39,7 +39,7 @@
                 </div>
                 
                 <!-- Answer Content with Enhanced Typography -->
-                <div class="answer-body mb-4 p-3 rounded-3" style="background: {% if answer.is_accepted %}rgba(74, 222, 128, 0.05){% else %}#f8fafc{% endif %}; border-left: 4px solid {% if answer.is_accepted %}#4ade80{% else %}var(--forum-primary){% endif %};">
+                <div class="answer-body mb-4 p-3 rounded-3">
                     {{ answer.content|safe }}
                 </div>
                 

--- a/crunevo/templates/forum/question.html
+++ b/crunevo/templates/forum/question.html
@@ -371,6 +371,100 @@ document.addEventListener('DOMContentLoaded', function() {
 {% endblock %}
 
 <style>
+/* Base responsive styling */
+.question-detail-card .card-body,
+.answer-card .card-body,
+.answer-body {
+  max-width: 100%;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+
+.question-content,
+.question-content .lead {
+  max-width: 100%;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+
+.question-content img,
+.answer-body img {
+  max-width: 100%;
+  height: auto;
+}
+
+.question-content table,
+.answer-body table,
+.question-content pre,
+.answer-body pre {
+  overflow-x: auto;
+  display: block;
+}
+
+.vote-group {
+  max-width: 100%;
+  word-break: break-word;
+}
+
+@media (max-width: 768px) {
+  .question-detail-card .card-body,
+  .answer-card .card-body,
+  .answer-body {
+    padding: 1rem;
+  }
+}
+
+/* Theme adjustments */
+[data-bs-theme="light"] .card-body,
+[data-bs-theme="light"] .answer-body {
+  background-color: var(--bs-body-bg);
+  color: var(--bs-body-color);
+}
+
+[data-bs-theme="dark"] .card-body,
+[data-bs-theme="dark"] .answer-body {
+  background-color: var(--bs-dark-bg-subtle);
+  color: var(--bs-body-color);
+}
+
+.answer-card .answer-body {
+  border-left: 4px solid var(--forum-primary);
+  background-color: var(--bs-light-bg-subtle);
+}
+
+.answer-card.accepted .answer-body {
+  border-left-color: #4ade80;
+  background-color: rgba(74, 222, 128, 0.05);
+}
+
+[data-bs-theme="dark"] .answer-card .answer-body {
+  background-color: var(--bs-dark-bg-subtle);
+}
+
+[data-bs-theme="dark"] .answer-card.accepted .answer-body {
+  background-color: rgba(74, 222, 128, 0.1);
+}
+
+[data-bs-theme="dark"] .vote-group .vote-btn {
+  color: var(--bs-light);
+}
+
+[data-bs-theme="light"] .vote-group .vote-btn {
+  color: var(--bs-body-color);
+}
+
+[data-bs-theme="dark"] .badge,
+[data-bs-theme="dark"] .btn,
+[data-bs-theme="dark"] .label {
+  color: var(--bs-body-color);
+}
+
+[data-bs-theme="light"] .badge,
+[data-bs-theme="light"] .btn,
+[data-bs-theme="light"] .label {
+  color: var(--bs-body-color);
+}
+
 /* Dark Mode Overrides for Question Detail */
 [data-bs-theme="dark"] {
   body {


### PR DESCRIPTION
## Summary
- ensure forum question and answer cards are responsive and use break-word to avoid overflow
- add dark/light theme-aware styling for cards, badges and vote buttons
- update vote button styles to inherit colors from Bootstrap variables

## Testing
- `pre-commit run --files AGENTS.md crunevo/static/css/forum_editor.css crunevo/templates/forum/partials/answer_card.html crunevo/templates/forum/question.html`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68953e62f9208325a1305e86f2a5f61b