### PR TITLE
feat: simplify nota enriquecida styling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1288,3 +1288,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Linked shared stylesheet and added Tailwind typography classes in Bloque Personalizado and Nota Enriquecida views for consistent block design. (PR personal-space-block-styles)
 - Added test covering creation and view rendering for all personal space block types and fixed 'bloque_personalizado' metadata to use structured subject data. (PR personal-space-block-tests)
 - Fixed personal space note creation by switching the Bitácora Inteligente card to use `nota_enriquecida` blocks and updating related JS, routes and styles. (PR personal-space-nota-enriquecida)
+- Simplified Nota Enriquecida block and view with Notion-like neutral styling using Tailwind utilities for improved readability. (PR personal-space-nota-notion-style)

--- a/crunevo/static/css/personal-space.css
+++ b/crunevo/static/css/personal-space.css
@@ -1212,7 +1212,7 @@
     margin-bottom: 1rem;
     font-size: 0.9rem;
     line-height: 1.6;
-    color: #374151;
+    color: #111827;
     display: -webkit-box;
     -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
@@ -1224,18 +1224,20 @@
 }
 
 .nota-enriquecida-content .rich-content {
-    background: rgba(99, 102, 241, 0.05);
-    border: 1px solid rgba(99, 102, 241, 0.1);
+    background: #fff;
+    border: 1px solid #e5e7eb;
     border-radius: 8px;
     padding: 0.75rem;
     margin-bottom: 1rem;
-    font-size: 0.85rem;
+    font-size: 0.875rem;
     line-height: 1.5;
+    color: #374151;
 }
 
 [data-bs-theme="dark"] .nota-enriquecida-content .rich-content {
-    background: rgba(139, 92, 246, 0.1);
-    border-color: rgba(139, 92, 246, 0.2);
+    background: #1f2937;
+    border-color: #374151;
+    color: #d1d5db;
 }
 
 .nota-enriquecida-content .rich-content h1,
@@ -1244,22 +1246,21 @@
     margin: 0 0 0.5rem 0;
     font-size: 1rem;
     font-weight: 600;
-    color: #6366f1;
+    color: #111827;
 }
 
 [data-bs-theme="dark"] .nota-enriquecida-content .rich-content h1,
 [data-bs-theme="dark"] .nota-enriquecida-content .rich-content h2,
 [data-bs-theme="dark"] .nota-enriquecida-content .rich-content h3 {
-    color: #a78bfa;
+    color: #f3f4f6;
 }
 
 .nota-enriquecida-content .rich-content p {
     margin: 0 0 0.5rem 0;
-    color: #64748b;
 }
 
 [data-bs-theme="dark"] .nota-enriquecida-content .rich-content p {
-    color: #94a3b8;
+    color: #d1d5db;
 }
 
 .nota-enriquecida-content .rich-content ul,
