### PR TITLE
feat: expose component-based personal space routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1299,3 +1299,5 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Simplified tarea_view.html with semantic-only markup, removing comments/attachments and keeping forms, lists and resource links. (PR tarea-template-simplify)
 - Added objective metadata persistence with GET/PATCH API endpoints, template hydration and debounced front-end saves with error rollback. (PR objective-persistence)
 - Rebuilt tarea_view.html with semantic markup, inline save toasts and backend subtasks/links CRUD stubs. (PR tarea-view-rebuild)
+
+- Added component-based personal space routes with new `/personal-space` dashboard, workspace, block detail view and API aliases for block CRUD operations. (PR personal-space-component-routes)

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -445,7 +445,11 @@ def create_app():
     from .routes.story_routes import stories_bp
     from .routes.developer_routes import developer_bp
     from .routes.backpack_routes import backpack_bp
-    from .routes.personal_space_routes import personal_space_bp
+    from .routes.personal_space_routes import (
+        personal_space_bp,
+        personal_space_new_bp,
+        personal_space_api_bp,
+    )
 
     from .api import init_api as init_api_blueprints
 
@@ -596,6 +600,8 @@ def create_app():
         app.register_blueprint(dashboard_bp)
         app.register_blueprint(settings_bp)
         app.register_blueprint(personal_space_bp)
+        app.register_blueprint(personal_space_new_bp)
+        app.register_blueprint(personal_space_api_bp)
         init_api_blueprints(app)
 
         from .routes.carrera_routes import carrera_bp

--- a/crunevo/templates/personal_space/block_detail.html
+++ b/crunevo/templates/personal_space/block_detail.html
@@ -1,0 +1,4 @@
+{% extends "base.html" %}
+{% block content %}
+  {% include component_template %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- add new /personal-space blueprint with dashboard, workspace and block detail views
- expose /api/personal-space/blocks CRUD aliases for component factory
- register new blueprints in app factory

## Testing
- `make fmt` *(fails: Failed to parse migrations/versions/personal_space_redesign_schema.py)*
- `make test` *(fails: Failed to parse migrations/versions/personal_space_redesign_schema.py)*

------
https://chatgpt.com/codex/tasks/task_e_689bf7507ec48325aad8b838105e2681