### PR TITLE
Enable dynamic feed post insertion without full reload

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1236,3 +1236,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Limited feed post uploads to images only, enforced 5MB max per file, rejected more than 10 images and read `comment_permission` once. (PR feed-upload-limits)
 - Improved forum question and answer pages with responsive layout, theme-aware card and badge colors, and dark/light compatible vote buttons. (PR forum-responsive-theme)
 - Comentarios en publicaciones requieren usuarios activados; intentos bloqueados se registran para monitoreo. (PR comment-auth-log)
+- Reemplazada recarga del feed tras publicar por inserción dinámica usando `_posts.html` retornado en JSON y prueba asociada. (PR feed-dynamic-insert)

--- a/crunevo/static/js/feed.js
+++ b/crunevo/static/js/feed.js
@@ -166,8 +166,10 @@ class ModernFeedManager {
       });
       const response = await this.fetchWithCSRF(form.action || window.location.pathname, {
         method: 'POST',
-        body: formData
+        body: formData,
+        headers: { 'Accept': 'application/json' }
       });
+      const data = await response.json();
 
       if (response.ok) {
         this.showToast('¡Publicación creada exitosamente! 🎉', 'success');
@@ -175,15 +177,17 @@ class ModernFeedManager {
         this.clearImagePreview();
         this.updatePostButtonState();
 
-        // Close modal if open
         const modal = bootstrap.Modal.getInstance(document.getElementById('crearPublicacionModal'));
         if (modal) modal.hide();
 
-        // Refresh feed
-        setTimeout(() => window.location.reload(), 1000);
+        const container = document.getElementById('feedContainer');
+        if (container && data.html) {
+          container.insertAdjacentHTML('afterbegin', data.html);
+          this.initPostInteractions();
+          this.initCommentSystem();
+        }
       } else {
-        const errorText = await response.text();
-        this.showToast('Error al publicar: ' + errorText, 'error');
+        this.showToast('Error al publicar: ' + (data.error || 'Error desconocido'), 'error');
       }
     } catch (error) {
       console.error('Error submitting post:', error);

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -48,6 +48,20 @@ def test_create_post_rejects_large_file(client, db_session, test_user):
     assert Post.query.count() == 0
 
 
+def test_create_post_returns_html_snippet(client, db_session, test_user):
+    login(client, test_user.username, "secret")
+    resp = client.post(
+        "/feed/post",
+        data={"content": "hola"},
+        headers={"Accept": "application/json"},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "html" in data
+    assert "hola" in data["html"]
+    assert Post.query.count() == 1
+
+
 def test_feed_shows_post_for_other_user(client, db_session, test_user, another_user):
     post = Post(content="Feed post", author=test_user)
     db_session.add(post)


### PR DESCRIPTION
## Summary
- Return `_posts.html` HTML snippet when creating posts via JSON
- Insert new post at the top of the feed without reloading
- Test JSON response for dynamic post insertion

## Testing
- `make test` *(fails: check_errors.py: F401 ‘os’ imported but unused, ...)*
- `pytest tests/test_feed.py::test_create_post_returns_html_snippet -q`


------
https://chatgpt.com/codex/tasks/task_e_6895448d86488325a99c5f73dbd87148