### PR TITLE
Fix mobile navbar search modal trigger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1279,3 +1279,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Global mobile navbar padding now handled via --mobile-navbar-height variable, body safe-area reservation, and script moved to enhanced-ui.js without defer; removed inline styles/scripts from mobile_navbar.html. (PR mobile-navbar-spacing-fix)
 - Notes list page adopts feed-style mobile full-width layout, wrapping content in `.page-notes` with responsive chips, search and edge-to-edge cards. (PR notes-mobile-full-width)
 - Added global search suggestions with debounce, accessible dropdown and full-screen mobile modal, plus `/api/search/suggest` endpoint. (PR navbar-search-suggest)
+- Mobile nav search uses Bootstrap modal attributes with legacy [data-action="open-search"] fallback listener and auto-hides modal on desktop resize. (PR mobile-search-modal-fix)

--- a/crunevo/static/js/search.js
+++ b/crunevo/static/js/search.js
@@ -7,6 +7,17 @@ const debounce = (fn, ms = 250) => {
   };
 };
 
+// Fallback for legacy templates still using data-action="open-search"
+document.addEventListener('click', (e) => {
+  const trigger = e.target.closest('[data-action="open-search"]');
+  if (!trigger) return;
+  e.preventDefault();
+  const modalEl = document.getElementById('mobileSearchModal');
+  if (modalEl) {
+    bootstrap.Modal.getOrCreateInstance(modalEl).show();
+  }
+});
+
 // ---- DESKTOP ----
 (() => {
   const input = document.getElementById('globalSearchInput');
@@ -104,6 +115,12 @@ const debounce = (fn, ms = 250) => {
   if (!modalEl || !input || !list || !submit) return;
 
   const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+  const hideOnDesktop = () => {
+    if (window.innerWidth >= 768) {
+      modal.hide();
+    }
+  };
+  window.addEventListener('resize', hideOnDesktop);
   const goToFullSearch = (q) => {
     modal.hide();
     window.location.href = `/search?q=${encodeURIComponent(q)}`;

--- a/crunevo/templates/components/mobile_navbar.html
+++ b/crunevo/templates/components/mobile_navbar.html
@@ -49,11 +49,10 @@
   <a href="#"
      class="nav-icon-btn btn-link"
      aria-label="Buscar"
-     data-action="open-search">
+     data-bs-toggle="modal"
+     data-bs-target="#mobileSearchModal"
+     role="button">
     <i class="bi bi-search"></i>
   </a>
 </nav>
 
-<script>
-// Eliminado: la lógica ahora vive en enhanced-ui.js
-</script>


### PR DESCRIPTION
## Summary
- use Bootstrap modal attributes for mobile nav search button
- add legacy `[data-action="open-search"]` listener and desktop resize auto-hide
- document in AGENTS

## Testing
- `pre-commit run --files AGENTS.md crunevo/static/js/search.js crunevo/templates/components/mobile_navbar.html`
- `pytest test_login.py test_server.py test_session.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6898150031588325bec973c6584ede46