### PR TITLE
feat: expire feed cache items

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1244,3 +1244,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Optimized feed loading by preloading posts with `joinedload` in `/load` API and using loaded objects instead of `Post.query.get`. (PR feed-joinedload-opt)
 - Reemplazado `innerHTML` por creación de nodos y uso de `textContent` en `notes/list.html` para stats y título dinámicos. (PR notes-textcontent)
 - feed.js ahora inserta dinámicamente el nuevo post en `#feedContainer` construyendo el HTML con los datos JSON del servidor y evitando recargar la página. (PR feed-json-insert)
+- Feed cache ahora incluye timestamp 'cached_at' y `cleanup` elimina entradas tras 10 minutos; considerar backend Redis con TTL por usuario. (PR feed-cache-expiry)

--- a/crunevo/cache/feed_cache.py
+++ b/crunevo/cache/feed_cache.py
@@ -1,24 +1,32 @@
 from collections import defaultdict
+from datetime import datetime, timedelta
+from typing import Optional
 
 log = __import__("logging").getLogger(__name__)
 # simple in-memory cache keyed by user_id
 _cache: dict[int, list[dict]] = defaultdict(list)
 
 MAX_CACHE = 500  # keep most recent items
+CACHE_TTL = 600  # expire items after 10 minutes
+
+# TODO: consider using Redis with per-user TTL for distributed environments.
 
 
 def push_items(user_id: int, items: list[dict]) -> None:
     """Store feed items for a user in memory sorted by score and timestamp."""
+    now = datetime.utcnow()
     entries = _cache[user_id]
-    entries.extend(items)
+    entries.extend({**it, "cached_at": now} for it in items)
     entries.sort(
         key=lambda it: it["score"] + it["created_at"].timestamp() / 1e6,
         reverse=True,
     )
+    cleanup_user(user_id, now)
     del entries[MAX_CACHE:]
 
 
 def fetch(user_id: int, start: int = 0, stop: int = 19) -> list[dict]:
+    cleanup_user(user_id)
     entries = _cache.get(user_id, [])
     sliced = entries[start : stop + 1]
     if log.isEnabledFor(__import__("logging").DEBUG):
@@ -30,6 +38,22 @@ def fetch(user_id: int, start: int = 0, stop: int = 19) -> list[dict]:
             stop,
         )
     return [it["payload"] for it in sliced]
+
+
+def cleanup_user(user_id: int, now: Optional[datetime] = None) -> None:
+    now = now or datetime.utcnow()
+    cutoff = now - timedelta(seconds=CACHE_TTL)
+    entries = _cache.get(user_id, [])
+    _cache[user_id] = [it for it in entries if it["cached_at"] >= cutoff]
+    if not _cache[user_id]:
+        _cache.pop(user_id, None)
+
+
+def cleanup(now: Optional[datetime] = None) -> None:
+    """Clean up expired items for all users."""
+    now = now or datetime.utcnow()
+    for uid in list(_cache.keys()):
+        cleanup_user(uid, now)
 
 
 def remove_item(user_id: int, item_type: str, ref_id: int) -> None:

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -117,6 +117,23 @@ def test_push_items_persists(reset_caches):
     assert fetch(1)[0] == {"a": 1}
 
 
+def test_feed_cache_cleanup_removes_old_entries(reset_caches):
+
+    from datetime import datetime, timedelta
+
+    feed_cache.push_items(
+        1, [{"score": 0, "created_at": datetime.utcnow(), "payload": {"a": 1}}]
+    )
+
+    feed_cache._cache[1][0]["cached_at"] = datetime.utcnow() - timedelta(
+        seconds=feed_cache.CACHE_TTL + 1
+    )
+
+    feed_cache.cleanup()
+
+    assert feed_cache.fetch(1) == []
+
+
 def test_feed_fetch_handles_error(monkeypatch, client, db_session, test_user):
     monkeypatch.setattr(
         feed_cache, "fetch", lambda *a, **k: (_ for _ in ()).throw(Exception("boom"))


### PR DESCRIPTION
## Summary
- timestamp feed cache entries and purge expired ones
- test feed cache cleanup behavior
- note feed cache expiration and future Redis backend in AGENTS

## Testing
- `make fmt`
- `make test` *(fails: F401 imported but unused, F541 f-string without placeholders)*

------
https://chatgpt.com/codex/tasks/task_e_68954c9c629c8325821fadfc80af8acb