### PR TITLE
Fix personal space trends and forum dashboard link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1312,3 +1312,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Guarded fix_jsonb_compatibility_for_sqlite migration to skip on PostgreSQL, preventing GIN index errors during Fly deploy. (PR personal-space-sqlite-migration-guard)
 - Fixed AnalyticsDashboard sample goals reference, added personal space stats API with updated JS paths, and created migration for missing `requires_review` forum columns.
 - Added migration for forum premium feature columns and restored personal space dashboard view. (PR forum-premium-columns)
+- Prevented undefined trend errors on personal space dashboard and fixed forum gamification link to avoid BuildError. (PR dashboard-trend-link-fix)

--- a/crunevo/templates/forum/list.html
+++ b/crunevo/templates/forum/list.html
@@ -456,7 +456,7 @@
           <div class="cta-icon">🎮</div>
           <h6 class="cta-title">¡Sube de nivel!</h6>
           <p class="cta-description">Responde preguntas, gana puntos y desbloquea insignias</p>
-          <a href="{{ url_for('forum.dashboard') }}" class="btn btn-primary btn-sm modern-btn">Ver mi progreso</a>
+          <a href="{{ url_for('forum.gamification_dashboard') }}" class="btn btn-primary btn-sm modern-btn">Ver mi progreso</a>
         </div>
       </div>
       {% endif %}

--- a/crunevo/templates/personal_space/dashboard.html
+++ b/crunevo/templates/personal_space/dashboard.html
@@ -105,9 +105,10 @@
                     </div>
                     <div class="stat-value">{{ productive_hours_today or 0 }}h</div>
                     <div class="stat-label">Horas productivas</div>
-                    <div class="stat-trend {{ 'positive' if productivity_trend >= 0 else 'negative' }}">
-                        <i class="bi bi-arrow-{{ 'up' if productivity_trend >= 0 else 'down' }}"></i> 
-                        {{ productivity_trend or 0 }}%
+                    {% set trend = productivity_trend | default(0) %}
+                    <div class="stat-trend {{ 'positive' if trend >= 0 else 'negative' }}">
+                        <i class="bi bi-arrow-{{ 'up' if trend >= 0 else 'down' }}"></i>
+                        {{ trend }}%
                     </div>
                 </div>
                 
@@ -117,9 +118,10 @@
                     </div>
                     <div class="stat-value">{{ focus_score or 0 }}%</div>
                     <div class="stat-label">Puntuación de foco</div>
-                    <div class="stat-trend {{ 'positive' if focus_trend >= 0 else 'negative' }}">
-                        <i class="bi bi-arrow-{{ 'up' if focus_trend >= 0 else 'down' }}"></i> 
-                        {{ focus_trend or 0 }}%
+                    {% set f_trend = focus_trend | default(0) %}
+                    <div class="stat-trend {{ 'positive' if f_trend >= 0 else 'negative' }}">
+                        <i class="bi bi-arrow-{{ 'up' if f_trend >= 0 else 'down' }}"></i>
+                        {{ f_trend }}%
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Default missing trend values on personal space dashboard to avoid 500 errors
- Correct forum gamification link to use existing `gamification_dashboard` endpoint
- Document latest changes in AGENTS log

## Testing
- `pytest tests/test_forum_routes.py tests/test_personal_space_views.py::test_dashboard_view -q`

------
https://chatgpt.com/codex/tasks/task_e_689d08de4fc48325a3f1288c8db18df5