### PR TITLE
Fix mobile navbar profile link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1254,3 +1254,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Added migration to add `thumbnail_url` to `note` with fallback and normalized error logging to store numeric status codes. (PR note-thumbnail-log-fix)
 - Fixed duplicate `head_extra` block in `forum/question.html`, resolving 500 on `/foro/pregunta/<id>` and loading Quill styles once. (PR forum-question-head-fix)
 - Modernized mobile navbar: ensured compact logo sizing and unified quick link styles in `navbar.css` for a social app feel. (PR mobile-navbar-modern)
+- Fixed mobile navbar profile tab to use `auth.view_profile` with login fallback and updated active state detection, resolving BuildError when rendering profile links. (PR mobile-navbar-profile-link)

--- a/crunevo/templates/components/mobile_navbar.html
+++ b/crunevo/templates/components/mobile_navbar.html
@@ -70,12 +70,12 @@
       </a>
       
       <!-- Perfil -->
-      <a href="{{ url_for('profile.profile', username=current_user.username) if current_user.is_authenticated else '/login' }}" class="mobile-tab-item {{ 'active' if 'profile' in request.endpoint else '' }}" aria-label="Perfil">
+      <a href="{{ url_for('auth.view_profile', username=current_user.username) if current_user.is_authenticated else url_for('auth.login') }}" class="mobile-tab-item {{ 'active' if request.endpoint in ('auth.perfil', 'auth.view_profile') else '' }}" aria-label="Perfil">
         <div class="tab-icon">
           {% if current_user.is_authenticated and current_user.avatar %}
             <img src="{{ current_user.avatar }}" alt="Avatar" class="profile-avatar">
           {% else %}
-            <i class="bi bi-person{{ '-fill' if 'profile' in request.endpoint else '' }}"></i>
+            <i class="bi bi-person{{ '-fill' if request.endpoint in ('auth.perfil', 'auth.view_profile') else '' }}"></i>
           {% endif %}
         </div>
         <span class="tab-label">Perfil</span>


### PR DESCRIPTION
## Summary
- fix mobile navbar profile tab to reference auth view_profile with login fallback
- note recent change in AGENTS.md

## Testing
- `make fmt`
- `make test` *(fails: F401 imported but unused)*

------
https://chatgpt.com/codex/tasks/task_e_68959c4a9ba88325b630e37251f9def0