### PR TITLE
Adjust mobile navbar spacing and icon order

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1257,3 +1257,5 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Fixed mobile navbar profile tab to use `auth.view_profile` with login fallback and updated active state detection, resolving BuildError when rendering profile links. (PR mobile-navbar-profile-link)
 
 - Reworked mobile navbar with grid layout, dynamic body padding and scroll hide to prevent overlap (PR mobile-navbar-grid-autohide)
+
+- Mobile navbar now reserves body space with safe-area support, adds scroll-margin-top for anchors, swaps Tienda/Notificaciones and Chat/Apuntes buttons, and renames "Mis Notas" to "Apuntes". (PR mobile-navbar-shop-notes)

--- a/crunevo/templates/components/mobile_navbar.html
+++ b/crunevo/templates/components/mobile_navbar.html
@@ -5,12 +5,15 @@
   <a href="{{ url_for('forum.list_questions') if 'forum.list_questions' in url_for.__globals__.get('current_app', {}).view_functions else '/foro' }}" class="nav-icon-btn {{ 'active' if 'forum' in request.endpoint else '' }}" aria-label="Explorar">
     <i class="bi bi-compass{{ '-fill' if 'forum' in request.endpoint else '' }}"></i>
   </a>
-  <a href="{{ url_for('noti.ver_notificaciones') }}" class="nav-icon-btn position-relative" aria-label="Notificaciones">
-    <i class="bi bi-bell"></i>
-    <span id="mobileNotificationBadge" class="notification-badge position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" style="display:none"></span>
+  {# Botón TIENDA en lugar de notificaciones #}
+  <a href="{{ url_for('commerce.commerce_index') if 'commerce.commerce_index' in url_for.__globals__.get('current_app', {}).view_functions else '/tienda' }}"
+     class="nav-icon-btn" aria-label="Tienda">
+    <i class="bi bi-shop"></i>
   </a>
-  <a href="{{ url_for('chat.chat_index') }}" class="nav-icon-btn" aria-label="Mensajes">
-    <i class="bi bi-chat-dots"></i>
+  {# Botón APUNTES en lugar de chat #}
+  <a href="{{ url_for('notes.my_notes') if 'notes.my_notes' in url_for.__globals__.get('current_app', {}).view_functions else '/apuntes' }}"
+     class="nav-icon-btn" aria-label="Apuntes">
+    <i class="bi bi-journal-text"></i>
   </a>
   <div class="dropdown">
     <a href="#" class="nav-icon-btn dropdown-toggle" data-bs-toggle="dropdown" aria-label="Menú">
@@ -23,8 +26,10 @@
     <ul class="dropdown-menu dropdown-menu-end shadow-lg border-0 rounded-3 mt-2">
       {% if current_user.is_authenticated %}
         <li><a class="dropdown-item" href="{{ url_for('auth.perfil') }}"><i class="bi bi-person me-2"></i>Mi Perfil</a></li>
-        <li><a class="dropdown-item" href="{{ url_for('notes.my_notes') if 'notes.my_notes' in url_for.__globals__.get('current_app', {}).view_functions else '/notas' }}"><i class="bi bi-journal-text me-2"></i>Mis Notas</a></li>
-        <li><a class="dropdown-item" href="{{ url_for('commerce.commerce_index') if 'commerce.commerce_index' in url_for.__globals__.get('current_app', {}).view_functions else '/tienda' }}"><i class="bi bi-shop me-2"></i>Tienda</a></li>
+        {# En el dropdown ahora va CHAT en lugar de notas #}
+        <li><a class="dropdown-item" href="{{ url_for('chat.chat_index') }}"><i class="bi bi-chat-dots me-2"></i>Chat</a></li>
+        {# En el dropdown ahora van NOTIFICACIONES en lugar de tienda #}
+        <li><a class="dropdown-item" href="{{ url_for('noti.ver_notificaciones') }}"><i class="bi bi-bell me-2"></i>Notificaciones</a></li>
         <li><hr class="dropdown-divider"></li>
         <li><a class="dropdown-item" href="{{ url_for('auth.logout') }}"><i class="bi bi-box-arrow-right me-2"></i>Cerrar Sesión</a></li>
       {% else %}
@@ -52,14 +57,13 @@
 [data-bs-theme="dark"] #mobileNavbar {
   background: rgba(36, 37, 38, 0.95);
 }
-body.with-mobile-navbar {
-  padding-top: var(--mobile-navbar-height, 56px);
-}
-@media (min-width: 992px) {
-  body.with-mobile-navbar {
-    padding-top: 0;
-  }
-}
+/* Dejar SIEMPRE espacio para que no tape el contenido */
+body.with-mobile-navbar { padding-top: var(--mobile-navbar-height, 56px); }
+[id] { scroll-margin-top: calc(var(--mobile-navbar-height, 56px) + 8px); }
+
+/* Safe area para iPhone con notch */
+#mobileNavbar { padding-top: env(safe-area-inset-top); height: calc(56px + env(safe-area-inset-top)); }
+body.with-mobile-navbar { padding-top: calc(var(--mobile-navbar-height, 56px) + env(safe-area-inset-top)); }
 #mobileNavbar a.nav-icon-btn,
 #mobileNavbar .dropdown > a {
   display: flex;
@@ -77,11 +81,15 @@ body.with-mobile-navbar {
 <script>
 document.addEventListener("DOMContentLoaded", () => {
   const navbar = document.getElementById("mobileNavbar");
-  if (navbar) {
-    const h = navbar.offsetHeight;
+  if (!navbar) return;
+  // Medir altura real (incluye safe-area gracias al padding-top)
+  requestAnimationFrame(() => {
+    const h = navbar.getBoundingClientRect().height || 56;
     document.body.classList.add("with-mobile-navbar");
     document.body.style.setProperty("--mobile-navbar-height", h + "px");
-  }
+    // fallback directo por si alguna hoja CSS ignora la var
+    document.body.style.paddingTop = `calc(${h}px + env(safe-area-inset-top))`;
+  });
 });
 
 let lastScroll = 0;


### PR DESCRIPTION
## Summary
- add safe-area aware padding and scroll-margin to mobile navbar
- swap Tienda/Notificaciones and Chat/Apuntes buttons in navbar and dropdown
- log navbar changes in AGENTS

## Testing
- `pre-commit run --files AGENTS.md crunevo/templates/components/mobile_navbar.html`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68964d7517688325b28d83c0af45d469