### PR TITLE
Insert posts dynamically using server response data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1242,3 +1242,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Integrado docx-preview para previsualizar DOCX con paginación y controles en viewer.js, viewer_docx.html y notes/detalle.html.
 - Reemplazada recarga del feed tras publicar por inserción dinámica usando `_posts.html` retornado en JSON y prueba asociada. (PR feed-dynamic-insert)
 - Optimized feed loading by preloading posts with `joinedload` in `/load` API and using loaded objects instead of `Post.query.get`. (PR feed-joinedload-opt)
+- feed.js ahora inserta dinámicamente el nuevo post en `#feedContainer` construyendo el HTML con los datos JSON del servidor y evitando recargar la página. (PR feed-json-insert)

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -26,6 +26,7 @@ def test_create_post_rejects_invalid_extension(client, db_session, test_user):
         "/feed/post",
         data=data,
         content_type="multipart/form-data",
+        headers={"Accept": "text/html"},
         follow_redirects=True,
     )
     assert resp.status_code == 200
@@ -41,6 +42,7 @@ def test_create_post_rejects_large_file(client, db_session, test_user):
         "/feed/post",
         data=data,
         content_type="multipart/form-data",
+        headers={"Accept": "text/html"},
         follow_redirects=True,
     )
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- Build new feed entries on the client using `buildPostHTML` to render server JSON into DOM and inject into `#feedContainer` without reloading.
- Document new UX for post insertion in AGENTS.md.
- Specify HTML `Accept` headers in feed tests when checking invalid uploads.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689549779230832584f849f8049d4974