### PR TITLE
feat(notes): mobile edge-to-edge layout, full-width filters & search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1277,3 +1277,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 
 - Reserved body space for fixed mobile navbar with dynamic height variable and improved mobile filter chips for readability. (PR mobile-navbar-chips)
 - Global mobile navbar padding now handled via --mobile-navbar-height variable, body safe-area reservation, and script moved to enhanced-ui.js without defer; removed inline styles/scripts from mobile_navbar.html. (PR mobile-navbar-spacing-fix)
+- Notes list page adopts feed-style mobile full-width layout, wrapping content in `.page-notes` with responsive chips, search and edge-to-edge cards. (PR notes-mobile-full-width)

--- a/crunevo/static/css/notes.css
+++ b/crunevo/static/css/notes.css
@@ -114,3 +114,87 @@
   border-color: var(--primary);
   box-shadow: 0 0 0 0.25rem rgba(109, 40, 217, 0.25);
 }
+
+/* ===== Apuntes: Layout móvil al estilo Feed ===== */
+@media (max-width: 768px) {
+  /* Elimina gutters/padding laterales */
+  .page-notes,
+  .with-mobile-navbar .container-fluid,
+  .page-notes .container-fluid {
+    width: 100%;
+    max-width: none;
+    margin: 0;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
+
+  .page-notes .row {
+    --bs-gutter-x: 0;
+    --bs-gutter-y: 0;
+    margin-left: 0;
+    margin-right: 0;
+  }
+  .page-notes [class*="col-"] {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
+
+  /* Título + buscador: que ocupen todo el ancho */
+  .page-notes h2,
+  .page-notes .notes-search,
+  .page-notes .input-group,
+  .page-notes .form-control {
+    width: 100%;
+  }
+
+  /* Chips/filtros horizontales como en feed */
+  .page-notes .top-filters {
+    display: flex;
+    gap: 8px;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    padding: 8px 12px;
+  }
+  .page-notes .top-filters::-webkit-scrollbar { display: none; }
+  .page-notes .top-filters .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.9rem;
+    line-height: 1.25;
+    padding: 8px 14px;
+    min-height: 36px;
+    border-radius: 9999px;
+    white-space: nowrap;
+    flex: 0 0 auto;
+    overflow: visible;
+  }
+  .page-notes .top-filters .btn i,
+  .page-notes .top-filters .btn .bi { margin-right: 4px; }
+
+  /* Tarjetas de nota: edge-to-edge con margen vertical suave */
+  .page-notes article.note-card,
+  .page-notes .card.note-card {
+    margin: 8px 0;
+    border-radius: 14px;
+    overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0,0,0,.06);
+    background: var(--surface, #fff);
+  }
+  .page-notes .note-card .card-body,
+  .page-notes .note-card .note-preview,
+  .page-notes .note-card .note-tags,
+  .page-notes .note-card .note-actions {
+    padding: 12px 14px;
+  }
+
+  /* Ajustes para grids de notas: 1 por fila en XS, sin sangrías */
+  .page-notes #notesList,
+  .page-notes .notes-list {
+    --bs-gutter-x: 0;
+    --bs-gutter-y: 0;
+    margin-left: 0;
+    margin-right: 0;
+  }
+}

--- a/crunevo/templates/notes/list.html
+++ b/crunevo/templates/notes/list.html
@@ -4,10 +4,9 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/notes.css') }}">
 {% endblock %}
 {% block content %}
-<div class="row">
-  <div class="col-12">
-    <h2 class="mb-3">Apuntes</h2>
-    <div class="d-flex flex-wrap gap-2 mb-3 justify-content-center notes-filters">
+<div class="page-notes px-3 px-lg-4">
+  <h2 class="mb-3">Apuntes</h2>
+  <div class="top-filters d-flex gap-3 mb-3 overflow-auto pb-2 notes-filters">
       <a href="{{ url_for('notes.list_notes', filter='recientes', tag=selected_tag) }}" class="btn btn-outline-primary {% if filter == 'recientes' %}active{% endif %}"><i class="bi bi-clock me-1"></i>Recientes</a>
       <a href="{{ url_for('notes.list_notes', filter='vistos', tag=selected_tag) }}" class="btn btn-outline-primary {% if filter == 'vistos' %}active{% endif %}"><i class="bi bi-eye-fill me-1"></i>Más vistos</a>
       <a href="{{ url_for('notes.list_notes', filter='gustados', tag=selected_tag) }}" class="btn btn-outline-primary {% if filter == 'gustados' %}active{% endif %}"><i class="bi bi-hand-thumbs-up-fill me-1"></i>Más gustados</a>
@@ -23,23 +22,23 @@
         </ul>
       </div>
     </div>
-    <div class="row align-items-center mb-3 d-flex justify-content-between">
-      <div class="col">
-        <input type="text" id="noteSearch" class="form-control" placeholder="Buscar...">
-      </div>
-      <div class="col-auto">
-        <a href="{{ url_for('notes.upload_note') }}" class="btn btn-primary">Subir apunte</a>
-      </div>
+  <div class="row align-items-center mb-3">
+    <div class="col">
+      <input type="text" id="noteSearch" class="form-control" placeholder="Buscar...">
     </div>
-    <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-5 row-cols-xl-6 row-cols-xxl-7 g-3" id="notesList">
+    <div class="col-auto">
+      <a href="{{ url_for('notes.upload_note') }}" class="btn btn-primary">Subir apunte</a>
+    </div>
+  </div>
+  <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-5 row-cols-xl-6 row-cols-xxl-7 g-3" id="notesList">
 {% for note in notes %}
   <div class="col">
     {% set show_quick_view = True %}
     {% include 'components/note_card.html' %}
   </div>
 {% endfor %}
-</div>
-<script>
+  </div>
+  <script>
 document.addEventListener('DOMContentLoaded', function () {
   document.getElementById('noteSearch').addEventListener('input', function(e){
     fetch("{{ url_for('notes.search_notes') }}?q=" + encodeURIComponent(e.target.value))
@@ -152,8 +151,7 @@ function createNoteCard(n) {
   col.appendChild(card);
   return col;
 }
-</script>
-  </div>
+  </script>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Wrap notes list content in `.page-notes` with horizontal `top-filters`, search and cards for a feed-style mobile layout
- Add responsive CSS removing gutters and styling chips and cards edge-to-edge below 768px

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897dad9820c8325a7a530d8cff4de4d