### PR TITLE
Optimize feed loading with joinedload

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1238,3 +1238,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Allowed uploading .webp note files and listed .webp in the upload form accept attribute. (PR notes-webp-upload)
 - Comentarios en publicaciones requieren usuarios activados; intentos bloqueados se registran para monitoreo. (PR comment-auth-log)
 - Reemplazada recarga del feed tras publicar por inserción dinámica usando `_posts.html` retornado en JSON y prueba asociada. (PR feed-dynamic-insert)
+- Optimized feed loading by preloading posts with `joinedload` in `/load` API and using loaded objects instead of `Post.query.get`. (PR feed-joinedload-opt)


### PR DESCRIPTION
## Summary
- preload related posts via `joinedload` in feed load API to avoid per-item queries
- document feed loading optimization in AGENTS log

## Testing
- `make test` *(fails: F401 `os` imported but unused)*
- `pytest -q` *(fails: tests/test_feed.py::test_create_post_rejects_invalid_extension - assert 400 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_6895465c0ea483259bee9eeaafac117b