### PR TITLE
Guard SQLite migration to fix Fly deployment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1309,3 +1309,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Fixed Personal Space dashboard loading unstyled by linking personal-space-optimized.css and adding aria labels to icon buttons. (PR personal-space-dashboard-style-fix)
 - Enabled Personal Space dashboard interactions by rendering modals and wiring quick notes to blocks API. (PR personal-space-dashboard-js)
 - Replaced deprecated `trend_positive` argument with `trend`/`trend_value` in personal space stat cards to fix 500 error on `/personal-space/`. (PR personal-space-trend-arg-fix)
+- Guarded fix_jsonb_compatibility_for_sqlite migration to skip on PostgreSQL, preventing GIN index errors during Fly deploy. (PR personal-space-sqlite-migration-guard)

--- a/migrations/versions/c0f842e75a5a_fix_jsonb_compatibility_for_sqlite.py
+++ b/migrations/versions/c0f842e75a5a_fix_jsonb_compatibility_for_sqlite.py
@@ -17,23 +17,27 @@ depends_on = None
 
 
 def upgrade():
+    bind = op.get_bind()
+    if bind.dialect.name != "sqlite":
+        return
+
     # Fix JSONB columns to use JSON for SQLite compatibility
     # This migration handles the conversion from postgresql.JSONB to sa.JSON
-    
+
     # For personal_space_blocks table
     with op.batch_alter_table('personal_space_blocks', schema=None) as batch_op:
         batch_op.alter_column('metadata',
                               existing_type=sa.Text(),
                               type_=sa.JSON(),
                               existing_nullable=True)
-    
+
     # For personal_space_templates table
     with op.batch_alter_table('personal_space_templates', schema=None) as batch_op:
         batch_op.alter_column('template_data',
                               existing_type=sa.Text(),
                               type_=sa.JSON(),
                               existing_nullable=False)
-    
+
     # For personal_space_analytics_events table
     with op.batch_alter_table('personal_space_analytics_events', schema=None) as batch_op:
         batch_op.alter_column('event_data',
@@ -43,22 +47,26 @@ def upgrade():
 
 
 def downgrade():
+    bind = op.get_bind()
+    if bind.dialect.name != "sqlite":
+        return
+
     # Revert JSON columns back to Text (since we can't go back to JSONB in SQLite)
-    
+
     # For personal_space_blocks table
     with op.batch_alter_table('personal_space_blocks', schema=None) as batch_op:
         batch_op.alter_column('metadata',
                               existing_type=sa.JSON(),
                               type_=sa.Text(),
                               existing_nullable=True)
-    
+
     # For personal_space_templates table
     with op.batch_alter_table('personal_space_templates', schema=None) as batch_op:
         batch_op.alter_column('template_data',
                               existing_type=sa.JSON(),
                               type_=sa.Text(),
                               existing_nullable=False)
-    
+
     # For personal_space_analytics_events table
     with op.batch_alter_table('personal_space_analytics_events', schema=None) as batch_op:
         batch_op.alter_column('event_data',


### PR DESCRIPTION
## Summary
- Skip JSON→JSONB conversion migration when not using SQLite to avoid PostgreSQL GIN index errors
- Documented migration guard in AGENTS notes

## Testing
- `make fmt` *(fails: api/index.py:26:58: F821 Undefined name `e` ... and 13 more)*
- `pytest` *(fails: tests/test_csrf.py::test_post_forms_have_csrf_macro, tests/test_migrations.py::test_alembic_upgrade, tests/test_objective_persistence.py::test_objective_view_uses_template, tests/test_objective_persistence.py::test_patch_objective_persists, tests/test_personal_space_views.py::test_dashboard_view)*

------
https://chatgpt.com/codex/tasks/task_e_689cdcaa5ba4832583488dd55d8e4668