### PR TITLE
refactor personal space routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1299,3 +1299,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Simplified tarea_view.html with semantic-only markup, removing comments/attachments and keeping forms, lists and resource links. (PR tarea-template-simplify)
 - Added objective metadata persistence with GET/PATCH API endpoints, template hydration and debounced front-end saves with error rollback. (PR objective-persistence)
 - Rebuilt tarea_view.html with semantic markup, inline save toasts and backend subtasks/links CRUD stubs. (PR tarea-view-rebuild)
+- Introduced personal space API and routes under /personal-space with new models for blocks, templates and analytics; connected frontend components and tests. (PR personal-space-routing-api)

--- a/crunevo/app.py
+++ b/crunevo/app.py
@@ -445,7 +445,7 @@ def create_app():
     from .routes.story_routes import stories_bp
     from .routes.developer_routes import developer_bp
     from .routes.backpack_routes import backpack_bp
-    from .routes.personal_space_routes import personal_space_bp
+    from .routes.personal_space_routes import personal_space_bp, personal_space_api_bp
 
     from .api import init_api as init_api_blueprints
 
@@ -596,6 +596,7 @@ def create_app():
         app.register_blueprint(dashboard_bp)
         app.register_blueprint(settings_bp)
         app.register_blueprint(personal_space_bp)
+        app.register_blueprint(personal_space_api_bp)
         init_api_blueprints(app)
 
         from .routes.carrera_routes import carrera_bp

--- a/crunevo/models/__init__.py
+++ b/crunevo/models/__init__.py
@@ -45,6 +45,9 @@ from .group_mission import GroupMission, GroupMissionParticipant  # noqa: F401
 from .user_block import UserBlock  # noqa: F401
 from .personal_block import PersonalBlock  # noqa: F401
 from .block import Block  # noqa: F401
+from .personal_space_block import PersonalSpaceBlock  # noqa: F401
+from .personal_space_template import PersonalSpaceTemplate  # noqa: F401
+from .personal_space_analytics_event import PersonalSpaceAnalyticsEvent  # noqa: F401
 from .league import AcademicTeam, TeamMember, LeagueMonth, TeamAction  # noqa: F401
 from .knowledge_backpack import KnowledgeBackpack  # noqa: F401
 from .knowledge_backpack import LearningEntry  # noqa: F401

--- a/crunevo/models/personal_space_analytics_event.py
+++ b/crunevo/models/personal_space_analytics_event.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+import uuid
+from crunevo.extensions import db
+
+
+class PersonalSpaceAnalyticsEvent(db.Model):
+    __tablename__ = "personal_space_analytics_events"
+
+    id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    event_type = db.Column(db.String(100), nullable=False)
+    event_data = db.Column(db.JSON, default=dict)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    user = db.relationship("User", backref="personal_space_analytics_events")
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "event_type": self.event_type,
+            "event_data": self.event_data or {},
+            "created_at": self.created_at.isoformat(),
+        }

--- a/crunevo/models/personal_space_block.py
+++ b/crunevo/models/personal_space_block.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+import uuid
+from crunevo.extensions import db
+
+
+class PersonalSpaceBlock(db.Model):
+    __tablename__ = "personal_space_blocks"
+
+    id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    type = db.Column(db.String(50), nullable=False)
+    title = db.Column(db.String(255), nullable=False, default="")
+    content = db.Column(db.Text)
+    metadata_json = db.Column("metadata", db.JSON, default=dict)
+    order_index = db.Column(db.Integer, default=0)
+    status = db.Column(db.String(20), default="active")
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    user = db.relationship("User", backref="personal_space_blocks")
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "type": self.type,
+            "title": self.title,
+            "content": self.content,
+            "metadata": self.metadata_json or {},
+            "order_index": self.order_index,
+            "status": self.status,
+        }
+
+    def get_metadata(self):
+        return self.metadata_json or {}
+
+    def set_metadata(self, value):
+        self.metadata_json = value or {}
+
+
+PersonalSpaceBlock.metadata = property(
+    PersonalSpaceBlock.get_metadata, PersonalSpaceBlock.set_metadata
+)

