### PR TITLE
Fix forum head block duplication and modernize mobile navbar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1252,3 +1252,5 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Resolved Jinja syntax error in tienda pagination by popping existing `page` from args and moving `**args` after explicit page parameter in `_product_cards.html`.
 - Ajustados colores de la tarjeta de estadísticas en perfil removiendo `text-white`, añadiendo `text-dark`/`text-primary` según el bloque y eliminando el enlace duplicado "Comprar Crolars". (PR perfil-stats-colors)
 - Added migration to add `thumbnail_url` to `note` with fallback and normalized error logging to store numeric status codes. (PR note-thumbnail-log-fix)
+- Fixed duplicate `head_extra` block in `forum/question.html`, resolving 500 on `/foro/pregunta/<id>` and loading Quill styles once. (PR forum-question-head-fix)
+- Modernized mobile navbar: ensured compact logo sizing and unified quick link styles in `navbar.css` for a social app feel. (PR mobile-navbar-modern)

--- a/crunevo/static/css/forum_question.mobile.css
+++ b/crunevo/static/css/forum_question.mobile.css
@@ -12,16 +12,9 @@
   }
 }
 
-/* Logo pequeño - NO gigante */
-.crunevo-logo-small { 
-  width: 72px; 
-  height: auto; 
-  display: block; 
-}
-
-.forum-question-page .crunevo-hero { 
-  padding: 8px 12px; 
-  border-radius: 12px; 
+.forum-question-page .crunevo-hero {
+  padding: 8px 12px;
+  border-radius: 12px;
 }
 
 /* Texto que no se corte (sólo en foro) */
@@ -72,33 +65,6 @@
   align-items: center;
   gap: .4rem;
   max-width: 100%;
-}
-
-/* Logo ya definido arriba - regla eliminada para evitar duplicación */
-
-/* Navbar móvil (los 6 iconos) - distribución uniforme y targets táctiles */
-.mobile-quick-links {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  width: 100%;
-  padding: 8px 12px;
-}
-
-.mobile-quick-links .icon-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 40px;
-  min-height: 40px;
-  border-radius: 12px;
-}
-
-/* Accesibilidad y animaciones */
-.mobile-quick-links .icon-btn:focus-visible {
-  outline: 2px solid var(--bs-primary);
-  outline-offset: 2px;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/crunevo/static/css/navbar.css
+++ b/crunevo/static/css/navbar.css
@@ -330,6 +330,45 @@
   transform: scale(1.1);
 }
 
+/* Ensure consistent small logo sizing */
+.crunevo-logo-small {
+  height: 28px;
+  width: auto;
+  display: block;
+}
+
+/* Mobile quick links styling */
+.mobile-quick-links {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  padding: 8px 12px;
+}
+
+.mobile-quick-links .icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.15);
+  backdrop-filter: blur(8px);
+  transition: background 0.3s ease, transform 0.2s ease;
+}
+
+.mobile-quick-links .icon-btn:active {
+  background: rgba(255, 255, 255, 0.25);
+  transform: scale(0.95);
+}
+
+.mobile-quick-links .icon-btn:focus-visible {
+  outline: 2px solid var(--bs-primary);
+  outline-offset: 2px;
+}
+
 /* Performance optimizations */
 .navbar-crunevo * {
   will-change: auto;

--- a/crunevo/templates/forum/question.html
+++ b/crunevo/templates/forum/question.html
@@ -5,6 +5,8 @@
 
 {% block head_extra %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/forum_question.mobile.css') }}">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/quill@1.3.7/dist/quill.snow.css">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/forum_editor.css') }}">
 {% endblock %}
 
 {% block content %}
@@ -765,11 +767,7 @@ document.addEventListener('DOMContentLoaded', function() {
     padding: 0.25rem !important;
   }
 }
-</style>
-{% block head_extra %}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/quill@1.3.7/dist/quill.snow.css">
-<link rel="stylesheet" href="{{ url_for('static', filename='css/forum_editor.css') }}">
-{% endblock %}
+}</style>
 
 {% block extra_js %}
 <script src="https://cdn.jsdelivr.net/npm/quill@1.3.7/dist/quill.min.js"></script>


### PR DESCRIPTION
## Summary
- Merge Quill styles into a single `head_extra` block on forum question page to stop template errors
- Consolidate mobile navbar styles with a compact logo and modern quick-link buttons

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895951b52c48325bc903eb58c3bacd7