### PR TITLE
chore: simplify fly release command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1263,3 +1263,5 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Config now defaults `SERVER_NAME` to `None` in production to avoid host-matching 404s on `www` vs apex domains. (PR remove-server-name)
 - Renamed `wsgi_admin` export to `application`, made `Dockerfile` honor `FLASK_APP`, and adjusted `fly-admin.toml` to point to `crunevo.wsgi_admin:application` for correct admin deployment. (PR wsgi-application-refactor)
 - Config now generates a temporary random SECRET_KEY when missing to avoid deployment failures during migrations (PR secret-key-fallback).
+
+- Removed obsolete `crunevo/cli.py` and updated `fly.toml` release_command to use `crunevo.app:create_app` for database migrations (PR fly-release-create-app).

--- a/crunevo/cli.py
+++ b/crunevo/cli.py
@@ -1,8 +1,0 @@
-from crunevo.app import create_app
-
-# Create a Flask app instance specifically for CLI commands
-# This is separate from the WSGI application which uses DispatcherMiddleware
-app = create_app()
-
-if __name__ == "__main__":
-    app.run()

--- a/fly.toml
+++ b/fly.toml
@@ -6,7 +6,7 @@ primary_region = 'gru'
   dockerfile = 'Dockerfile'
 
 [deploy]
-  release_command = "FLASK_APP=crunevo.cli:app flask db upgrade"
+  release_command = "FLASK_APP=crunevo.app:create_app flask db upgrade"
 
 [env]
   FLASK_APP = 'crunevo.wsgi:application'


### PR DESCRIPTION
## Summary
- remove obsolete CLI script
- run fly release migrations using `crunevo.app:create_app`
- record deployment change in AGENTS log

## Testing
- `make fmt`
- `make test` *(fails: unused imports and formatting issues in unrelated scripts)*

------
https://chatgpt.com/codex/tasks/task_e_6896ab8e850c8325aa77faa998aa9fbf