### PR TITLE
Handle missing personal space tables gracefully

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1304,3 +1304,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 
 - Updated personal space API tests to use /api/personal-space paths, extended moment stub to accept datetime, simplified reorder logic and marked view test as skip. (PR personal-space-tests-fix)
 - Merged Alembic heads e1e5b8d0853a and migrate_personal_space_data into 5007130f0224 to resolve multiple head revisions.
+- Added table existence checks and error handling in personal space routes to avoid 500 errors when tables are missing. (PR personal-space-table-check)


### PR DESCRIPTION
## Summary
- guard personal space dashboard and API routes with table existence checks
- log and fail gracefully when personal space tables are missing

## Testing
- `make fmt`
- `make test` *(fails: ruff F401 unused imports across repository)*
- `pytest -q` *(fails: test_migrations.py::test_alembic_upgrade, test_objective_persistence.py::test_objective_view_uses_template, test_objective_persistence.py::test_patch_objective_persists)*

------
https://chatgpt.com/codex/tasks/task_e_689c2cfaea088325a18afcc6922aa994