### PR TITLE
feat: persist objective via API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1296,3 +1296,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Routed 'objetivo' blocks to objective_detail, updated block card links, and hardened objective.js with selector guards, ARIA synced progress and keyboard-accessible drag handles. (PR objective-routing-assets)
 
 - Hid mobile search modal and backdrop on desktop with CSS/JS hardening, removing pointer events and orphaned overlays. Added back navigation fallback, config modal stubs, JSON export and focus mode scroll lock with overlay fixes on objective detail. (PR objective-modal-focus)
+- Added objective API endpoints with metadata persistence, preloaded hydration and frontend saving with rollback toast. (PR objective-persistence)

--- a/crunevo/templates/personal_space/views/objective_detail.html
+++ b/crunevo/templates/personal_space/views/objective_detail.html
@@ -4,6 +4,9 @@
 {% block head_extra %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/personal-space.css') }}?v=20240603">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/objective.css') }}?v=20240603">
+<script>
+  window.__OBJECTIVE_PRELOADED__ = {{ objective_json|tojson }};
+</script>
 <script defer src="{{ url_for('static', filename='js/objective.js') }}?v=20240603"></script>
 {% endblock %}
 

--- a/tests/test_personal_space_api.py
+++ b/tests/test_personal_space_api.py
@@ -110,3 +110,19 @@ def test_reorder_blocks(client, db_session, test_user):
         json={},
     )
     assert resp2.status_code == 200
+
+
+def test_objective_patch_persists(client, db_session, test_user):
+    block = Block(user_id=test_user.id, type="objetivo", title="Goal")
+    block.set_metadata({"objective": {"title": "Goal", "milestones": [], "resources": []}})
+    db_session.add(block)
+    db_session.commit()
+
+    login(client, test_user.username)
+    resp = client.patch(
+        f"/espacio-personal/api/objectives/{block.id}",
+        json={"title": "Nuevo", "milestones": []},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["objective"]["title"] == "Nuevo"

--- a/tests/test_personal_space_views.py
+++ b/tests/test_personal_space_views.py
@@ -1,3 +1,6 @@
+from crunevo.models.block import Block
+
+
 def login(client, username, password="secret"):
     return client.post("/login", data={"username": username, "password": password})
 
@@ -27,3 +30,15 @@ def test_apply_template_by_slug(client, test_user):
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["success"]
+
+
+def test_view_objective_detail(client, db_session, test_user):
+    block = Block(user_id=test_user.id, type="objetivo", title="Goal")
+    block.set_metadata({"objective": {"title": "Goal", "milestones": [], "resources": []}})
+    db_session.add(block)
+    db_session.commit()
+
+    login(client, test_user.username)
+    resp = client.get(f"/espacio-personal/bloque/{block.id}")
+    assert resp.status_code == 200
+    assert b"objective-page" in resp.data


### PR DESCRIPTION
## Summary
- add objective GET/PATCH endpoints persisting data in block metadata
- hydrate objective detail from preloaded metadata
- save objective fields via debounced PATCH with rollback on failure

## Testing
- `pytest tests/test_personal_space_views.py::test_view_objective_detail tests/test_personal_space_api.py::test_objective_patch_persists -q`


------
https://chatgpt.com/codex/tasks/task_e_689bb8fbf5d08325a5bba80ab8f9a643