### PR TITLE
Add forum premium columns migration and restore personal space dashboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1311,3 +1311,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Replaced deprecated `trend_positive` argument with `trend`/`trend_value` in personal space stat cards to fix 500 error on `/personal-space/`. (PR personal-space-trend-arg-fix)
 - Guarded fix_jsonb_compatibility_for_sqlite migration to skip on PostgreSQL, preventing GIN index errors during Fly deploy. (PR personal-space-sqlite-migration-guard)
 - Fixed AnalyticsDashboard sample goals reference, added personal space stats API with updated JS paths, and created migration for missing `requires_review` forum columns.
+- Added migration for forum premium feature columns and restored personal space dashboard view. (PR forum-premium-columns)

--- a/migrations/versions/forum_premium_features_columns.py
+++ b/migrations/versions/forum_premium_features_columns.py
@@ -1,0 +1,80 @@
+"""Add premium feature columns to forum tables
+
+Revision ID: forum_premium_features_columns
+Revises: forum_requires_review_column
+Create Date: 2025-08-14 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.engine.reflection import Inspector
+
+revision = "forum_premium_features_columns"
+down_revision = "forum_requires_review_column"
+branch_labels = None
+depends_on = None
+
+
+def has_table(name: str, conn) -> bool:
+    inspector = Inspector.from_engine(conn)
+    return name in inspector.get_table_names()
+
+
+def has_column(table_name: str, column_name: str, conn) -> bool:
+    inspector = Inspector.from_engine(conn)
+    columns = [col["name"] for col in inspector.get_columns(table_name)]
+    return column_name in columns
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    if has_table("forum_question", conn):
+        if not has_column("forum_question", "is_boosted", conn):
+            op.add_column(
+                "forum_question",
+                sa.Column(
+                    "is_boosted",
+                    sa.Boolean(),
+                    server_default=sa.text("false"),
+                    nullable=False,
+                ),
+            )
+            op.execute(
+                "ALTER TABLE forum_question ALTER COLUMN is_boosted DROP DEFAULT"
+            )
+        if not has_column("forum_question", "boost_expires", conn):
+            op.add_column("forum_question", sa.Column("boost_expires", sa.DateTime()))
+
+    if has_table("forum_answer", conn):
+        if not has_column("forum_answer", "is_highlighted", conn):
+            op.add_column(
+                "forum_answer",
+                sa.Column(
+                    "is_highlighted",
+                    sa.Boolean(),
+                    server_default=sa.text("false"),
+                    nullable=False,
+                ),
+            )
+            op.execute(
+                "ALTER TABLE forum_answer ALTER COLUMN is_highlighted DROP DEFAULT"
+            )
+        if not has_column("forum_answer", "highlight_expires", conn):
+            op.add_column("forum_answer", sa.Column("highlight_expires", sa.DateTime()))
+
+
+def downgrade():
+    conn = op.get_bind()
+
+    if has_table("forum_answer", conn):
+        if has_column("forum_answer", "highlight_expires", conn):
+            op.drop_column("forum_answer", "highlight_expires")
+        if has_column("forum_answer", "is_highlighted", conn):
+            op.drop_column("forum_answer", "is_highlighted")
+
+    if has_table("forum_question", conn):
+        if has_column("forum_question", "boost_expires", conn):
+            op.drop_column("forum_question", "boost_expires")
+        if has_column("forum_question", "is_boosted", conn):
+            op.drop_column("forum_question", "is_boosted")


### PR DESCRIPTION
## Summary
- add migration for forum premium feature columns
- render personal space dashboard template with testing fallback

## Testing
- `pre-commit run --files migrations/versions/forum_premium_features_columns.py crunevo/routes/personal_space_routes.py AGENTS.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d043e4eb08325b1d57d91c197c90a