### PR TITLE
Fix multiple Alembic heads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1303,3 +1303,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Fixed syntax error in personal_space_redesign_schema migration by completing downgrade and dropping related indexes to ensure Fly deployment succeeds. (PR personal-space-migration-fix)
 
 - Updated personal space API tests to use /api/personal-space paths, extended moment stub to accept datetime, simplified reorder logic and marked view test as skip. (PR personal-space-tests-fix)
+- Merged Alembic heads e1e5b8d0853a and migrate_personal_space_data into 5007130f0224 to resolve multiple head revisions.

--- a/migrations/versions/5007130f0224_merge_heads.py
+++ b/migrations/versions/5007130f0224_merge_heads.py
@@ -1,0 +1,24 @@
+"""merge heads
+
+Revision ID: 5007130f0224
+Revises: e1e5b8d0853a, migrate_personal_space_data
+Create Date: 2025-08-13 06:04:20.648875
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '5007130f0224'
+down_revision = ('e1e5b8d0853a', 'migrate_personal_space_data')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
## Summary
- merge migrations e1e5b8d0853a and migrate_personal_space_data into 5007130f0224 to resolve conflicting heads
- document migration merge in AGENTS

## Testing
- `make test` *(fails: F401 unused imports in repository)*

------
https://chatgpt.com/codex/tasks/task_e_689c2a5c494c8325a75ca0f5780e1647