### PR TITLE
Remove mobile feed side padding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1273,3 +1273,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Introduced dedicated health blueprint with `/healthz`, `/live` and `/ready` endpoints, config validation script, smoke check and docs; updated Fly configs and tests accordingly. (PR health-blueprint-refresh)
 - Centralized env config for HTTPS and health checks, returning JSON in /healthz; added deploy and secret scripts with docs (PR health-config-middleware).
 - Feed on mobile now spans full width by wrapping posts in `.page-feed` and adding responsive card and filter styles. (PR feed-mobile-full-width)
+- Removed mobile feed side gutters by adding `px-0` to the main container and appending CSS rules to eliminate padding and gutters under 768px. (PR feed-mobile-gutterless)

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -1393,3 +1393,52 @@ select:focus {
   .page-feed .top-filters::-webkit-scrollbar { display: none; }
 }
 
+@media (max-width: 768px) {
+  html, body { margin:0; padding:0; overflow-x:hidden; }
+
+  .page-feed,
+  .with-mobile-navbar .container-fluid,
+  .page-feed .container-fluid {
+    width:100%;
+    max-width:none;
+    margin:0;
+    padding-left:0 !important;
+    padding-right:0 !important;
+  }
+
+  .page-feed .row {
+    --bs-gutter-x: 0;
+    --bs-gutter-y: 0;
+  }
+
+  .page-feed [class*="col-"] {
+    padding-left:0 !important;
+    padding-right:0 !important;
+  }
+
+  .page-feed article.facebook-post {
+    border-radius:14px;
+    margin:8px 0;
+    background:var(--surface,#fff);
+    overflow:hidden;
+    box-shadow:0 1px 3px rgba(0,0,0,.06);
+  }
+
+  .page-feed .post-header,
+  .page-feed .post-content,
+  .page-feed .post-actions,
+  .page-feed .post-footer {
+    padding:12px 14px;
+  }
+
+  .page-feed .post-media,
+  .page-feed .post-media img,
+  .page-feed .post-media video {
+    display:block;
+    width:100%;
+    height:auto;
+    object-fit:cover;
+  }
+}
+
+

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -80,7 +80,7 @@
 
     <!-- Main content with enhanced container -->
     <main class="flex-grow-1">
-        <div class="container-fluid px-md-5 pb-5 pt-2">
+        <div class="container-fluid px-0 px-md-5 pb-2 pt-2">
             <!-- Toast notifications -->
             {% import 'components/toast.html' as toast %}
             {% with messages = get_flashed_messages(with_categories=True) %}


### PR DESCRIPTION
## Summary
- drop mobile padding in base layout by adding `px-0`
- add mobile CSS rules to eliminate feed gutters and ensure full-width posts
- document mobile gutter removal in AGENTS log

## Testing
- `make fmt`
- `make test` *(fails: ruff check . -- 18 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689708c039b88325b8b4e53d35796e88