### PR TITLE
Add health check endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1268,3 +1268,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Replaced Fly.io release commands with `flask --app crunevo.app:create_app db upgrade` to avoid spawning errors during migrations (PR fix-fly-release-command-args).
 - Renamed WSGI exports from `application` to `app` and updated Fly config files and helper script accordingly for deployment (PR wsgi-app-rename).
 - Dockerfile now runs Gunicorn with eventlet bound to 0.0.0.0:8080, sets `PORT` and exposes 8080 to align with Fly.io checks (PR fly-gunicorn-port-fix).
+- Added `/healthz` blueprint returning 200 without auth and exempt from Talisman and CSRF (PR health-endpoint).

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -403,6 +403,11 @@ def create_app():
     app.config["ADMIN_INSTANCE"] = is_admin
 
     app.register_blueprint(health_bp)
+    csrf.exempt("health.healthz")
+    try:
+        talisman.exempt_view("health.healthz")
+    except Exception:
+        pass
     app.register_blueprint(maintenance_bp)
     app.register_blueprint(main_bp)
     app.register_blueprint(developer_bp)

--- a/crunevo/routes/health_routes.py
+++ b/crunevo/routes/health_routes.py
@@ -4,7 +4,7 @@ from crunevo.extensions import talisman
 health_bp = Blueprint("health", __name__)
 
 
-@health_bp.route("/healthz")
+@health_bp.get("/healthz")
 @talisman(force_https=False)
 def healthz():
     return "ok", 200

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -3,10 +3,9 @@ from crunevo.app import create_app
 
 
 def test_health_endpoint():
-    os.environ["ENABLE_TALISMAN"] = "0"
+    os.environ["ENABLE_TALISMAN"] = "1"
     app = create_app()
-    app.add_url_rule("/health", "health", lambda: ("ok", 200))
     with app.test_client() as client:
-        resp = client.get("/health")
+        resp = client.get("/healthz")
         assert resp.status_code == 200
         assert resp.data == b"ok"


### PR DESCRIPTION
## Summary
- add `/healthz` blueprint and skip Talisman/CSRF enforcement
- test that `/healthz` returns 200 even with HTTPS forcing enabled

## Testing
- `make fmt`
- `make test` *(fails: F401/F541 lint errors in unrelated scripts)*
- `pytest tests/test_health.py -q`
- `flyctl status -a crunevo2` *(login required)*

------
https://chatgpt.com/codex/tasks/task_e_6896c85392148325956ddca1a66d9326