### PR TITLE
fix: load personal space dashboard styles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1306,3 +1306,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Merged Alembic heads e1e5b8d0853a and migrate_personal_space_data into 5007130f0224 to resolve multiple head revisions.
 - Added table existence checks and error handling in personal space routes to avoid 500 errors when tables are missing. (PR personal-space-table-check)
 - Fixed /personal-space/ 500 by correcting template links, removing invalid macros and adding dashboard view test. (PR personal-space-dashboard-fix)
+- Restored Personal Space dashboard styling by linking the stylesheet through the correct head block and adding ARIA labels to icon-only buttons. (PR personal-space-dashboard-style-fix)

--- a/crunevo/templates/personal_space/dashboard.html
+++ b/crunevo/templates/personal_space/dashboard.html
@@ -7,11 +7,12 @@
 
 {% block title %}Personal Space - Dashboard{% endblock %}
 
-{% block extra_head %}
+{% block head_extra %}
 <!-- Chart.js for analytics -->
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <!-- Sortable.js for drag and drop -->
 <script src="https://cdn.jsdelivr.net/npm/sortablejs@latest/Sortable.min.js"></script>
+<link rel="stylesheet" href="{{ url_for('static', filename='css/personal-space.css') }}">
 <!-- Custom CSS -->
 <style>
 /* Dashboard Specific Styles */
@@ -475,9 +476,9 @@
                     </button>
                     
                     <div class="dropdown">
-                        <button class="btn quick-action-btn secondary dropdown-toggle" 
-                                type="button" 
-                                data-bs-toggle="dropdown">
+                        <button class="btn quick-action-btn secondary dropdown-toggle"
+                                type="button"
+                                data-bs-toggle="dropdown" title="Más opciones" aria-label="Más opciones">
                             <i class="bi bi-three-dots"></i>
                         </button>
                         <ul class="dropdown-menu">
@@ -558,7 +559,7 @@
                             Enfoque de Hoy
                         </h3>
                         <div class="section-actions">
-                            <button type="button" class="btn btn-sm btn-outline-primary" onclick="refreshTodaysFocus()">
+                            <button type="button" class="btn btn-sm btn-outline-primary" onclick="refreshTodaysFocus()" title="Actualizar enfoque" aria-label="Actualizar enfoque">
                                 <i class="bi bi-arrow-clockwise"></i>
                             </button>
                         </div>
@@ -691,11 +692,11 @@
 </div>
 
 <!-- Floating Action Button -->
-<button type="button" 
-        class="floating-action-btn" 
-        data-bs-toggle="modal" 
-        data-bs-target="#block-factory-modal" 
-        title="Crear nuevo bloque">
+<button type="button"
+        class="floating-action-btn"
+        data-bs-toggle="modal"
+        data-bs-target="#block-factory-modal"
+        title="Crear nuevo bloque" aria-label="Crear nuevo bloque">
     <i class="bi bi-plus"></i>
 </button>
 


### PR DESCRIPTION
## Summary
- ensure personal space dashboard template loads its CSS through `head_extra`
- add descriptive titles for icon-only buttons to improve accessibility
- document dashboard style fix in AGENTS log

## Testing
- `python -m pytest tests/test_personal_space_views.py`

------
https://chatgpt.com/codex/tasks/task_e_689c360d255883259d7cb733aa0f1747