### PR TITLE
Fix personal space migration downgrade and cleanups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1300,3 +1300,5 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Added objective metadata persistence with GET/PATCH API endpoints, template hydration and debounced front-end saves with error rollback. (PR objective-persistence)
 - Rebuilt tarea_view.html with semantic markup, inline save toasts and backend subtasks/links CRUD stubs. (PR tarea-view-rebuild)
 - Introduced personal space API and routes under /personal-space with new models for blocks, templates and analytics; connected frontend components and tests. (PR personal-space-routing-api)
+
+- Fixed syntax error in `personal_space_redesign_schema` downgrade by dropping indexes and tables properly, replaced lambda stub in dashboard with helper function, and updated template boolean filters to use `is_(True)`. (PR personal-space-migration-fix)

--- a/crunevo/routes/personal_space_routes.py
+++ b/crunevo/routes/personal_space_routes.py
@@ -4,7 +4,6 @@ from types import SimpleNamespace
 from flask import Blueprint, jsonify, render_template, request
 from flask_login import current_user, login_required
 
-from crunevo.extensions import db
 from crunevo.models import (
     PersonalSpaceBlock,
     PersonalSpaceTemplate,
@@ -53,10 +52,15 @@ def dashboard():
         productivity_trend=0,
     )
     recent_blocks = blocks[:5]
-    moment_stub = lambda: SimpleNamespace(
-        hour=datetime.utcnow().hour,
-        format=lambda fmt=None: datetime.utcnow().strftime("%Y-%m-%d"),
-    )
+    def moment_stub():
+        def _format(fmt: str | None = None) -> str:
+            return datetime.utcnow().strftime("%Y-%m-%d")
+
+        return SimpleNamespace(
+            hour=datetime.utcnow().hour,
+            format=_format,
+        )
+
     return render_template(
         "personal_space/dashboard.html",
         user=current_user,

--- a/crunevo/services/template_service.py
+++ b/crunevo/services/template_service.py
@@ -5,8 +5,7 @@ from crunevo.extensions import db
 from crunevo.models import PersonalSpaceTemplate, PersonalSpaceBlock
 from crunevo.services.block_service import BlockService
 from crunevo.services.validation_service import ValidationService
-from crunevo.services.cache_service import CacheService, CacheInvalidator
-import uuid
+from crunevo.services.cache_service import CacheInvalidator
 
 
 class TemplateService:
@@ -89,7 +88,7 @@ class TemplateService:
             and_(
                 PersonalSpaceTemplate.id == template_id,
                 or_(
-                    PersonalSpaceTemplate.is_public == True,
+                    PersonalSpaceTemplate.is_public.is_(True),
                     PersonalSpaceTemplate.user_id == user_id
                 )
             )
@@ -132,7 +131,7 @@ class TemplateService:
             query = query.filter(
                 or_(
                     PersonalSpaceTemplate.user_id == user_id,
-                    PersonalSpaceTemplate.is_public == True
+                      PersonalSpaceTemplate.is_public.is_(True)
                 )
             )
         else:
@@ -150,7 +149,7 @@ class TemplateService:
             PersonalSpaceTemplate.category,
             db.func.count(PersonalSpaceTemplate.id).label('count')
         ).filter(
-            PersonalSpaceTemplate.is_public == True
+            PersonalSpaceTemplate.is_public.is_(True)
         ).group_by(PersonalSpaceTemplate.category).all()
         
         return [
@@ -263,7 +262,7 @@ class TemplateService:
             and_(
                 or_(
                     PersonalSpaceTemplate.user_id == user_id,
-                    PersonalSpaceTemplate.is_public == True
+                    PersonalSpaceTemplate.is_public.is_(True)
                 ),
                 or_(
                     PersonalSpaceTemplate.name.ilike(search_pattern),

--- a/migrations/versions/personal_space_redesign_schema.py
+++ b/migrations/versions/personal_space_redesign_schema.py
@@ -100,7 +100,19 @@ def upgrade():
 
 def downgrade():
     # Drop tables in reverse order
+    op.drop_index('idx_personal_space_analytics_created_at', table_name='personal_space_analytics_events')
+    op.drop_index('idx_personal_space_analytics_event_type', table_name='personal_space_analytics_events')
+    op.drop_index('idx_personal_space_analytics_user_id', table_name='personal_space_analytics_events')
     op.drop_table('personal_space_analytics_events')
+
     op.drop_table('personal_space_block_attachments')
+
     op.drop_table('personal_space_templates')
-    op.drop_table('
+
+    op.drop_index('idx_personal_space_blocks_metadata', table_name='personal_space_blocks')
+    op.drop_index('idx_personal_space_blocks_updated_at', table_name='personal_space_blocks')
+    op.drop_index('idx_personal_space_blocks_order', table_name='personal_space_blocks')
+    op.drop_index('idx_personal_space_blocks_status', table_name="personal_space_blocks")
+    op.drop_index('idx_personal_space_blocks_type', table_name='personal_space_blocks')
+    op.drop_index('idx_personal_space_blocks_user_id', table_name='personal_space_blocks')
+    op.drop_table('personal_space_blocks')


### PR DESCRIPTION
## Summary
- finalize downgrade for personal space redesign migration, dropping indexes and tables
- remove lambda stub in personal space dashboard with helper function
- use SQLAlchemy `is_(True)` for template visibility checks

## Testing
- `make test` *(fails: 53 lint errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_689c1d79bd148325b2b497da6dfc2fa0