### PR TITLE
Fix forum dashboard endpoint and personal space stats defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1312,3 +1312,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Guarded fix_jsonb_compatibility_for_sqlite migration to skip on PostgreSQL, preventing GIN index errors during Fly deploy. (PR personal-space-sqlite-migration-guard)
 - Fixed AnalyticsDashboard sample goals reference, added personal space stats API with updated JS paths, and created migration for missing `requires_review` forum columns.
 - Added migration for forum premium feature columns and restored personal space dashboard view. (PR forum-premium-columns)
+- Fixed forum dashboard endpoint and updated template links; passed default analytics data to personal space dashboard to avoid undefined stats. (PR forum-dashboard-personal-space-fix)

--- a/crunevo/routes/forum_routes.py
+++ b/crunevo/routes/forum_routes.py
@@ -790,7 +790,7 @@ def forum_stats():
 
 @forum_bp.route("/foro/dashboard")
 @login_required
-def gamification_dashboard():
+def dashboard():
     """User gamification dashboard"""
     # Update user's reputation score
     GamificationService.calculate_reputation(current_user)

--- a/crunevo/routes/personal_space_routes.py
+++ b/crunevo/routes/personal_space_routes.py
@@ -40,8 +40,30 @@ def dashboard():
         def moment_fn():
             return SimpleNamespace(hour=datetime.utcnow().hour)
 
+    stats = AnalyticsService.get_productivity_metrics(current_user.id)
+    pending_tasks_count = (
+        stats.get("task_completion", {}).get("total_tasks", 0)
+        - stats.get("task_completion", {}).get("completed_tasks", 0)
+    )
+    active_objectives = stats.get("objective_progress", {}).get("total_objectives", 0)
+    objective_progress_avg = stats.get("objective_progress", {}).get(
+        "average_progress", 0
+    )
+    productivity_trend = stats.get("productivity_trends", {}).get(
+        "weekly_average", 0
+    )
+
     return render_template(
-        "personal_space/dashboard.html", user=current_user, moment=moment_fn
+        "personal_space/dashboard.html",
+        user=current_user,
+        moment=moment_fn,
+        pending_tasks_count=pending_tasks_count,
+        active_objectives=active_objectives,
+        objective_progress_avg=objective_progress_avg,
+        productive_hours_today=0,
+        productivity_trend=productivity_trend,
+        focus_score=0,
+        focus_trend=0,
     )
 
 

--- a/crunevo/templates/forum/badges.html
+++ b/crunevo/templates/forum/badges.html
@@ -166,7 +166,7 @@
                     <i class="fas fa-search mr-2"></i>
                     Responder Preguntas
                 </a>
-                <a href="{{ url_for('forum.gamification_dashboard') }}" 
+                <a href="{{ url_for('forum.dashboard') }}"
                    class="bg-purple-600 text-white px-6 py-3 rounded-lg hover:bg-purple-700 transition-colors">
                     <i class="fas fa-chart-line mr-2"></i>
                     Ver Mi Dashboard

--- a/crunevo/templates/forum/leaderboard.html
+++ b/crunevo/templates/forum/leaderboard.html
@@ -221,7 +221,7 @@
                     <i class="fas fa-search mr-2"></i>
                     Responder Preguntas
                 </a>
-                <a href="{{ url_for('forum.gamification_dashboard') }}" 
+                <a href="{{ url_for('forum.dashboard') }}"
                    class="bg-purple-600 text-white px-6 py-3 rounded-lg hover:bg-purple-700 transition-colors">
                     <i class="fas fa-chart-line mr-2"></i>
                     Ver Mi Progreso


### PR DESCRIPTION
## Summary
- Rename forum dashboard route and update templates to prevent BuildError
- Pass default analytics metrics to personal space dashboard to avoid undefined stats

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d08de4fc48325a3f1288c8db18df5