### PR TITLE
Fix mobile search modal and enhance objective page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1294,3 +1294,5 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Rebuilt Nota Enriquecida editor blocks with drag handles, SortableJS reordering, hover controls, improved icon popover styles and ARIA labels. (PR nota-enriquecida-dnd-ui)
 - Renamed objetivo_view.html to objective_detail_old.html and added objective_detail.html with accompanying objective.css and objective.js implementing focus mode and milestone/resource CRUD.
 - Routed 'objetivo' blocks to objective_detail, updated block card links, and hardened objective.js with selector guards, ARIA synced progress and keyboard-accessible drag handles. (PR objective-routing-assets)
+
+- Hid mobile search modal and backdrop on desktop with CSS/JS hardening, removing pointer events and orphaned overlays. Added back navigation fallback, config modal stubs, JSON export and focus mode scroll lock with overlay fixes on objective detail. (PR objective-modal-focus)

--- a/crunevo/static/css/navbar.css
+++ b/crunevo/static/css/navbar.css
@@ -28,6 +28,20 @@
   #mobileSearchResults{ max-height: calc(100vh - 180px); overflow:auto; }
 }
 
+/* El modal móvil y su backdrop no existen visualmente en escritorio */
+@media (min-width: 992px) {
+  #mobileSearchModal,
+  #mobileSearchModal.show,
+  #mobileSearchModal + .modal-backdrop {
+    display: none !important;
+  }
+}
+
+/* Garantía extra: cuando esté oculto, que no capture eventos */
+#mobileSearchModal[aria-hidden="true"] {
+  pointer-events: none;
+}
+
 /* Enhanced Modern Responsive Navbar with Glassmorphism */
 .navbar-crunevo {
   background: rgba(102, 126, 234, 0.9);

--- a/crunevo/static/css/objective.css
+++ b/crunevo/static/css/objective.css
@@ -388,11 +388,13 @@
   box-shadow: var(--shadow-sm);
 }
 
+.focus-overlay[hidden] { display: none !important; }
 .focus-overlay {
   position: fixed;
   inset: 0;
   background: rgba(0, 0, 0, 0.8);
   z-index: 1000;
+  pointer-events: auto;
 }
 
 .focus-mode .objective-left,
@@ -861,6 +863,11 @@
   align-items: center;
   justify-content: center;
   padding: var(--gap);
