### PR TITLE
Add note thumbnail migration and stabilize error logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1251,3 +1251,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Generated thumbnails for notes by converting first page to image and storing `thumbnail_url`; note cards now display the miniaturas when available. (PR note-thumbnail)
 - Resolved Jinja syntax error in tienda pagination by popping existing `page` from args and moving `**args` after explicit page parameter in `_product_cards.html`.
 - Ajustados colores de la tarjeta de estadísticas en perfil removiendo `text-white`, añadiendo `text-dark`/`text-primary` según el bloque y eliminando el enlace duplicado "Comprar Crolars". (PR perfil-stats-colors)
+- Added migration to add `thumbnail_url` to `note` with fallback and normalized error logging to store numeric status codes. (PR note-thumbnail-log-fix)

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -567,10 +567,15 @@ def create_app():
     def log_exception(e):
         try:
             db.session.rollback()
+            code = getattr(e, "code", 500)
+            try:
+                code = int(code)
+            except (TypeError, ValueError):
+                code = 500
             err = SystemErrorLog(
                 ruta=request.path,
                 mensaje=str(e),
-                status_code=getattr(e, "code", 500),
+                status_code=code,
                 user_id=current_user.id if current_user.is_authenticated else None,
             )
             db.session.add(err)

--- a/migrations/versions/e1e5b8d0853a_add_note_thumbnail_url.py
+++ b/migrations/versions/e1e5b8d0853a_add_note_thumbnail_url.py
@@ -1,0 +1,35 @@
+"""add thumbnail_url column to note
+
+Revision ID: e1e5b8d0853a
+Revises: 5683aa47fe36
+Create Date: 2025-08-08 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def has_col(table: str, column: str, conn) -> bool:
+    inspector = sa.inspect(conn)
+    return any(c["name"] == column for c in inspector.get_columns(table))
+
+
+# revision identifiers, used by Alembic.
+revision = "e1e5b8d0853a"
+down_revision = "5683aa47fe36"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    with op.batch_alter_table("note", schema=None) as batch_op:
+        if not has_col("note", "thumbnail_url", conn):
+            batch_op.add_column(
+                sa.Column("thumbnail_url", sa.String(length=200), nullable=True, server_default="")
+            )
+
+
+def downgrade():
+    with op.batch_alter_table("note", schema=None) as batch_op:
+        batch_op.drop_column("thumbnail_url", if_exists=True)


### PR DESCRIPTION
## Summary
- add Alembic migration to ensure `note.thumbnail_url` column exists with default
- guard exception logger against non-numeric status codes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68956a41d4348325816aa5a1d8fd7bd1