@@ -1270,11 +1271,10 @@
 
 .nota-enriquecida-content .rich-content li {
     margin-bottom: 0.25rem;
-    color: #64748b;
 }
 
 [data-bs-theme="dark"] .nota-enriquecida-content .rich-content li {
-    color: #94a3b8;
+    color: #d1d5db;
 }
 
 .nota-enriquecida-meta {

--- a/crunevo/templates/personal_space/blocks/nota_enriquecida_block.html
+++ b/crunevo/templates/personal_space/blocks/nota_enriquecida_block.html
@@ -1,204 +1,82 @@
-<div class="nota-enriquecida-content">
+<div class="nota-enriquecida-content flex flex-col h-full">
     {% set metadata = block.get_metadata() %}
-    
-    <!-- Header con icono y título -->
-    <div class="nota-header">
-        <div class="nota-icon">
+
+    <div class="flex items-center gap-3 mb-3">
+        <div class="w-8 h-8 flex items-center justify-center rounded bg-primary/10 text-primary">
             <i class="{{ metadata.get('icon', 'bi bi-file-text') }}"></i>
         </div>
-        <div class="nota-title-section">
-            <h6 class="nota-title">{{ block.title or 'Nota sin título' }}</h6>
+        <div>
+            <h6 class="m-0 font-semibold text-gray-900 dark:text-gray-100">{{ block.title or 'Nota sin título' }}</h6>
             {% if metadata.get('template_type') %}
-            <span class="template-badge">{{ metadata.get('template_type')|title }}</span>
+            <span class="ml-1 text-xs px-2 py-0.5 rounded bg-emerald-100 text-emerald-600 dark:bg-emerald-800 dark:text-emerald-200">{{ metadata.get('template_type')|title }}</span>
             {% endif %}
         </div>
     </div>
-    
-    <!-- Contenido preview -->
-    <div class="nota-preview">
+
+    <div class="flex-1 mb-3 text-sm space-y-2">
         {% if metadata.get('blocks') %}
             {% set content_blocks = metadata.get('blocks', []) %}
             {% for content_block in content_blocks[:3] %}
-                <div class="content-block content-{{ content_block.type }}">
-                    {% if content_block.type == 'heading' %}
-                        <h6 class="block-heading">{{ content_block.content[:50] }}{% if content_block.content|length > 50 %}...{% endif %}</h6>
-                    {% elif content_block.type == 'text' %}
-                        <p class="block-text">{{ content_block.content[:80] }}{% if content_block.content|length > 80 %}...{% endif %}</p>
-                    {% elif content_block.type == 'list' %}
-                        <ul class="block-list">
-                            {% for item in content_block.items[:2] %}
-                            <li>{{ item[:40] }}{% if item|length > 40 %}...{% endif %}</li>
-                            {% endfor %}
-                            {% if content_block.items|length > 2 %}
-                            <li class="text-muted">+{{ content_block.items|length - 2 }} más...</li>
-                            {% endif %}
-                        </ul>
-                    {% elif content_block.type == 'code' %}
-                        <div class="block-code">
-                            <code>{{ content_block.content[:60] }}{% if content_block.content|length > 60 %}...{% endif %}</code>
-                        </div>
-                    {% elif content_block.type == 'quote' %}
-                        <blockquote class="block-quote">
-                            {{ content_block.content[:70] }}{% if content_block.content|length > 70 %}...{% endif %}
-                        </blockquote>
-                    {% endif %}
-                </div>
+                {% if content_block.type == 'heading' %}
+                    <h6 class="text-sm font-semibold text-gray-900 dark:text-gray-100">{{ content_block.content[:50] }}{% if content_block.content|length > 50 %}...{% endif %}</h6>
+                {% elif content_block.type == 'text' %}
+                    <p class="text-sm text-gray-600 dark:text-gray-300">{{ content_block.content[:80] }}{% if content_block.content|length > 80 %}...{% endif %}</p>
+                {% elif content_block.type == 'list' %}
+                    <ul class="list-disc pl-4 text-sm text-gray-600 dark:text-gray-300">
+                        {% for item in content_block.items[:2] %}
+                        <li>{{ item[:40] }}{% if item|length > 40 %}...{% endif %}</li>
+                        {% endfor %}
+                        {% if content_block.items|length > 2 %}
+                        <li class="text-gray-400">+{{ content_block.items|length - 2 }} más...</li>
+                        {% endif %}
+                    </ul>
+                {% elif content_block.type == 'code' %}
+                    <div class="bg-gray-100 dark:bg-gray-800 rounded px-2 py-1 font-mono text-xs overflow-hidden">
+                        {{ content_block.content[:60] }}{% if content_block.content|length > 60 %}...{% endif %}
+                    </div>
+                {% elif content_block.type == 'quote' %}
+                    <blockquote class="border-l-2 border-primary pl-3 italic text-sm text-gray-500 dark:text-gray-400">
+                        {{ content_block.content[:70] }}{% if content_block.content|length > 70 %}...{% endif %}
+                    </blockquote>
+                {% endif %}
             {% endfor %}
             {% if content_blocks|length > 3 %}
-            <div class="more-blocks">
-                <span class="text-muted">+{{ content_blocks|length - 3 }} bloques más...</span>
-            </div>
+            <div class="text-center text-xs text-gray-500">+{{ content_blocks|length - 3 }} bloques más...</div>
             {% endif %}
         {% else %}
-            <div class="nota-empty">
-                <i class="bi bi-plus-circle text-muted"></i>
-                <p class="text-muted">Comienza a escribir tu nota</p>
+            <div class="text-center text-gray-500 py-5">
+                <i class="bi bi-plus-circle mb-2"></i>
+                <p>Comienza a escribir tu nota</p>
             </div>
         {% endif %}
     </div>
-    
-    <!-- Metadatos -->
-    <div class="nota-metadata">
+
+    <div class="mt-auto pt-3 border-t border-gray-200 dark:border-gray-700 text-xs">
         {% if metadata.get('tags') %}
-        <div class="nota-tags">
+        <div class="flex flex-wrap gap-2 mb-2">
             {% for tag in metadata.get('tags', [])[:3] %}
-            <span class="tag-pill">{{ tag }}</span>
+            <span class="px-2 py-0.5 rounded bg-emerald-100 text-emerald-600 dark:bg-emerald-800 dark:text-emerald-200">{{ tag }}</span>
             {% endfor %}
             {% if metadata.get('tags')|length > 3 %}
-            <span class="tag-pill">+{{ metadata.get('tags')|length - 3 }}</span>
+            <span class="px-2 py-0.5 rounded bg-emerald-100 text-emerald-600 dark:bg-emerald-800 dark:text-emerald-200">+{{ metadata.get('tags')|length - 3 }}</span>
             {% endif %}
         </div>
         {% endif %}
-        
-        <div class="nota-stats">
-            <span class="stat-item">
+
+        <div class="flex gap-4 text-gray-500 dark:text-gray-400">
+            <span class="flex items-center gap-1">
                 <i class="bi bi-file-text"></i>
                 {{ metadata.get('blocks', [])|length }} bloques
             </span>
-            <span class="stat-item">
+            <span class="flex items-center gap-1">
                 <i class="bi bi-clock"></i>
                 {{ block.updated_at.strftime('%d/%m') }}
             </span>
         </div>
     </div>
-    
+
     <button class="btn btn-sm btn-outline-primary mt-2" onclick="openBlock({{ block.id }})">
         <i class="bi bi-pencil"></i>
         Editar nota
     </button>
 </div>
-
-<style>
-.nota-header {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    margin-bottom: 12px;
-}
-
-.nota-icon {
-    width: 32px;
-    height: 32px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: var(--bs-primary-bg);
-    border-radius: 6px;
-    color: var(--bs-primary);
-}
-
-.nota-title {
-    margin: 0;
-    font-weight: 600;
-}
-
-.template-badge {
-    font-size: 0.7rem;
-    background: var(--bs-success-bg);
-    color: var(--bs-success);
-    padding: 2px 6px;
-    border-radius: 4px;
-    font-weight: 500;
-}
-
-.content-block {
-    margin-bottom: 8px;
-    padding: 6px 0;
-}
-
-.block-heading {
-    font-size: 0.9rem;
-    font-weight: 600;
-    margin: 0;
-    color: var(--bs-dark);
-}
-
-.block-text {
-    font-size: 0.85rem;
-    margin: 0;
-    line-height: 1.4;
-}
-
-.block-list {
-    font-size: 0.85rem;
-    margin: 0;
-    padding-left: 16px;
-}
-
-.block-list li {
-    margin-bottom: 2px;
-}
-
-.block-code {
-    background: var(--bs-gray-100);
-    padding: 4px 8px;
-    border-radius: 4px;
-    font-family: 'Courier New', monospace;
-    font-size: 0.8rem;
-}
-
-.block-quote {
-    border-left: 3px solid var(--bs-primary);
-    padding-left: 12px;
-    margin: 0;
-    font-style: italic;
-    font-size: 0.85rem;
-    color: var(--bs-secondary);
-}
-
-.more-blocks {
-    text-align: center;
-    padding: 8px;
-    font-size: 0.8rem;
-}
-
-.nota-metadata {
-    margin-top: 12px;
-    padding-top: 12px;
-    border-top: 1px solid var(--bs-border-color);
-}
-
-.nota-stats {
-    display: flex;
-    gap: 12px;
-    margin-top: 8px;
-}
-
-.stat-item {
-    font-size: 0.75rem;
-    color: var(--bs-secondary);
-    display: flex;
-    align-items: center;
-    gap: 4px;
-}
-
-.nota-empty {
-    text-align: center;
-    padding: 20px;
-}
-
-.nota-empty i {
-    font-size: 1.5rem;
-    margin-bottom: 8px;
-}
-</style>

--- a/crunevo/templates/personal_space/views/nota_enriquecida_view.html
+++ b/crunevo/templates/personal_space/views/nota_enriquecida_view.html
@@ -9,10 +9,9 @@
     max-width: 1000px;
     margin: 0 auto;
     padding: 2rem;
-    background: linear-gradient(135deg, rgba(139, 92, 246, 0.02), rgba(139, 92, 246, 0.01));
-    border-radius: 20px;
-    box-shadow: 0 8px 32px rgba(139, 92, 246, 0.1);
-    border: 1px solid rgba(139, 92, 246, 0.1);
+    background: var(--bs-body-bg);
+    border-radius: 0.75rem;
+    border: 1px solid var(--bs-border-color);
 }
 
 .nota-header {
@@ -21,7 +20,7 @@
     gap: 20px;
     margin-bottom: 3rem;
     padding-bottom: 2rem;
-    border-bottom: 1px solid rgba(139, 92, 246, 0.15);
+    border-bottom: 1px solid var(--bs-border-color);
 }
 
 .nota-icon-selector {
@@ -31,24 +30,22 @@
 .icon-display {
     width: 60px;
     height: 60px;
-    background: linear-gradient(135deg, rgba(139, 92, 246, 0.1), rgba(139, 92, 246, 0.05));
-    border: 1px solid rgba(139, 92, 246, 0.2);
+    background: var(--bs-primary-bg-subtle);
+    border: 1px solid var(--bs-border-color);
     border-radius: 16px;
     display: flex;
     align-items: center;
     justify-content: center;
     font-size: 1.8rem;
-    color: #8b5cf6;
+    color: var(--bs-primary);
     cursor: pointer;
     transition: all 0.3s ease;
-    box-shadow: 0 4px 12px rgba(139, 92, 246, 0.1);
 }
 
 .icon-display:hover {
-    background: linear-gradient(135deg, #8b5cf6, #7c3aed);
-    color: white;
-    transform: scale(1.05) rotate(5deg);
-    box-shadow: 0 8px 20px rgba(139, 92, 246, 0.3);
+    background: var(--bs-primary);
+    color: #fff;
+    transform: scale(1.05);
 }
 
 .icon-selector-menu {
@@ -56,11 +53,11 @@
     top: 70px;
     left: 0;
     z-index: 20;
-    background: #fff;
-    border: 1px solid rgba(139, 92, 246, 0.2);
+    background: var(--bs-body-bg);
+    border: 1px solid var(--bs-border-color);
     border-radius: 12px;
     padding: 12px;
-    box-shadow: 0 12px 30px rgba(139, 92, 246, 0.2);
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.1);
     width: 320px;
     display: none;
 }
@@ -82,44 +79,41 @@
     align-items: center;
     justify-content: center;
     height: 40px;
-    border: 1px solid rgba(139, 92, 246, 0.2);
+    border: 1px solid var(--bs-border-color);
     border-radius: 10px;
     cursor: pointer;
-    color: #8b5cf6;
-    background: linear-gradient(135deg, rgba(139,92,246,0.06), rgba(139,92,246,0.03));
+    color: var(--bs-primary);
+    background: var(--bs-primary-bg-subtle);
     transition: all 0.2s ease;
 }
 
 .icon-option:hover {
-    background: linear-gradient(135deg, #8b5cf6, #7c3aed);
+    background: var(--bs-primary);
     color: #fff;
     transform: translateY(-2px);
 }
 
 .nota-title-input {
     border: none;
-    font-size: 2.2rem;
+    font-size: 2rem;
     font-weight: 700;
     background: transparent;
     width: 100%;
     padding: 12px 0;
-    background: linear-gradient(135deg, #8b5cf6, #7c3aed);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
+    color: var(--bs-emphasis-color);
 }
 
 .nota-title-input:focus {
     outline: none;
-    border-bottom: 3px solid #8b5cf6;
-    box-shadow: 0 3px 0 rgba(139, 92, 246, 0.2);
+    border-bottom: 2px solid var(--bs-primary);
+    box-shadow: none;
 }
 
 .template-selector {
     margin-bottom: 2rem;
     padding: 1.5rem;
-    background: linear-gradient(135deg, rgba(139, 92, 246, 0.05), rgba(139, 92, 246, 0.02));
-    border: 1px solid rgba(139, 92, 246, 0.1);
+    background: var(--bs-body-bg);
+    border: 1px solid var(--bs-border-color);
     border-radius: 16px;
 }
 


### PR DESCRIPTION
## Summary
- give nota enriquecida editor neutral notion-like styles
- rebuild block card with Tailwind utilities for readability

## Testing
- `make fmt`
- `make test` *(fails: F401 unused imports in scripts like check_errors.py)*

------
https://chatgpt.com/codex/tasks/task_e_689a5a93845083258109a7d0fb8424c0