### PR TITLE
Add pagination and sorting to tienda

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1242,3 +1242,5 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Integrado docx-preview para previsualizar DOCX con paginación y controles en viewer.js, viewer_docx.html y notes/detalle.html.
 - Reemplazada recarga del feed tras publicar por inserción dinámica usando `_posts.html` retornado en JSON y prueba asociada. (PR feed-dynamic-insert)
 - Optimized feed loading by preloading posts with `joinedload` in `/load` API and using loaded objects instead of `Post.query.get`. (PR feed-joinedload-opt)
+
+- Added pagination and sorting controls to tienda products, preserving existing filters in page links. (PR tienda-pagination-sort)

--- a/crunevo/templates/tienda/_product_cards.html
+++ b/crunevo/templates/tienda/_product_cards.html
@@ -1,6 +1,6 @@
 {% import 'components/csrf.html' as csrf %}
 {% from 'components/price_credits.html' import render_price_credits %}
-{% for product in products %}
+{% for product in pagination.items %}
 <div class="col">
     <div class="card h-100 product-card shadow-hover">
         {% if product.is_featured %}
@@ -113,3 +113,26 @@
     </div>
 </div>
 {% endfor %}
+
+<div class="col-12">
+    {% set args = request.args.to_dict(flat=False) %}
+    <nav aria-label="Paginación de productos">
+        <ul class="pagination justify-content-center">
+            <li class="page-item {% if not pagination.has_prev %}disabled{% endif %}">
+                <a class="page-link" href="{{ url_for('commerce.commerce_index', **args, page=pagination.prev_num) if pagination.has_prev else '#' }}" aria-label="Anterior">&laquo;</a>
+            </li>
+            {% for p in pagination.iter_pages(left_edge=1, right_edge=1, left_current=1, right_current=2) %}
+                {% if p %}
+                    <li class="page-item {% if p == pagination.page %}active{% endif %}">
+                        <a class="page-link" href="{{ url_for('commerce.commerce_index', **args, page=p) }}">{{ p }}</a>
+                    </li>
+                {% else %}
+                    <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
+                {% endif %}
+            {% endfor %}
+            <li class="page-item {% if not pagination.has_next %}disabled{% endif %}">
+                <a class="page-link" href="{{ url_for('commerce.commerce_index', **args, page=pagination.next_num) if pagination.has_next else '#' }}" aria-label="Siguiente">&raquo;</a>
+            </li>
+        </ul>
+    </nav>
+</div>

--- a/crunevo/templates/tienda/tienda.html
+++ b/crunevo/templates/tienda/tienda.html
@@ -25,6 +25,7 @@
                 <div class="card-body">
                     <h5 class="card-title mb-3">Filtros</h5>
                     <form id="filter-form" method="get" action="{{ url_for('commerce.commerce_index') }}">
+                        <input type="hidden" name="sort" value="{{ sort }}">
                         <!-- Búsqueda -->
                         <div class="mb-3">
                             <label for="search" class="form-label">Buscar</label>
@@ -215,12 +216,27 @@
             <!-- Lista de productos -->
             <div class="card shadow-sm">
                 <div class="card-body">
-                    <div class="d-flex justify-content-between align-items-center mb-3">
-                        <h5 class="card-title mb-0">Productos</h5>
-                        <span class="text-muted">{{ products|length }} productos encontrados</span>
+                    <div class="d-flex justify-content-between align-items-center mb-3 flex-wrap">
+                        <div>
+                            <h5 class="card-title mb-0">Productos</h5>
+                            <span class="text-muted">{{ pagination.total }} productos encontrados</span>
+                        </div>
+                        <form method="get" class="d-flex align-items-center">
+                            {% for key, values in request.args.lists() if key not in ['sort','page'] %}
+                                {% for val in values %}
+                                <input type="hidden" name="{{ key }}" value="{{ val }}">
+                                {% endfor %}
+                            {% endfor %}
+                            <label for="sort" class="me-2 mb-0">Ordenar por:</label>
+                            <select name="sort" id="sort" class="form-select" onchange="this.form.submit()">
+                                <option value="date" {% if sort == 'date' %}selected{% endif %}>Fecha</option>
+                                <option value="price" {% if sort == 'price' %}selected{% endif %}>Precio</option>
+                                <option value="popular" {% if sort == 'popular' %}selected{% endif %}>Popularidad</option>
+                            </select>
+                        </form>
                     </div>
-                    
-                    {% if products %}
+
+                    {% if pagination.items %}
                     <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4" id="products-container">
                         {% include "tienda/_product_cards.html" %}
                     </div>


### PR DESCRIPTION
## Summary
- paginate products in `commerce_index` route with page & sort params
- add sort selector and pagination controls in tienda templates
- document tienda pagination and sorting in AGENTS instructions

## Testing
- `make fmt`
- `make test` *(failed: tests/test_feed.py::test_create_post_rejects_invalid_extension - assert 400 == 200; tests/test_feed.py::test_create_post_rejects_large_file - assert 400 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68954a8920848325a14a5a51034d40f5