### PR TITLE
fix: update stat card trend arguments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1308,3 +1308,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Fixed /personal-space/ 500 by correcting template links, removing invalid macros and adding dashboard view test. (PR personal-space-dashboard-fix)
 - Fixed Personal Space dashboard loading unstyled by linking personal-space-optimized.css and adding aria labels to icon buttons. (PR personal-space-dashboard-style-fix)
 - Enabled Personal Space dashboard interactions by rendering modals and wiring quick notes to blocks API. (PR personal-space-dashboard-js)
+- Replaced deprecated `trend_positive` argument with `trend`/`trend_value` in personal space stat cards to fix 500 error on `/personal-space/`. (PR personal-space-trend-arg-fix)

--- a/crunevo/templates/personal_space/components/widgets/AnalyticsDashboard.html
+++ b/crunevo/templates/personal_space/components/widgets/AnalyticsDashboard.html
@@ -75,10 +75,10 @@
                 {{ render_stat_card(
                     title='Tareas Completadas',
                     value=analytics_data.tasks_completed if analytics_data else 24,
-                    icon='bi-check-circle',
+                    icon='check-circle',
                     color='success',
-                    trend='+12%',
-                    trend_positive=true
+                    trend='up',
+                    trend_value='+12%'
                 ) }}
             </div>
             
@@ -86,10 +86,10 @@
                 {{ render_stat_card(
                     title='Objetivos Alcanzados',
                     value=analytics_data.goals_achieved if analytics_data else 3,
-                    icon='bi-target',
+                    icon='target',
                     color='primary',
-                    trend='+25%',
-                    trend_positive=true
+                    trend='up',
+                    trend_value='+25%'
                 ) }}
             </div>
             
@@ -97,10 +97,10 @@
                 {{ render_stat_card(
                     title='Tiempo Productivo',
                     value=(analytics_data.productive_hours if analytics_data else 32) ~ 'h',
-                    icon='bi-clock',
+                    icon='clock',
                     color='info',
-                    trend='+8%',
-                    trend_positive=true
+                    trend='up',
+                    trend_value='+8%'
                 ) }}
             </div>
             
@@ -108,10 +108,10 @@
                 {{ render_stat_card(
                     title='Puntuación de Foco',
                     value=(analytics_data.focus_score if analytics_data else 85) ~ '%',
-                    icon='bi-bullseye',
+                    icon='bullseye',
                     color='warning',
-                    trend='-3%',
-                    trend_positive=false
+                    trend='down',
+                    trend_value='-3%'
                 ) }}
             </div>
         </div>

--- a/crunevo/templates/personal_space/templates.html
+++ b/crunevo/templates/personal_space/templates.html
@@ -622,35 +622,34 @@
                 {{ render_stat_card(
                     icon='collection',
                     value=total_templates or 0,
-                    label='Plantillas disponibles',
-                    trend='+' + (template_growth or '0') + '%',
-                    trend_positive=true,
+                    title='Plantillas disponibles',
+                    trend='up',
+                    trend_value='+' + (template_growth or '0') + '%',
                     color='primary'
                 ) }}
                 
                 {{ render_stat_card(
                     icon='heart',
                     value=user_favorites or 0,
-                    label='Mis favoritas',
-                    trend='',
+                    title='Mis favoritas',
                     color='success'
                 ) }}
                 
                 {{ render_stat_card(
                     icon='person-plus',
                     value=user_templates or 0,
-                    label='Mis plantillas',
-                    trend='+' + (user_template_growth or '0') + '%',
-                    trend_positive=true,
+                    title='Mis plantillas',
+                    trend='up',
+                    trend_value='+' + (user_template_growth or '0') + '%',
                     color='warning'
                 ) }}
                 
                 {{ render_stat_card(
                     icon='download',
                     value=template_downloads or 0,
-                    label='Descargas totales',
-                    trend='+' + (download_growth or '0') + '%',
-                    trend_positive=true,
+                    title='Descargas totales',
+                    trend='up',
+                    trend_value='+' + (download_growth or '0') + '%',
                     color='info'
                 ) }}
             </div>


### PR DESCRIPTION
## Summary
- adjust personal space stat card calls to use `trend` and `trend_value` instead of removed `trend_positive`
- document change in AGENTS notes

## Testing
- `pre-commit run --files AGENTS.md crunevo/templates/personal_space/components/widgets/AnalyticsDashboard.html crunevo/templates/personal_space/templates.html`
- `pytest tests/test_personal_space_views.py tests/test_personal_space_block_types.py tests/test_personal_space_api.py` *(fails: assert 500 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_689c3c4d64748325bbd2054f6f55edb0