--- a/crunevo/models/personal_space_template.py
+++ b/crunevo/models/personal_space_template.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+import uuid
+from crunevo.extensions import db
+
+
+class PersonalSpaceTemplate(db.Model):
+    __tablename__ = "personal_space_templates"
+
+    id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"))
+    name = db.Column(db.String(255), nullable=False)
+    description = db.Column(db.Text)
+    template_data = db.Column(db.JSON, nullable=False, default=dict)
+    category = db.Column(db.String(100))
+    is_public = db.Column(db.Boolean, default=False)
+    usage_count = db.Column(db.Integer, default=0)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    user = db.relationship("User", backref="personal_space_templates")
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+            "template_data": self.template_data or {},
+            "category": self.category,
+            "is_public": self.is_public,
+            "usage_count": self.usage_count,
+        }

--- a/crunevo/templates/auth/perfil.html
+++ b/crunevo/templates/auth/perfil.html
@@ -386,7 +386,7 @@
               <a href="{{ url_for('commerce.commerce_index') if 'commerce.commerce_index' in url_for.__globals__.get('current_app', {}).view_functions else '/tienda' }}" class="btn btn-outline-warning btn-sm">
                 <i class="bi bi-shop"></i> Tienda
               </a>
-              <a href="{{ url_for('personal_space.index') }}" class="btn btn-outline-primary btn-sm">
+              <a href="{{ url_for('personal_space.dashboard') }}" class="btn btn-outline-primary btn-sm">
                 <i class="bi bi-house-gear"></i>
                 Mi Espacio Personal
               </a>

--- a/crunevo/templates/components/launcher_menu.html
+++ b/crunevo/templates/components/launcher_menu.html
@@ -8,7 +8,7 @@
         <i class="bi bi-person-circle fs-3 text-primary"></i>
         <span class="small mt-1">Perfil</span>
       </a>
-      <a href="{{ url_for('personal_space.index') }}" class="launcher-item">
+    <a href="{{ url_for('personal_space.dashboard') }}" class="launcher-item">
         <i class="bi bi-house-heart fs-3 text-info"></i>
         <span class="small mt-1">Espacio</span>
       </a>

--- a/crunevo/templates/components/navbar.html
+++ b/crunevo/templates/components/navbar.html
@@ -84,7 +84,7 @@
                 <li><a class="dropdown-item" href="{{ url_for('saved.list_saved') }}">
                   <i class="bi bi-bookmark me-2"></i>Guardados
                 </a></li>
-                <li><a class="dropdown-item" href="{{ url_for('personal_space.index') }}">
+                <li><a class="dropdown-item" href="{{ url_for('personal_space.dashboard') }}">
                   <i class="bi bi-house-gear me-2"></i>Mi Espacio Personal
                 </a></li>
                 <li><hr class="dropdown-divider"></li>

--- a/crunevo/templates/components/sidebar_left_feed.html
+++ b/crunevo/templates/components/sidebar_left_feed.html
@@ -55,7 +55,7 @@
         </li>
 
         <li>
-          <a href="{{ url_for('personal_space.index') if 'personal_space.index' in url_for.__globals__.get('current_app', {}).view_functions else '/personal_space' }}" class="nav-link {{ 'active' if request.endpoint == 'personal_space.index' }}">
+          <a href="{{ url_for('personal_space.dashboard') if 'personal_space.dashboard' in url_for.__globals__.get('current_app', {}).view_functions else '/personal-space' }}" class="nav-link {{ 'active' if request.endpoint == 'personal_space.dashboard' }}">
             <i class="bi bi-house-gear"></i>
             <span class="fw-semibold">Mi Espacio Personal</span>
           </a>

--- a/crunevo/templates/personal_space/analytics_dashboard.html
+++ b/crunevo/templates/personal_space/analytics_dashboard.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% from 'personal_space/components/widgets/AnalyticsDashboard.html' import render_analytics_dashboard %}
+{% block title %}Personal Space Analytics{% endblock %}
+
+{% block content %}
+{{ render_analytics_dashboard() }}
+{% endblock %}

--- a/crunevo/templates/personal_space/block_detail.html
+++ b/crunevo/templates/personal_space/block_detail.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+{% block title %}Block Detail{% endblock %}
+
+{% block content %}
+<div id="block-detail" data-block-id="{{ block.id }}" data-block-type="{{ block.type }}">
+    <!-- The appropriate editor component will be loaded via JavaScript -->
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    console.log('Block detail loaded for', '{{ block.id }}');
+});
+</script>
+{% endblock %}

