### PR TITLE
feat(mobile): reserve body space for fixed navbar and improve filter chips legibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1274,3 +1274,5 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Centralized env config for HTTPS and health checks, returning JSON in /healthz; added deploy and secret scripts with docs (PR health-config-middleware).
 - Feed on mobile now spans full width by wrapping posts in `.page-feed` and adding responsive card and filter styles. (PR feed-mobile-full-width)
 - Removed mobile feed side gutters by adding `px-0` to the main container and appending CSS rules to eliminate padding and gutters under 768px. (PR feed-mobile-gutterless)
+
+- Reserved body space for fixed mobile navbar with dynamic height variable and improved mobile filter chips for readability. (PR mobile-navbar-chips)

--- a/crunevo/static/css/feed.css
+++ b/crunevo/static/css/feed.css
@@ -1441,4 +1441,32 @@ select:focus {
   }
 }
 
+@media (max-width: 768px) {
+  .top-filters {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    padding-bottom: 8px;
+  }
+  .top-filters::-webkit-scrollbar { display: none; }
+
+  .top-filters .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.9rem;
+    line-height: 1.25;
+    padding: 8px 14px;
+    min-height: 36px;
+    border-radius: 9999px;
+    white-space: nowrap;
+    flex: 0 0 auto;
+    overflow: visible;
+  }
+  .top-filters .btn i,
+  .top-filters .btn .bi {
+    margin-right: 4px;
+  }
+}
+
 

--- a/crunevo/static/css/main.css
+++ b/crunevo/static/css/main.css
@@ -966,3 +966,26 @@ textarea.form-control {
 body.photo-modal-open {
   overflow: hidden;
 }
+
+:root {
+  --mobile-navbar-h: 56px; /* altura visual del navbar móvil */
+}
+
+@media (max-width: 768px) {
+  /* El body reserva espacio para el navbar fijo */
+  body.with-mobile-navbar {
+    padding-top: calc(var(--mobile-navbar-h) + env(safe-area-inset-top, 0px));
+  }
+
+  /* Los anclajes/páginas no quedan ocultos al navegar con hash/links */
+  .page-feed,
+  [id] {
+    scroll-margin-top: calc(var(--mobile-navbar-h) + 8px);
+  }
+
+  /* El contenedor del feed no debe reintroducir gutters */
+  .with-mobile-navbar .container-fluid {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
+}

--- a/crunevo/static/js/enhanced-ui.js
+++ b/crunevo/static/js/enhanced-ui.js
@@ -421,3 +421,15 @@ window.CRUNEVO_UI = {
     updateCartCount,
     showRewardNotification
 };
+
+(function () {
+  function setMobileNavbarHeight() {
+    var nb = document.getElementById('mobileNavbar');
+    if (!nb) return;
+    var h = nb.getBoundingClientRect().height;
+    document.documentElement.style.setProperty('--mobile-navbar-h', Math.round(h) + 'px');
+  }
+  window.addEventListener('load', setMobileNavbarHeight);
+  window.addEventListener('resize', setMobileNavbarHeight);
+  window.addEventListener('orientationchange', setMobileNavbarHeight);
+})();

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -61,7 +61,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/mobile-responsive-fix.css') }}">
     {% block head_extra %}{% endblock %}
 </head>
-<body class="d-flex flex-column min-vh-100">
+<body class="d-flex flex-column min-vh-100 {% if not request.path.startswith('/admin') and request.endpoint not in ['auth.login', 'onboarding.register'] %}with-mobile-navbar{% endif %}">
     {% if current_app.config.MAINTENANCE_MODE and not request.path.startswith('/admin') %}
     <div class="alert alert-warning text-center m-0" role="alert">
         El sitio se encuentra en mantenimiento. Algunas funciones pueden no estar disponibles.

--- a/crunevo/templates/components/mobile_navbar.html
+++ b/crunevo/templates/components/mobile_navbar.html
@@ -72,8 +72,6 @@
   background: rgba(36, 37, 38, 0.95);
 }
 /* Dejar SIEMPRE espacio para que no tape el contenido (sin doble-contar safe-area) */
-body.with-mobile-navbar { padding-top: var(--mobile-navbar-height, 56px); }
-[id] { scroll-margin-top: calc(var(--mobile-navbar-height, 56px) + 8px); }
 /* Safe area para iPhone con notch (aplicado SOLO en el navbar) */
 #mobileNavbar { padding-top: env(safe-area-inset-top); height: calc(56px + env(safe-area-inset-top)); }
 
@@ -97,13 +95,6 @@ body.with-mobile-navbar { padding-top: var(--mobile-navbar-height, 56px); }
 document.addEventListener("DOMContentLoaded", () => {
   const navbar = document.getElementById("mobileNavbar");
   if (!navbar) return;
-  requestAnimationFrame(() => {
-    const h = navbar.getBoundingClientRect().height || 56; // ya incluye safe-area
-    document.body.classList.add("with-mobile-navbar");
-    document.body.style.setProperty("--mobile-navbar-height", h + "px");
-    // fallback directo (sin sumar safe-area de nuevo)
-    document.body.style.paddingTop = h + "px";
-  });
 
   // Modal de búsqueda (simple): si existe #mobileSearchModal, ábrelo; si no, crea uno básico
   const openSearch = () => {


### PR DESCRIPTION
## Summary
- ensure body reserves space for mobile navbar via CSS variable and JS height sync
- make feed filter chips scrollable and legible on mobile

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689781add48c8325917f63a0f2bc4a2e