### PR TITLE
feat: add docx preview with pagination

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1237,3 +1237,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Improved forum question and answer pages with responsive layout, theme-aware card and badge colors, and dark/light compatible vote buttons. (PR forum-responsive-theme)
 - Allowed uploading .webp note files and listed .webp in the upload form accept attribute. (PR notes-webp-upload)
 - Comentarios en publicaciones requieren usuarios activados; intentos bloqueados se registran para monitoreo. (PR comment-auth-log)
+- Integrado docx-preview para previsualizar DOCX con paginación y controles en viewer.js, viewer_docx.html y notes/detalle.html.

--- a/crunevo/templates/components/viewer_docx.html
+++ b/crunevo/templates/components/viewer_docx.html
@@ -1,1 +1,8 @@
-<div id="noteViewer" data-url="{{ note.filename }}" data-type="docx" class="mx-auto" style="max-width:850px;"></div>
+<div id="noteViewer" data-url="{{ note.filename }}" data-type="docx" class="mx-auto" style="max-width:850px;">
+  <div id="docxWrapper"></div>
+  <div id="docxControls" class="d-flex justify-content-between align-items-center mt-2">
+    <button class="btn btn-outline-secondary btn-sm" id="prevPage">&#x25C0;</button>
+    <span class="small" id="pageInfo"></span>
+    <button class="btn btn-outline-secondary btn-sm" id="nextPage">&#x25B6;</button>
+  </div>
+</div>

--- a/crunevo/templates/notes/detalle.html
+++ b/crunevo/templates/notes/detalle.html
@@ -1,5 +1,11 @@
 {% extends 'base.html' %}
 {% import 'components/csrf.html' as csrf %}
+{% block head_extra %}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docx-preview/dist/docx-preview.min.css">
+<style>
+  .docx-page { margin-bottom: 1rem; }
+</style>
+{% endblock %}
 {% block content %}
 <div class="container-xl my-4">
   <div class="row g-4">
@@ -202,7 +208,7 @@
 
 {% block body_end %}
 <script src="{{ url_for('static', filename='pdfjs/pdf.min.js') }}"></script>
-<script src="{{ url_for('static', filename='vendor/mammoth.browser.min.js') }}"></script>
+<script src="https://cdn.jsdelivr.net/npm/docx-preview/dist/docx-preview.min.js"></script>
 <script src="{{ url_for('static', filename='js/viewer.js') }}"></script>
 <script>pdfjsLib.GlobalWorkerOptions.workerSrc = "{{ url_for('static', filename='pdfjs/pdf.worker.min.js') }}";</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add docx-preview integration for paginated docx viewing
- load docx-preview assets and navigation controls
- document changes in AGENTS

## Testing
- `pre-commit run --files AGENTS.md crunevo/static/js/viewer.js crunevo/templates/components/viewer_docx.html crunevo/templates/notes/detalle.html`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68954502930c83258ce7193ce1b5218f