+}
+
+.modal-backdrop,
+.modal__backdrop {
+  z-index: 1990;
 }
 
 .modal__backdrop {

--- a/crunevo/static/js/search.js
+++ b/crunevo/static/js/search.js
@@ -12,6 +12,44 @@ window.CRUNEVO.debounce = window.CRUNEVO.debounce || ((fn, ms = 250) => {
 });
 const debounce = window.CRUNEVO.debounce;
 
+(function () {
+  const modal = document.getElementById('mobileSearchModal');
+
+  function hideMobileSearchHard() {
+    if (!modal) return;
+    modal.classList.remove('show');
+    modal.setAttribute('aria-hidden', 'true');
+    modal.style.display = 'none';
+
+    document.querySelectorAll('.modal-backdrop').forEach(b => {
+      if (!document.body.classList.contains('modal-open')) {
+        b.remove();
+      }
+    });
+    document.body.classList.remove('modal-open');
+  }
+
+  function enforceModalPerViewport() {
+    if (!modal) return;
+    const isDesktop = window.matchMedia('(min-width: 992px)').matches;
+    if (isDesktop) hideMobileSearchHard();
+  }
+
+  enforceModalPerViewport();
+  window.addEventListener('resize', enforceModalPerViewport);
+
+  document.addEventListener('click', (e) => {
+    if (!modal) return;
+    const isDesktop = window.matchMedia('(min-width: 992px)').matches;
+    if (isDesktop && e.target.closest('[data-action="open-search"]')) {
+      e.preventDefault();
+      hideMobileSearchHard();
+    }
+  });
+
+  window.hideMobileSearchHard = hideMobileSearchHard;
+})();
+
 // Fallback for legacy templates still using data-action="open-search"
 document.addEventListener('click', (e) => {
   const trigger = e.target.closest('[data-action="open-search"]');
@@ -120,13 +158,6 @@ document.addEventListener('click', (e) => {
   if (!modalEl || !input || !list || !submit) return;
 
   const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
-    const hideOnDesktop = () => {
-      if (window.innerWidth >= 768) {
-        modal.hide();
-      }
-    };
-    window.addEventListener('resize', hideOnDesktop);
-    hideOnDesktop();
   const goToFullSearch = (q) => {
     modal.hide();
     window.location.href = `/search?q=${encodeURIComponent(q)}`;
@@ -183,7 +214,6 @@ document.addEventListener('click', (e) => {
   });
 
     modalEl.addEventListener('shown.bs.modal', () => {
-      hideOnDesktop();
       input.focus();
     });
 })();

--- a/crunevo/templates/personal_space/views/objective_detail.html
+++ b/crunevo/templates/personal_space/views/objective_detail.html
@@ -16,11 +16,11 @@
         <span class="sr-only">Volver</span>
       </button>
       <div class="objective-header__actions">
-        <button type="button" class="btn btn--secondary btn--sm" aria-label="Exportar objetivo">
+        <button type="button" class="btn btn--secondary btn--sm btn-export" aria-label="Exportar objetivo">
           <i class="bi bi-download" aria-hidden="true"></i>
           <span>Exportar</span>
         </button>
-        <button type="button" class="btn btn--secondary btn--sm" aria-label="Configurar objetivo">
+        <button type="button" class="btn btn--secondary btn--sm btn-config" aria-label="Configurar objetivo">
           <i class="bi bi-gear" aria-hidden="true"></i>
           <span>Configurar</span>
         </button>
@@ -191,6 +191,33 @@
     <i class="bi bi-x-lg" aria-hidden="true"></i>
     <span>Salir de Enfoque</span>
   </button>
+</div>
+
+<!-- Configurar objetivo -->
+<div class="modal" data-config-modal hidden role="dialog" aria-labelledby="config-modal-title" aria-hidden="true">
+  <div class="modal__backdrop" data-modal-backdrop></div>
+  <div class="modal__content">
+    <div class="modal__header">
+      <h3 id="config-modal-title" class="modal__title">Configurar objetivo</h3>
+      <button type="button" class="modal__close" data-modal-close aria-label="Cerrar modal">
+        <i class="bi bi-x" aria-hidden="true"></i>
+      </button>
+    </div>
+    <div class="modal__body">
+      <div class="form-group">
+        <label class="form-label">Acciones</label>
+        <div class="btn-row">
+          <button type="button" class="btn btn--secondary" data-action="rename-obj">Renombrar</button>
+          <button type="button" class="btn btn--secondary" data-action="archive-obj">Archivar</button>
+          <button type="button" class="btn btn--secondary" data-action="delete-obj">Eliminar</button>
+        </div>
+      </div>
+      <p class="form-help">Estas acciones operarán sobre este objetivo solamente.</p>
+    </div>
+    <div class="modal__actions">
+      <button type="button" class="btn btn--secondary" data-modal-close>Cerrar</button>
+    </div>
+  </div>
 </div>
 
 <!-- Modal para agregar/editar recursos -->


### PR DESCRIPTION
## Summary
- prevent mobile search modal/backdrop from intercepting clicks on desktop
- add back/export/config controls and safer focus mode to objective detail
- document objective-related changes in AGENTS log

## Testing
- `pre-commit run --files AGENTS.md crunevo/static/css/navbar.css crunevo/static/css/objective.css crunevo/static/js/objective.js crunevo/static/js/search.js crunevo/templates/personal_space/views/objective_detail.html`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689bb34b67008325a1df2e067de0c172