### PR TITLE
Fix tienda pagination syntax error

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1247,3 +1247,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Reemplazado `innerHTML` por creación de nodos y uso de `textContent` en `notes/list.html` para stats y título dinámicos. (PR notes-textcontent)
 - feed.js ahora inserta dinámicamente el nuevo post en `#feedContainer` construyendo el HTML con los datos JSON del servidor y evitando recargar la página. (PR feed-json-insert)
 - Feed cache ahora incluye timestamp 'cached_at' y `cleanup` elimina entradas tras 10 minutos; considerar backend Redis con TTL por usuario. (PR feed-cache-expiry)
+- Resolved Jinja syntax error in tienda pagination by popping existing `page` from args and moving `**args` after explicit page parameter in `_product_cards.html`.

--- a/crunevo/templates/tienda/_product_cards.html
+++ b/crunevo/templates/tienda/_product_cards.html
@@ -116,22 +116,23 @@
 
 <div class="col-12">
     {% set args = request.args.to_dict(flat=False) %}
+    {% set _ = args.pop('page', None) %}
     <nav aria-label="Paginación de productos">
         <ul class="pagination justify-content-center">
             <li class="page-item {% if not pagination.has_prev %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('commerce.commerce_index', **args, page=pagination.prev_num) if pagination.has_prev else '#' }}" aria-label="Anterior">&laquo;</a>
+                <a class="page-link" href="{{ url_for('commerce.commerce_index', page=pagination.prev_num, **args) if pagination.has_prev else '#' }}" aria-label="Anterior">&laquo;</a>
             </li>
             {% for p in pagination.iter_pages(left_edge=1, right_edge=1, left_current=1, right_current=2) %}
                 {% if p %}
                     <li class="page-item {% if p == pagination.page %}active{% endif %}">
-                        <a class="page-link" href="{{ url_for('commerce.commerce_index', **args, page=p) }}">{{ p }}</a>
+                        <a class="page-link" href="{{ url_for('commerce.commerce_index', page=p, **args) }}">{{ p }}</a>
                     </li>
                 {% else %}
                     <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
                 {% endif %}
             {% endfor %}
             <li class="page-item {% if not pagination.has_next %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('commerce.commerce_index', **args, page=pagination.next_num) if pagination.has_next else '#' }}" aria-label="Siguiente">&raquo;</a>
+                <a class="page-link" href="{{ url_for('commerce.commerce_index', page=pagination.next_num, **args) if pagination.has_next else '#' }}" aria-label="Siguiente">&raquo;</a>
             </li>
         </ul>
     </nav>


### PR DESCRIPTION
## Summary
- fix Jinja pagination links to avoid invalid syntax errors
- document fix in AGENTS

## Testing
- `make test` *(fails: F401 and F541 errors in unrelated scripts)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689561ed759c83259c627a3457d9c7da