### PR TITLE
Rename WSGI application exports to app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1266,3 +1266,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 
 - Removed obsolete `crunevo/cli.py` and updated `fly.toml` release_command to use `crunevo.app:create_app` for database migrations (PR fly-release-create-app).
 - Replaced Fly.io release commands with `flask --app crunevo.app:create_app db upgrade` to avoid spawning errors during migrations (PR fix-fly-release-command-args).
+- Renamed WSGI exports from `application` to `app` and updated Fly config files and helper script accordingly for deployment (PR wsgi-app-rename).

--- a/crunevo/wsgi.py
+++ b/crunevo/wsgi.py
@@ -4,7 +4,7 @@ from crunevo.app import create_app
 from crunevo.extensions import talisman
 
 # Creamos la aplicación principal
-app = create_app()
+flask_app = create_app()
 
 # Creamos una mini-app súper ligera SOLO para el health check
 health_app = Flask(__name__)
@@ -20,8 +20,8 @@ def health():
 # Usamos un Dispatcher para enrutar el tráfico.
 # Si la petición es para /healthz, va a la app ligera.
 # Para todo lo demás, va a la app principal.
-application = DispatcherMiddleware(
-    app,  # App principal como default
+app = DispatcherMiddleware(
+    flask_app,  # App principal como default
     {
         "/healthz": health_app,  # Health check en ruta específica
     },

--- a/crunevo/wsgi_admin.py
+++ b/crunevo/wsgi_admin.py
@@ -4,5 +4,5 @@ os.environ["ADMIN_INSTANCE"] = "1"
 
 from crunevo.app import create_app  # noqa: E402
 
-# Expose the Flask application as `application` to mirror the main WSGI module
-application = create_app()
+# Expose the Flask app as `app` to mirror the main WSGI module
+app = create_app()

--- a/fly-admin.toml
+++ b/fly-admin.toml
@@ -9,7 +9,7 @@ primary_region = "gru"
   release_command = "flask --app crunevo.app:create_app db upgrade"
 
 [env]
-  FLASK_APP = "crunevo.wsgi_admin:application"
+  FLASK_APP = "crunevo.wsgi_admin:app"
   FLASK_ENV = "production"
   ADMIN_INSTANCE = "1"
   MAINTENANCE_MODE = "0"

--- a/fly.toml
+++ b/fly.toml
@@ -9,7 +9,7 @@ primary_region = 'gru'
   release_command = "flask --app crunevo.app:create_app db upgrade"
 
 [env]
-  FLASK_APP = 'crunevo.wsgi:application'
+  FLASK_APP = 'crunevo.wsgi:app'
   FLASK_ENV = 'production'
   PORT = "8080"
   SESSION_COOKIE_HTTPONLY = "true"

--- a/test_server.py
+++ b/test_server.py
@@ -4,7 +4,7 @@ Script para probar la aplicación localmente con el DispatcherMiddleware
 """
 
 from werkzeug.serving import run_simple
-from crunevo.wsgi import application
+from crunevo.wsgi import app
 
 if __name__ == "__main__":
     print("Iniciando servidor de prueba en http://0.0.0.0:8080")
@@ -12,7 +12,7 @@ if __name__ == "__main__":
     run_simple(
         hostname="0.0.0.0",
         port=8080,
-        application=application,
+        application=app,
         use_debugger=True,
         use_reloader=True,
     )


### PR DESCRIPTION
## Summary
- rename WSGI exports from `application` to `app`
- update Fly configs and helper script to reference new WSGI export
- document change in AGENTS

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896b087bd90832590e33990cec90e3d