### PR TITLE
Fix personal space note block type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1287,3 +1287,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Unified personal space block cards layout with responsive grid, restored single/double click interactions and fixed edit modal backdrop cleanup. (PR personal-space-blocks-layout)
 - Linked shared stylesheet and added Tailwind typography classes in Bloque Personalizado and Nota Enriquecida views for consistent block design. (PR personal-space-block-styles)
 - Added test covering creation and view rendering for all personal space block types and fixed 'bloque_personalizado' metadata to use structured subject data. (PR personal-space-block-tests)
+- Fixed personal space note creation by switching the Bitácora Inteligente card to use `nota_enriquecida` blocks and updating related JS, routes and styles. (PR personal-space-nota-enriquecida)

--- a/crunevo/routes/personal_space_routes.py
+++ b/crunevo/routes/personal_space_routes.py
@@ -146,7 +146,10 @@ def create_block():
         metadata.setdefault("template_type", "")
         metadata.setdefault("tags", [])
     elif data["type"] == "bloque_personalizado":
-        metadata.setdefault("subject", {"name": "", "code": "", "profesor": "", "color": "", "icon": "bi bi-book"})
+        metadata.setdefault(
+            "subject",
+            {"name": "", "code": "", "profesor": "", "color": "", "icon": "bi bi-book"},
+        )
         metadata.setdefault("subject_code", "")
         metadata.setdefault("professor", "")
         metadata.setdefault("elementos", [])
@@ -322,7 +325,11 @@ def get_smart_suggestions():
         )
 
     # Check if user has no notes
-    notes_count = Block.query.filter_by(user_id=current_user.id, type="nota").count()
+    notes_count = (
+        Block.query.filter_by(user_id=current_user.id)
+        .filter(Block.type.in_(["nota", "nota_enriquecida"]))
+        .count()
+    )
 
     if notes_count == 0:
         suggestions.append(

--- a/crunevo/static/css/personal-space.css
+++ b/crunevo/static/css/personal-space.css
@@ -1909,12 +1909,12 @@
 /* Focus Mode */
 .focus-mode .ps-header,
 .focus-mode .ps-suggestions,
-.focus-mode .block-card:not([data-block-type="nota"]) {
+.focus-mode .block-card:not([data-block-type="nota_enriquecida"]) {
     opacity: 0.3;
     pointer-events: none;
 }
 
-.focus-mode .block-card[data-block-type="nota"] {
+.focus-mode .block-card[data-block-type="nota_enriquecida"] {
     transform: scale(1.02);
     box-shadow: 0 16px 48px rgba(99, 102, 241, 0.2);
 }

--- a/crunevo/static/js/personal-space.js
+++ b/crunevo/static/js/personal-space.js
@@ -13,6 +13,8 @@ let isFocusMode = localStorage.getItem('focus_mode') === 'on';
 
 const DEFAULT_ICONS = {
     'nota': 'bi-journal-text',
+    'nota_enriquecida': 'bi-file-richtext',
+    'bitacora': 'bi-journal-text',
     'lista': 'bi-check2-square',
     'meta': 'bi-target',
     'recordatorio': 'bi-alarm',
@@ -223,6 +225,7 @@ function createBlockElement(block) {
 function generateBlockHTML(block) {
     const typeLabels = {
         'nota': 'Nota Rápida',
+        'nota_enriquecida': 'Bitácora Inteligente',
         'lista': 'Lista de Tareas',
         'meta': 'Meta',
         'recordatorio': 'Recordatorio',
@@ -272,6 +275,9 @@ function generateBlockHTML(block) {
 function generateBlockContent(block) {
     switch (block.type) {
         case 'nota':
+        case 'nota_enriquecida':
+        case 'nota_enriquecida':
+        case 'nota_enriquecida':
             return `
                 <div class="note-content">
                     ${block.content ?
@@ -451,6 +457,7 @@ function createNewBlock(type) {
 function getDefaultTitle(type) {
     const titles = {
         'nota': 'Nueva nota',
+        'nota_enriquecida': 'Nueva nota',
         'lista': 'Lista de tareas',
         'meta': 'Nueva meta',
         'recordatorio': 'Recordatorio',
@@ -472,13 +479,17 @@ function getDefaultMetadata(type) {
             return { author: '', category: 'motivacional' };
         case 'enlace':
             return { url: '', description: '' };
+        case 'nota_enriquecida':
+            return { blocks: [], template_type: '', tags: [] };
+        case 'bitacora':
+            return { entries: [], streak: 0, mood_tracking: true };
         default:
             return {};
     }
 }
 
 function startPersonalSpace() {
-    const requests = ['nota', 'kanban', 'objetivo'].map(type =>
+    const requests = ['nota_enriquecida', 'kanban', 'objetivo'].map(type =>
         fetch('/espacio-personal/api/create-block', {
             method: 'POST',
             headers: {
@@ -1130,7 +1141,7 @@ function handleSuggestionClick(e) {
                 }
                 break;
             case 'create_nota_block':
-                if (!blockTypeExists('nota')) {
+                if (!blockTypeExists('nota_enriquecida')) {
                     fetch('/espacio-personal/api/create-block', {
                         method: 'POST',
                         headers: {
@@ -1138,8 +1149,8 @@ function handleSuggestionClick(e) {
                             'X-CSRFToken': getCsrfToken()
                         },
                         body: JSON.stringify({
-                            type: 'nota',
-                            metadata: { color: 'indigo', icon: DEFAULT_ICONS['nota'] }
+                            type: 'nota_enriquecida',
+                            metadata: Object.assign({ color: 'indigo', icon: DEFAULT_ICONS['nota_enriquecida'] }, getDefaultMetadata('nota_enriquecida'))
                         })
                     })
                     .then(res => res.json())
@@ -1390,6 +1401,7 @@ function updateDashboardMetrics() {
 
         switch(type) {
             case 'nota':
+            case 'nota_enriquecida':
                 metrics.notas++;
                 break;
             case 'tarea':

--- a/crunevo/templates/personal_space/index.html
+++ b/crunevo/templates/personal_space/index.html
@@ -317,9 +317,9 @@
                     <div class="block-section">
                         <h6 class="block-section-title">🎓 Herramientas Académicas</h6>
 
-                        <div class="block-type-card" data-type="nota">
+                        <div class="block-type-card" data-type="nota_enriquecida">
                             <div class="block-type-icon">
-                                <i class="bi bi-journal-text"></i>
+                                <i class="bi bi-file-richtext"></i>
                             </div>
                             <h6>Bitácora Inteligente</h6>
                             <p>Notas enriquecidas estilo Notion</p>


### PR DESCRIPTION
## Summary
- Switch Bitácora Inteligente card to create `nota_enriquecida` blocks instead of unfinished `nota`
- Update personal space JS, routes and styles for the new block type
- Document the change in AGENTS.md

## Testing
- `make test` *(fails: check_errors.py:2:8: F401 `os` imported but unused)*
- `pytest tests/test_personal_space_block_types.py`


------
https://chatgpt.com/codex/tasks/task_e_68993f51d21c8325901473e2f9863002