### PR TITLE
fix: standardize wsgi entrypoint and Docker FLASK_APP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1261,3 +1261,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Mobile navbar now reserves body space with safe-area support, adds scroll-margin-top for anchors, swaps Tienda/Notificaciones and Chat/Apuntes buttons, and renames "Mis Notas" to "Apuntes". (PR mobile-navbar-shop-notes)
 - Expanded mobile navbar to include menu offcanvas, separate chat and notification icons with badge, search modal trigger and updated offcanvas markup. (PR mobile-navbar-menu-search)
 - Config now defaults `SERVER_NAME` to `None` in production to avoid host-matching 404s on `www` vs apex domains. (PR remove-server-name)
+- Renamed `wsgi_admin` export to `application`, made `Dockerfile` honor `FLASK_APP`, and adjusted `fly-admin.toml` to point to `crunevo.wsgi_admin:application` for correct admin deployment. (PR wsgi-application-refactor)

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,5 @@ COPY migrations /app/migrations
 COPY migrations/versions /app/migrations/versions
 
 # Ejecutar aplicación
-# Run gunicorn with eventlet worker for websocket support
-CMD ["gunicorn", "--workers", "3", "--timeout", "120", "-k", "eventlet", "-b", "0.0.0.0:8080", "crunevo.wsgi:application"]
+# Use FLASK_APP to allow running admin or main instance
+CMD ["sh", "-c", "gunicorn --workers 3 --timeout 120 -k eventlet -b 0.0.0.0:8080 ${FLASK_APP}"]

--- a/crunevo/cli.py
+++ b/crunevo/cli.py
@@ -4,5 +4,5 @@ from crunevo.app import create_app
 # This is separate from the WSGI application which uses DispatcherMiddleware
 app = create_app()
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     app.run()

--- a/crunevo/wsgi_admin.py
+++ b/crunevo/wsgi_admin.py
@@ -4,4 +4,5 @@ os.environ["ADMIN_INSTANCE"] = "1"
 
 from crunevo.app import create_app  # noqa: E402
 
-app = create_app()
+# Expose the Flask application as `application` to mirror the main WSGI module
+application = create_app()

--- a/fly-admin.toml
+++ b/fly-admin.toml
@@ -9,7 +9,7 @@ primary_region = "gru"
   release_command = "FLASK_APP=crunevo.cli:app flask db upgrade"
 
 [env]
-  FLASK_APP = "crunevo.wsgi_admin:app"
+  FLASK_APP = "crunevo.wsgi_admin:application"
   FLASK_ENV = "production"
   ADMIN_INSTANCE = "1"
   MAINTENANCE_MODE = "0"

--- a/test_server.py
+++ b/test_server.py
@@ -6,13 +6,13 @@ Script para probar la aplicación localmente con el DispatcherMiddleware
 from werkzeug.serving import run_simple
 from crunevo.wsgi import application
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     print("Iniciando servidor de prueba en http://0.0.0.0:8080")
     print("Presiona Ctrl+C para detener")
     run_simple(
-        hostname='0.0.0.0',
+        hostname="0.0.0.0",
         port=8080,
         application=application,
         use_debugger=True,
-        use_reloader=True
+        use_reloader=True,
     )


### PR DESCRIPTION
## Summary
- expose admin WSGI as `application`
- run gunicorn using `${FLASK_APP}` for admin/main flexibility
- point fly admin config to `wsgi_admin:application`

## Testing
- `pre-commit run --files crunevo/wsgi_admin.py fly-admin.toml Dockerfile test_server.py crunevo/cli.py AGENTS.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896a48761ac8325817393ed7e20e8f9