### PR TITLE
Fix personal space modal and debounce duplication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1281,3 +1281,5 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Added global search suggestions with debounce, accessible dropdown and full-screen mobile modal, plus `/api/search/suggest` endpoint. (PR navbar-search-suggest)
 - Mobile nav search uses Bootstrap modal attributes with legacy [data-action="open-search"] fallback listener and auto-hides modal on desktop resize. (PR mobile-search-modal-fix)
 - Moved mobile search modal outside desktop-only navbar wrapper and included globally so it renders on mobile. (PR mobile-search-modal-visible)
+
+- Namespaced global `CRUNEVO.debounce` to prevent duplicate search.js execution, fixed personal space block modal/backdrop with body-appended modal and single-click opener, added container layout to block detail views, and versioned assets with aria-label fixes. (PR personal-space-modal-debounce)

--- a/crunevo/static/js/personal-space.js
+++ b/crunevo/static/js/personal-space.js
@@ -32,6 +32,12 @@ function initializePersonalSpace() {
     initializeEventListeners();
     initializeAutoSave();
 
+    // Ensure modals are not constrained by parent containers
+    const editModal = document.getElementById('editBlockModal');
+    if (editModal && editModal.parentNode !== document.body) {
+        document.body.appendChild(editModal);
+    }
+
     // Restore dismissed suggestions
     hideDismissedSuggestions();
 
@@ -195,7 +201,11 @@ function createBlockElement(block) {
 
     div.innerHTML = generateBlockHTML(block);
 
-    div.addEventListener('dblclick', () => openBlock(block.id));
+    div.addEventListener('click', (e) => {
+        if (!e.target.closest('.dropdown') && !e.target.closest('.enter-block')) {
+            showEditBlockModal(block.id);
+        }
+    });
 
     return div;
 }
@@ -501,7 +511,7 @@ function handleBlockInteractions(e) {
     } else if (e.target.closest('.enter-block')) {
         e.preventDefault();
         openBlock(blockId);
-    } else if (e.target.closest('.block-content') && !e.target.closest('.dropdown')) {
+    } else if (!e.target.closest('.dropdown') && !e.target.closest('.enter-block')) {
         showEditBlockModal(blockId);
     }
 }

--- a/crunevo/static/js/search.js
+++ b/crunevo/static/js/search.js
@@ -1,11 +1,13 @@
-// Lightweight debounce
-const debounce = (fn, ms = 250) => {
+// Lightweight debounce with global namespace guard
+window.CRUNEVO = window.CRUNEVO || {};
+window.CRUNEVO.debounce = window.CRUNEVO.debounce || ((fn, ms = 250) => {
   let t;
   return (...args) => {
     clearTimeout(t);
     t = setTimeout(() => fn(...args), ms);
   };
-};
+});
+const debounce = window.CRUNEVO.debounce;
 
 // Fallback for legacy templates still using data-action="open-search"
 document.addEventListener('click', (e) => {

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -56,7 +56,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/feed.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/notes.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/photo-modal.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/personal-space.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/personal-space.css') }}?v=20240603">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/carrera.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/mobile-responsive-fix.css') }}">
     {% block head_extra %}{% endblock %}
@@ -212,7 +212,7 @@
 
     <!-- Main app initialization -->
     <script src="https://cdn.jsdelivr.net/npm/socket.io-client@4.7.2/dist/socket.io.min.js" defer></script>
-    <script src="{{ url_for('static', filename='js/search.js') }}" defer></script>
+    <script src="{{ url_for('static', filename='js/search.js') }}?v=20240603" defer></script>
     <script src="{{ url_for('static', filename='js/main.js') }}" defer></script>
     <script src="{{ url_for('static', filename='js/share.js') }}" defer></script>
     <script>

--- a/crunevo/templates/personal_space/index.html
+++ b/crunevo/templates/personal_space/index.html
@@ -2,9 +2,7 @@
 {% import 'personal_space/components/macros.html' as ps_macros %}
 {% block title %}Mi Espacio Personal{% endblock %}
 
-{% block head %}
-<link rel="stylesheet" href="{{ url_for('static', filename='css/personal-space.css') }}">
-{% endblock %}
+{% block head %}{% endblock %}
 
 {% block content %}
 <div class="personal-space-container">
@@ -133,12 +131,12 @@
                         </button>
                         <div class="row g-1">
                             <div class="col-6">
-                                <a href="{{ url_for('personal_space.calendar_view') }}" class="btn btn-outline-info btn-sm w-100">
+                                <a href="{{ url_for('personal_space.calendar_view') }}" class="btn btn-outline-info btn-sm w-100" aria-label="Calendario">
                                     <i class="bi bi-calendar3"></i>
                                 </a>
                             </div>
                             <div class="col-6">
-                                <a href="{{ url_for('personal_space.statistics_view') }}" class="btn btn-outline-success btn-sm w-100">
+                                <a href="{{ url_for('personal_space.statistics_view') }}" class="btn btn-outline-success btn-sm w-100" aria-label="Estadísticas">
                                     <i class="bi bi-graph-up"></i>
                                 </a>
                             </div>
@@ -429,7 +427,7 @@
 
 {% block extra_js %}
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
-    <script src="{{ url_for('static', filename='js/personal-space.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/personal-space.js') }}?v=20240603"></script>
     <script>
         // Enhanced dashboard functionality
         document.addEventListener('DOMContentLoaded', function() {

--- a/crunevo/templates/personal_space/views/bloque_personalizado_view.html
+++ b/crunevo/templates/personal_space/views/bloque_personalizado_view.html
@@ -2,7 +2,6 @@
 {% block title %}Bloque Personalizado - {{ block.title }}{% endblock %}
 
 {% block head %}
-<link rel="stylesheet" href="{{ url_for('static', filename='css/personal-space.css') }}">
 <style>
 .bloque-container {
     max-width: 1000px;
@@ -286,7 +285,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="bloque-container">
+<div class="bloque-container container py-4">
     <!-- Header -->
     <div class="d-flex justify-content-between align-items-center mb-4">
         <div>

--- a/crunevo/templates/personal_space/views/nota_enriquecida_view.html
+++ b/crunevo/templates/personal_space/views/nota_enriquecida_view.html
@@ -2,7 +2,6 @@
 {% block title %}Nota Enriquecida - {{ block.title }}{% endblock %}
 
 {% block head %}
-<link rel="stylesheet" href="{{ url_for('static', filename='css/personal-space.css') }}">
 <style>
 .nota-editor-container {
     max-width: 900px;
@@ -258,7 +257,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="nota-editor-container">
+<div class="nota-editor-container container py-4">
     <!-- Header -->
     <div class="d-flex justify-content-between align-items-center mb-4">
         <div>


### PR DESCRIPTION
## Summary
- Namespace debounce in search.js to avoid duplicate definitions
- Open personal space blocks with a single click and append modal to body
- Wrap block detail views in Bootstrap containers and add asset cache busting

## Testing
- `make fmt`
- `make test` *(fails: F401 `os` imported but unused, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6898249794708325a04ad67fab08eaf8