### PR TITLE
Fix Fly release command for migrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1265,3 +1265,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Config now generates a temporary random SECRET_KEY when missing to avoid deployment failures during migrations (PR secret-key-fallback).
 
 - Removed obsolete `crunevo/cli.py` and updated `fly.toml` release_command to use `crunevo.app:create_app` for database migrations (PR fly-release-create-app).
+- Replaced Fly.io release commands with `flask --app crunevo.app:create_app db upgrade` to avoid spawning errors during migrations (PR fix-fly-release-command-args).

--- a/fly-admin.toml
+++ b/fly-admin.toml
@@ -6,7 +6,7 @@ primary_region = "gru"
   dockerfile = "Dockerfile"
 
 [deploy]
-  release_command = "flask db upgrade"
+  release_command = "flask --app crunevo.app:create_app db upgrade"
 
 [env]
   FLASK_APP = "crunevo.wsgi_admin:application"

--- a/fly.toml
+++ b/fly.toml
@@ -6,7 +6,7 @@ primary_region = 'gru'
   dockerfile = 'Dockerfile'
 
 [deploy]
-  release_command = "FLASK_APP=crunevo.app:create_app flask db upgrade"
+  release_command = "flask --app crunevo.app:create_app db upgrade"
 
 [env]
   FLASK_APP = 'crunevo.wsgi:application'


### PR DESCRIPTION
## Summary
- use `flask --app crunevo.app:create_app db upgrade` in Fly release commands to avoid spawning errors
- document release command update in AGENTS.md

## Testing
- `pre-commit run --files AGENTS.md fly-admin.toml fly.toml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896ad86aa0483259180d92c91165f56