--- a/crunevo/templates/personal_space/components/blocks/KanbanBlock.html
+++ b/crunevo/templates/personal_space/components/blocks/KanbanBlock.html
@@ -935,7 +935,7 @@ window.KanbanBlock = {
     
     // Update card position on server
     updateCardPosition: async function(cardId, columnId, boardId) {
-        const response = await fetch(`/personal_space/kanban/${boardId}/cards/${cardId}/move`, {
+        const response = await fetch(`/api/personal-space/kanban/${boardId}/cards/${cardId}/move`, {
             method: 'PATCH',
             headers: {
                 'Content-Type': 'application/json',
@@ -961,7 +961,7 @@ window.KanbanBlock = {
 
 // Global functions for template usage
 window.openKanbanBoard = function(boardId) {
-    window.location.href = `/personal_space/kanban/${boardId}`;
+    window.location.href = `/personal-space/kanban/${boardId}`;
 };
 
 window.editKanban = function(boardId) {

--- a/crunevo/templates/personal_space/components/blocks/NoteBlock.html
+++ b/crunevo/templates/personal_space/components/blocks/NoteBlock.html
@@ -628,7 +628,7 @@ window.NoteBlock = {
     
     // Create note on server
     createNote: async function(noteData) {
-        const response = await fetch('/personal_space/blocks', {
+        const response = await fetch('/api/personal-space/blocks', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -724,7 +724,7 @@ window.NoteBlock = {
 
 // Global functions for template usage
 window.openNoteDetails = function(noteId) {
-    window.location.href = `/personal_space/blocks/${noteId}`;
+    window.location.href = `/personal-space/block/${noteId}`;
 };
 
 window.editNote = function(noteId) {

--- a/crunevo/templates/personal_space/components/blocks/ObjectiveBlock.html
+++ b/crunevo/templates/personal_space/components/blocks/ObjectiveBlock.html
@@ -766,7 +766,7 @@ window.ObjectiveBlock = {
     // Update objective progress
     updateObjectiveProgress: async function(objectiveId, progress) {
         try {
-            const response = await fetch(`/personal_space/objectives/${objectiveId}/progress`, {
+            const response = await fetch(`/api/personal-space/objectives/${objectiveId}/progress`, {
                 method: 'PATCH',
                 headers: {
                     'Content-Type': 'application/json',
@@ -845,11 +845,11 @@ window.ObjectiveBlock = {
 
 // Global functions for template usage
 window.openObjectiveDetails = function(objectiveId) {
-    window.location.href = `/personal_space/objectives/${objectiveId}`;
+    window.location.href = `/personal-space/objectives/${objectiveId}`;
 };
 
 window.editObjective = function(objectiveId) {
-    window.location.href = `/personal_space/objectives/${objectiveId}/edit`;
+    window.location.href = `/personal-space/objectives/${objectiveId}/edit`;
 };
 
 window.updateProgress = function(objectiveId) {
@@ -864,7 +864,7 @@ window.addObjective = async function(event) {
     const data = Object.fromEntries(formData.entries());
     
     try {
-        const response = await fetch('/personal_space/objectives', {
+        const response = await fetch('/api/personal-space/objectives', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',

--- a/crunevo/templates/personal_space/components/blocks/TaskBlock.html
+++ b/crunevo/templates/personal_space/components/blocks/TaskBlock.html
@@ -550,7 +550,7 @@ window.TaskBlock = {
     
     // Update task status on server
     updateTaskStatus: async function(taskId, status) {
-        const response = await fetch(`/personal_space/blocks/${taskId}/status`, {
+        const response = await fetch(`/api/personal-space/blocks/${taskId}`, {
             method: 'PATCH',
             headers: {
                 'Content-Type': 'application/json',
@@ -615,7 +615,7 @@ window.TaskBlock = {
     
     // Create task on server
     createTask: async function(taskData) {
-        const response = await fetch('/personal_space/blocks', {
+        const response = await fetch('/api/personal-space/blocks', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -658,7 +658,7 @@ window.TaskBlock = {
 
 // Global functions for template usage
 window.openTaskDetails = function(taskId) {
-    window.location.href = `/personal_space/blocks/${taskId}`;
+    window.location.href = `/personal-space/block/${taskId}`;
 };
 
 window.editTask = function(taskId) {

--- a/crunevo/templates/personal_space/components/layout/DashboardLayout.html
+++ b/crunevo/templates/personal_space/components/layout/DashboardLayout.html
@@ -938,11 +938,11 @@ window.toggleDashboardView = function() {
 };
 
 window.openBlock = function(blockId) {
-    window.location.href = `/personal_space/blocks/${blockId}`;
+    window.location.href = `/personal-space/block/${blockId}`;
 };
 
 window.viewAllActivity = function() {
-    window.location.href = '/personal_space/activity';
+    window.location.href = '/personal-space/activity';
 };
 
 window.saveQuickNote = async function() {
@@ -955,7 +955,7 @@ window.saveQuickNote = async function() {
     }
     
     try {
-        const response = await fetch('/personal_space/notes/quick', {
+        const response = await fetch('/api/personal-space/notes/quick', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',

--- a/crunevo/templates/personal_space/components/layout/WorkspaceLayout.html
+++ b/crunevo/templates/personal_space/components/layout/WorkspaceLayout.html
@@ -1174,7 +1174,7 @@ window.WorkspaceLayout = {
     // Create block in workspace
     createBlockInWorkspace: async function(blockType, gridPos) {
         try {
-            const response = await fetch('/personal_space/blocks', {
+            const response = await fetch('/api/personal-space/blocks', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -1228,7 +1228,7 @@ window.WorkspaceLayout = {
     // Update block position on server
     updateBlockPosition: async function(blockId, gridPos) {
         try {
-            await fetch(`/personal_space/blocks/${blockId}/position`, {
+            await fetch(`/api/personal-space/blocks/${blockId}/position`, {
                 method: 'PATCH',
                 headers: {
                     'Content-Type': 'application/json',
@@ -1265,7 +1265,7 @@ window.WorkspaceLayout = {
         }));
         
         try {
-            await fetch(`/personal_space/workspaces/${this.currentWorkspaceId}`, {
+            await fetch(`/api/personal-space/workspaces/${this.currentWorkspaceId}`, {
                 method: 'PATCH',
                 headers: {
                     'Content-Type': 'application/json',

--- a/crunevo/templates/personal_space/components/widgets/AnalyticsDashboard.html
+++ b/crunevo/templates/personal_space/components/widgets/AnalyticsDashboard.html
@@ -852,7 +852,7 @@ window.AnalyticsDashboard = {
     // Load analytics data
     loadAnalyticsData: async function() {
         try {
-            const response = await fetch(`/personal_space/analytics?period=${this.currentPeriod}`);
+            const response = await fetch(`/api/personal-space/analytics/productivity?period=${this.currentPeriod}`);
             if (response.ok) {
                 const data = await response.json();
                 this.updateMetrics(data);
@@ -1044,7 +1044,7 @@ window.AnalyticsDashboard = {
     // Export analytics
     exportAnalytics: async function() {
         try {
-            const response = await fetch(`/personal_space/analytics/export?period=${this.currentPeriod}`);
+            const response = await fetch(`/api/personal-space/analytics/export?period=${this.currentPeriod}`);
             if (response.ok) {
                 const blob = await response.blob();
                 const url = window.URL.createObjectURL(blob);

--- a/crunevo/templates/personal_space/components/widgets/BlockFactory.html
+++ b/crunevo/templates/personal_space/components/widgets/BlockFactory.html
@@ -1412,7 +1412,7 @@ Completado</textarea>
             }
             
             // Send to server
-            const response = await fetch('/personal_space/blocks/create', {
+            const response = await fetch('/api/personal-space/blocks', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',

--- a/crunevo/templates/personal_space/components/widgets/TemplateGallery.html
+++ b/crunevo/templates/personal_space/components/widgets/TemplateGallery.html
@@ -1028,7 +1028,7 @@ window.TemplateGallery = {
     // Load templates
     loadTemplates: async function() {
         try {
-            const response = await fetch('/personal_space/templates');
+            const response = await fetch('/api/personal-space/templates');
             if (response.ok) {
                 const data = await response.json();
                 this.renderTemplates(data);
@@ -1230,7 +1230,7 @@ window.TemplateGallery = {
         };
         
         try {
-            const response = await fetch('/personal_space/templates', {
+            const response = await fetch('/api/personal-space/templates', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -1263,7 +1263,7 @@ window.TemplateGallery = {
     // Preview template
     previewTemplate: async function(templateId) {
         try {
-            const response = await fetch(`/personal_space/templates/${templateId}`);
+            const response = await fetch(`/api/personal-space/templates/${templateId}`);
             if (response.ok) {
                 const template = await response.json();
                 this.showTemplatePreview(template);
@@ -1324,7 +1324,7 @@ window.TemplateGallery = {
     // Use template
     useTemplate: async function(templateId) {
         try {
-            const response = await fetch(`/personal_space/templates/${templateId}/use`, {
+            const response = await fetch(`/api/personal-space/templates/${templateId}/use`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -1336,7 +1336,7 @@ window.TemplateGallery = {
                 const result = await response.json();
                 
                 // Redirect to new workspace
-                window.location.href = `/personal_space/workspace/${result.workspace_id}`;
+                window.location.href = `/personal-space/workspace/${result.workspace_id}`;
             } else {
                 throw new Error('Failed to use template');
             }
@@ -1362,7 +1362,7 @@ window.TemplateGallery = {
     
     // Share template
     shareTemplate: function(templateId) {
-        const url = `${window.location.origin}/personal_space/templates/${templateId}`;
+        const url = `${window.location.origin}/personal-space/templates/${templateId}`;
         
         if (navigator.share) {
             navigator.share({
@@ -1380,7 +1380,7 @@ window.TemplateGallery = {
     // Favorite template
     favoriteTemplate: async function(templateId) {
         try {
-            await fetch(`/personal_space/templates/${templateId}/favorite`, {
+            await fetch(`/api/personal-space/templates/${templateId}/favorite`, {
                 method: 'POST',
                 headers: {
                     'X-CSRFToken': this.getCSRFToken()
@@ -1404,7 +1404,7 @@ window.TemplateGallery = {
         }
         
         try {
-            const response = await fetch(`/personal_space/templates/${templateId}`, {
+            const response = await fetch(`/api/personal-space/templates/${templateId}`, {
                 method: 'DELETE',
                 headers: {
                     'X-CSRFToken': this.getCSRFToken()
@@ -1456,7 +1456,7 @@ window.TemplateGallery = {
     // Create imported template
     createImportedTemplate: async function(templateData) {
         try {
-            const response = await fetch('/personal_space/templates/import', {
+            const response = await fetch('/api/personal-space/templates/import', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',

--- a/crunevo/templates/personal_space/dashboard.html
+++ b/crunevo/templates/personal_space/dashboard.html
@@ -737,7 +737,7 @@ window.PersonalSpaceDashboard = {
     // Load dashboard data
     loadDashboardData: async function() {
         try {
-            const response = await fetch('/personal_space/dashboard/data');
+            const response = await fetch('/api/personal-space/analytics/productivity');
             if (response.ok) {
                 const data = await response.json();
                 this.updateDashboardStats(data.stats);
@@ -803,7 +803,7 @@ window.PersonalSpaceDashboard = {
         if (!content) return;
         
         try {
-            const response = await fetch('/personal_space/quick_notes', {
+            const response = await fetch('/api/personal-space/quick_notes', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -834,7 +834,7 @@ window.PersonalSpaceDashboard = {
     // Load recent quick notes
     loadRecentQuickNotes: async function() {
         try {
-            const response = await fetch('/personal_space/quick_notes/recent');
+            const response = await fetch('/api/personal-space/quick_notes/recent');
             if (response.ok) {
                 const notes = await response.json();
                 this.renderRecentQuickNotes(notes);
@@ -911,7 +911,7 @@ window.refreshTodaysFocus = function() {
 };
 
 window.viewWeeklyDetails = function() {
-    window.location.href = '/personal_space/analytics?period=week';
+    window.location.href = '/personal-space/analytics?period=week';
 };
 
 window.toggleAnalytics = function() {

--- a/crunevo/templates/personal_space/index.html
+++ b/crunevo/templates/personal_space/index.html
@@ -796,7 +796,7 @@ window.PersonalSpaceIndex = {
     // Load user statistics
     loadUserStats: async function() {
         try {
-            const response = await fetch('/personal_space/stats');
+            const response = await fetch('/api/personal-space/stats');
             if (response.ok) {
                 const stats = await response.json();
                 this.updateUserStats(stats);
@@ -912,7 +912,7 @@ window.PersonalSpaceIndex = {
                 
             case 'explore-workspace':
                 // Navigate to workspace
-                window.location.href = '/personal_space/workspace';
+                window.location.href = '/personal-space/workspace';
                 break;
                 
             default:

--- a/crunevo/templates/personal_space/templates.html
+++ b/crunevo/templates/personal_space/templates.html
@@ -943,7 +943,7 @@ window.PersonalSpaceTemplates = {
                 ...this.currentFilters
             });
             
-            const response = await fetch(`/personal_space/templates/data?${params}`);
+            const response = await fetch(`/api/personal-space/templates?${params}`);
             if (response.ok) {
                 const data = await response.json();
                 this.renderTemplates(data.templates);
@@ -1126,7 +1126,7 @@ window.PersonalSpaceTemplates = {
     // Use template
     useTemplate: async function(templateId) {
         try {
-            const response = await fetch(`/personal_space/templates/${templateId}/use`, {
+            const response = await fetch(`/api/personal-space/templates/${templateId}/use`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -1140,7 +1140,7 @@ window.PersonalSpaceTemplates = {
                 
                 // Redirect to workspace or dashboard
                 setTimeout(() => {
-                    window.location.href = result.redirect_url || '/personal_space/workspace';
+                    window.location.href = result.redirect_url || '/personal-space/workspace';
                 }, 1000);
             } else {
                 throw new Error('Failed to use template');
@@ -1154,7 +1154,7 @@ window.PersonalSpaceTemplates = {
     // Preview template
     previewTemplate: async function(templateId) {
         try {
-            const response = await fetch(`/personal_space/templates/${templateId}`);
+            const response = await fetch(`/api/personal-space/templates/${templateId}`);
             if (response.ok) {
                 const template = await response.json();
                 this.showTemplatePreview(template);
@@ -1174,7 +1174,7 @@ window.PersonalSpaceTemplates = {
     // Toggle favorite
     toggleFavorite: async function(templateId) {
         try {
-            const response = await fetch(`/personal_space/templates/${templateId}/favorite`, {
+            const response = await fetch(`/api/personal-space/templates/${templateId}/favorite`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',

--- a/crunevo/templates/personal_space/views/bloque_personalizado_view.html
+++ b/crunevo/templates/personal_space/views/bloque_personalizado_view.html
@@ -300,7 +300,7 @@
             <button class="btn btn-primary" onclick="editSubject()">
                 <i class="bi bi-gear"></i> Configurar
             </button>
-            <a href="{{ url_for('personal_space.index') }}" class="btn btn-outline-secondary">
+            <a href="{{ url_for('personal_space.dashboard') }}" class="btn btn-outline-secondary">
                 <i class="bi bi-arrow-left"></i> Volver
             </a>
         </div>

--- a/crunevo/templates/personal_space/views/lista_view.html
+++ b/crunevo/templates/personal_space/views/lista_view.html
@@ -509,7 +509,7 @@
                 <button class="modern-btn modern-btn-primary" onclick="editLista()">
                     <i class="bi bi-gear"></i> Configurar
                 </button>
-                <a href="{{ url_for('personal_space.index') }}" class="modern-btn modern-btn-outline">
+                <a href="{{ url_for('personal_space.dashboard') }}" class="modern-btn modern-btn-outline">
                     <i class="bi bi-arrow-left"></i> Volver
                 </a>
             </div>

--- a/crunevo/templates/personal_space/views/meta_view.html
+++ b/crunevo/templates/personal_space/views/meta_view.html
@@ -424,7 +424,7 @@
             <button class="modern-btn modern-btn-primary" onclick="editMeta()">
                 <i class="bi bi-gear"></i> Configurar
             </button>
-            <a href="{{ url_for('personal_space.index') }}" class="modern-btn modern-btn-secondary">
+            <a href="{{ url_for('personal_space.dashboard') }}" class="modern-btn modern-btn-secondary">
                 <i class="bi bi-arrow-left"></i> Volver
             </a>
         </div>

--- a/crunevo/templates/personal_space/views/recordatorio_view.html
+++ b/crunevo/templates/personal_space/views/recordatorio_view.html
@@ -482,7 +482,7 @@
             <button class="modern-btn modern-btn-primary" onclick="editRecordatorio()">
                 <i class="bi bi-gear"></i> Configurar
             </button>
-            <a href="{{ url_for('personal_space.index') }}" class="modern-btn modern-btn-secondary">
+            <a href="{{ url_for('personal_space.dashboard') }}" class="modern-btn modern-btn-secondary">
                 <i class="bi bi-arrow-left"></i> Volver
             </a>
         </div>

--- a/crunevo/templates/personal_space/views/search_view.html
+++ b/crunevo/templates/personal_space/views/search_view.html
@@ -537,7 +537,7 @@
                         <i class="bi bi-bookmark"></i>
                         Guardar Búsqueda
                     </button>
-                    <a href="{{ url_for('personal_space.index') }}" class="modern-btn modern-btn-secondary">
+                    <a href="{{ url_for('personal_space.dashboard') }}" class="modern-btn modern-btn-secondary">
                         <i class="bi bi-arrow-left"></i>
                         Volver al Dashboard
                     </a>

--- a/crunevo/templates/personal_space/views/settings_view.html
+++ b/crunevo/templates/personal_space/views/settings_view.html
@@ -347,7 +347,7 @@ input:checked + .toggle-slider:before {
                             <i class="bi bi-check-circle"></i>
                             Guardar Cambios
                         </button>
-                        <a href="{{ url_for('personal_space.index') }}" class="btn btn-secondary">
+                        <a href="{{ url_for('personal_space.dashboard') }}" class="btn btn-secondary">
                             <i class="bi bi-arrow-left"></i>
                             Volver al Dashboard
                         </a>

--- a/crunevo/templates/personal_space/views/statistics_view.html
+++ b/crunevo/templates/personal_space/views/statistics_view.html
@@ -223,7 +223,7 @@
                         <i class="bi bi-download me-2"></i>
                         Exportar Reporte
                     </button>
-                    <a href="{{ url_for('personal_space.index') }}" class="btn btn-light">
+                    <a href="{{ url_for('personal_space.dashboard') }}" class="btn btn-light">
                         <i class="bi bi-arrow-left me-2"></i>
                         Volver al Dashboard
                     </a>

--- a/crunevo/templates/personal_space/views/tarea_view.html
+++ b/crunevo/templates/personal_space/views/tarea_view.html
@@ -7,7 +7,7 @@
 {% block content %}
 <header id="task-header">
   <nav aria-label="Navegación">
-    <a href="{{ request.referrer or (url_for('personal_space.index') if app and 'personal_space.index' in app.view_functions else '#') }}">Volver</a>
+    <a href="{{ request.referrer or (url_for('personal_space.dashboard') if app and 'personal_space.dashboard' in app.view_functions else '#') }}">Volver</a>
     <a href="{{ url_for('personal_space.settings_view') if app and 'personal_space.settings_view' in app.view_functions else '#' }}">Configurar</a>
     <a href="{{ url_for('personal_space.link_note', block_id=block.id) if app and 'personal_space.link_note' in app.view_functions else '#' }}">Vincular Apunte</a>
     <a href="{{ url_for('personal_space.link_forum', block_id=block.id) if app and 'personal_space.link_forum' in app.view_functions else '#' }}">Vincular Foro</a>

--- a/crunevo/templates/personal_space/views/templates_view.html
+++ b/crunevo/templates/personal_space/views/templates_view.html
@@ -378,7 +378,7 @@
                             <i class="bi bi-plus-circle"></i>
                             Crear Plantilla
                         </button>
-                        <a href="{{ url_for('personal_space.index') }}" class="btn btn-secondary">
+                        <a href="{{ url_for('personal_space.dashboard') }}" class="btn btn-secondary">
                             <i class="bi bi-arrow-left"></i>
                             Volver al Dashboard
                         </a>
@@ -427,7 +427,7 @@
                         <button class="btn px-4 py-3 rounded-3 fw-semibold" style="background: linear-gradient(135deg, #8b5cf6, #7c3aed); color: white; border: none; box-shadow: 0 8px 20px rgba(139, 92, 246, 0.3); transition: all 0.3s ease;" onmouseover="this.style.transform='translateY(-3px) scale(1.05)'; this.style.boxShadow='0 12px 30px rgba(139, 92, 246, 0.4)'" onmouseout="this.style.transform='translateY(0) scale(1)'; this.style.boxShadow='0 8px 20px rgba(139, 92, 246, 0.3)'" onclick="createCustomTemplate()">
                             <i class="bi bi-plus-circle me-2"></i>Crear Plantilla
                         </button>
-                        <a href="{{ url_for('personal_space.index') }}" class="btn btn-outline-secondary px-4 py-3 rounded-3 fw-semibold" style="border: 2px solid rgba(139, 92, 246, 0.3); color: #8b5cf6; transition: all 0.3s ease;" onmouseover="this.style.background='rgba(139, 92, 246, 0.1)'; this.style.transform='translateY(-2px)'" onmouseout="this.style.background='transparent'; this.style.transform='translateY(0)'">
+                        <a href="{{ url_for('personal_space.dashboard') }}" class="btn btn-outline-secondary px-4 py-3 rounded-3 fw-semibold" style="border: 2px solid rgba(139, 92, 246, 0.3); color: #8b5cf6; transition: all 0.3s ease;" onmouseover="this.style.background='rgba(139, 92, 246, 0.1)'; this.style.transform='translateY(-2px)'" onmouseout="this.style.background='transparent'; this.style.transform='translateY(0)'">
                             <i class="bi bi-arrow-left me-2"></i>Volver al Dashboard
                         </a>
                     </div>

--- a/crunevo/templates/personal_space/views/trash_view.html
+++ b/crunevo/templates/personal_space/views/trash_view.html
@@ -424,7 +424,7 @@
                             <i class="bi bi-trash"></i>
                             Vaciar Papelera
                         </button>
-                        <a href="{{ url_for('personal_space.index') }}" class="btn btn-secondary">
+                        <a href="{{ url_for('personal_space.dashboard') }}" class="btn btn-secondary">
                             <i class="bi bi-arrow-left"></i>
                             Volver al Dashboard
                         </a>
@@ -520,7 +520,7 @@
                 <i class="bi bi-trash"></i>
                 <h4>La papelera está vacía</h4>
                 <p>No hay elementos eliminados para mostrar.</p>
-                <a href="{{ url_for('personal_space.index') }}" class="btn btn-primary">
+                <a href="{{ url_for('personal_space.dashboard') }}" class="btn btn-primary">
                     <i class="bi bi-plus"></i>
                     Crear Nuevo Bloque
                 </a>

--- a/crunevo/templates/personal_space/views/under_construction.html
+++ b/crunevo/templates/personal_space/views/under_construction.html
@@ -3,6 +3,6 @@
 <div class="container py-5 text-center">
   <h2 class="mb-3">{{ block.title or 'Herramienta en desarrollo' }}</h2>
   <p>Esta función estará disponible pronto.</p>
-  <a href="{{ url_for('personal_space.index') }}" class="btn btn-primary mt-3">Volver</a>
+  <a href="{{ url_for('personal_space.dashboard') }}" class="btn btn-primary mt-3">Volver</a>
 </div>
 {% endblock %}

--- a/crunevo/templates/personal_space/workspace.html
+++ b/crunevo/templates/personal_space/workspace.html
@@ -880,7 +880,7 @@ window.PersonalSpaceWorkspace = {
     // Create new block
     createBlock: async function(blockData) {
         try {
-            const response = await fetch('/personal_space/blocks', {
+            const response = await fetch('/api/personal-space/blocks', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -976,7 +976,7 @@ window.PersonalSpaceWorkspace = {
     // Load workspace data
     loadWorkspaceData: async function() {
         try {
-            const response = await fetch('/personal_space/workspace/data');
+            const response = await fetch('/api/personal-space/blocks');
             if (response.ok) {
                 const data = await response.json();
                 this.renderWorkspaceBlocks(data.blocks);
@@ -1073,7 +1073,7 @@ window.PersonalSpaceWorkspace = {
         this.setSaveStatus('saving');
         
         try {
-            const response = await fetch('/personal_space/workspace/save', {
+            const response = await fetch('/api/personal-space/blocks/reorder', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',

--- a/tests/test_personal_space_views.py
+++ b/tests/test_personal_space_views.py
@@ -5,13 +5,13 @@ def login(client, username, password="secret"):
 def test_personal_space_views(client, test_user):
     login(client, test_user.username)
     paths = [
-        "/espacio-personal/",
-        "/espacio-personal/calendario",
-        "/espacio-personal/estadisticas",
-        "/espacio-personal/plantillas",
-        "/espacio-personal/configuracion",
-        "/espacio-personal/buscar",
-        "/espacio-personal/papelera",
+        "/personal-space/",
+        "/personal-space/calendario",
+        "/personal-space/estadisticas",
+        "/personal-space/templates",
+        "/personal-space/configuracion",
+        "/personal-space/buscar",
+        "/personal-space/papelera",
     ]
     for path in paths:
         resp = client.get(path, environ_overrides={"wsgi.url_scheme": "https"})
@@ -21,7 +21,7 @@ def test_personal_space_views(client, test_user):
 def test_apply_template_by_slug(client, test_user):
     login(client, test_user.username)
     resp = client.post(
-        "/espacio-personal/plantillas/aplicar/university-student",
+        "/personal-space/templates/aplicar/university-student",
         environ_overrides={"wsgi.url_scheme": "https"},
     )
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add personal space block, template, and analytics models
- implement new /personal-space routes and API endpoints
- update templates and JS to use /api/personal-space paths

## Testing
- `pytest tests/test_personal_space_views.py::test_personal_space_views -vv -s` *(fails: assert 500 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_689bf7507ec48325aad8b838105e2681