### PR TITLE
Require activation for feed comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1235,3 +1235,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Validated feed post uploads by limiting files to safe extensions and 5MB max size, updated toast templates for flash categories and added tests. (PR feed-upload-validation)
 - Limited feed post uploads to images only, enforced 5MB max per file, rejected more than 10 images and read `comment_permission` once. (PR feed-upload-limits)
 - Improved forum question and answer pages with responsive layout, theme-aware card and badge colors, and dark/light compatible vote buttons. (PR forum-responsive-theme)
+- Comentarios en publicaciones requieren usuarios activados; intentos bloqueados se registran para monitoreo. (PR comment-auth-log)

--- a/tests/test_pending_comments.py
+++ b/tests/test_pending_comments.py
@@ -6,18 +6,15 @@ def login(client, username, password="secret"):
     return client.post("/login", data={"username": username, "password": password})
 
 
-def test_anonymous_comment_pending(client, db_session, test_user):
+def test_anonymous_comment_blocked(client, db_session, test_user):
     post = Post(content="x", author=test_user)
     db_session.add(post)
     db_session.commit()
     create_feed_item_for_all("post", post.id)
 
     resp = client.post(f"/feed/comment/{post.id}", data={"body": "hi"})
-    assert resp.status_code == 202
-
-    c = PostComment.query.first()
-    assert c.pending is True
-    assert c.author_id is None
+    assert resp.status_code == 302
+    assert PostComment.query.count() == 0
 
 
 def test_admin_approves_comment(client, db_session, test_user):


### PR DESCRIPTION
## Summary
- require activated accounts for posting comments and log blocked attempts
- update pending comment test to reflect authentication requirement
- note in AGENTS that comments now need activation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895426e6fe083259eb3baed76082eed