### PR TITLE
fix: show mobile search modal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1280,3 +1280,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Notes list page adopts feed-style mobile full-width layout, wrapping content in `.page-notes` with responsive chips, search and edge-to-edge cards. (PR notes-mobile-full-width)
 - Added global search suggestions with debounce, accessible dropdown and full-screen mobile modal, plus `/api/search/suggest` endpoint. (PR navbar-search-suggest)
 - Mobile nav search uses Bootstrap modal attributes with legacy [data-action="open-search"] fallback listener and auto-hides modal on desktop resize. (PR mobile-search-modal-fix)
+- Moved mobile search modal outside desktop-only navbar wrapper and included globally so it renders on mobile. (PR mobile-search-modal-visible)

--- a/crunevo/static/js/search.js
+++ b/crunevo/static/js/search.js
@@ -115,12 +115,13 @@ document.addEventListener('click', (e) => {
   if (!modalEl || !input || !list || !submit) return;
 
   const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
-  const hideOnDesktop = () => {
-    if (window.innerWidth >= 768) {
-      modal.hide();
-    }
-  };
-  window.addEventListener('resize', hideOnDesktop);
+    const hideOnDesktop = () => {
+      if (window.innerWidth >= 768) {
+        modal.hide();
+      }
+    };
+    window.addEventListener('resize', hideOnDesktop);
+    hideOnDesktop();
   const goToFullSearch = (q) => {
     modal.hide();
     window.location.href = `/search?q=${encodeURIComponent(q)}`;
@@ -176,9 +177,10 @@ document.addEventListener('click', (e) => {
     if (q) goToFullSearch(q);
   });
 
-  modalEl.addEventListener('shown.bs.modal', () => {
-    input.focus();
-  });
+    modalEl.addEventListener('shown.bs.modal', () => {
+      hideOnDesktop();
+      input.focus();
+    });
 })();
 
 // ---- helpers ----

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -70,13 +70,14 @@
     <!-- Navigation -->
     {% if not request.path.startswith('/admin')
           and request.endpoint not in ['auth.login', 'onboarding.register'] %}
-      {% if config.ADMIN_INSTANCE %}
-        {% include 'components/navbar_admin.html' %}
-      {% else %}
-        <div class="d-none d-lg-block">{% include 'components/navbar.html' %}</div>
-        {% include 'components/mobile_navbar.html' %}
+        {% if config.ADMIN_INSTANCE %}
+          {% include 'components/navbar_admin.html' %}
+        {% else %}
+          <div class="d-none d-lg-block">{% include 'components/navbar.html' %}</div>
+          {% include 'components/mobile_navbar.html' %}
+          {% include 'components/mobile_search_modal.html' %}
+        {% endif %}
       {% endif %}
-    {% endif %}
 
     <!-- Main content with enhanced container -->
     <main class="flex-grow-1">

--- a/crunevo/templates/components/mobile_search_modal.html
+++ b/crunevo/templates/components/mobile_search_modal.html
@@ -1,0 +1,18 @@
+<!-- Mobile Search Modal -->
+<div class="modal fade" id="mobileSearchModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-fullscreen-sm-down">
+    <div class="modal-content bg-body">
+      <div class="modal-header border-0">
+        <input id="mobileSearchInput" type="search" class="form-control"
+               placeholder="Buscar en CRUNEVO" aria-label="Buscar" autofocus>
+        <button type="button" class="btn-close ms-2" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+      </div>
+      <div class="modal-body p-0">
+        <div id="mobileSearchResults" class="list-group list-group-flush" role="listbox" aria-live="polite"></div>
+      </div>
+      <div class="modal-footer border-0">
+        <button id="mobileSearchSubmit" class="btn btn-primary w-100">Buscar en toda la plataforma</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -126,21 +126,3 @@
   </div>
 </nav>
 
-<!-- Mobile Search Modal -->
-<div class="modal fade" id="mobileSearchModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-fullscreen-sm-down">
-    <div class="modal-content bg-body">
-      <div class="modal-header border-0">
-        <input id="mobileSearchInput" type="search" class="form-control"
-               placeholder="Buscar en CRUNEVO" aria-label="Buscar" autofocus>
-        <button type="button" class="btn-close ms-2" data-bs-dismiss="modal" aria-label="Cerrar"></button>
-      </div>
-      <div class="modal-body p-0">
-        <div id="mobileSearchResults" class="list-group list-group-flush" role="listbox" aria-live="polite"></div>
-      </div>
-      <div class="modal-footer border-0">
-        <button id="mobileSearchSubmit" class="btn btn-primary w-100">Buscar en toda la plataforma</button>
-      </div>
-    </div>
-  </div>
-</div>


### PR DESCRIPTION
## Summary
- render mobile search modal outside desktop navbar so it displays properly on phones
- ensure modal closes automatically on desktop

## Testing
- `make fmt`
- `make test` *(fails: ruff found style issues in unrelated scripts)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898227c76088325af3009fde0587303