### PR TITLE
Fix forum gamification link and add sample insights helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1314,3 +1314,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Added migration for forum premium feature columns and restored personal space dashboard view. (PR forum-premium-columns)
 - Prevented undefined trend errors on personal space dashboard and fixed forum gamification link to avoid BuildError. (PR dashboard-trend-link-fix)
 - Fixed forum dashboard endpoint and updated template links; passed default analytics data to personal space dashboard to avoid undefined stats. (PR forum-dashboard-personal-space-fix)
+- Corrected forum gamification link to use existing endpoint and added sample insights template global to prevent Personal Space dashboard errors. (PR forum-personal-space-fixes)

--- a/crunevo/routes/personal_space_routes.py
+++ b/crunevo/routes/personal_space_routes.py
@@ -22,6 +22,44 @@ personal_space_api_bp = Blueprint(
 )
 
 
+def get_sample_insights():
+    """Return sample insights for the analytics dashboard."""
+    return [
+        {
+            "title": "Pico de productividad",
+            "description": (
+                "Tus mejores horas son entre las 9:00 y 11:00 AM. "
+                "Considera programar tareas importantes en este horario."
+            ),
+            "icon": "bi-clock",
+            "action": "optimizeSchedule()",
+            "action_text": "Optimizar horario",
+        },
+        {
+            "title": "Objetivos en riesgo",
+            "description": (
+                "Tienes 2 objetivos que podrían no cumplirse a tiempo. "
+                "Revisa tus prioridades."
+            ),
+            "icon": "bi-exclamation-triangle",
+            "action": "reviewGoals()",
+            "action_text": "Revisar objetivos",
+        },
+        {
+            "title": "Racha de productividad",
+            "description": (
+                "¡Felicidades! Has completado tareas durante 7 días consecutivos."
+            ),
+            "icon": "bi-trophy",
+            "action": None,
+            "action_text": None,
+        },
+    ]
+
+
+personal_space_bp.add_app_template_global(get_sample_insights)
+
+
 # ---------------------------------------------------------------------------
 # Page routes
 # ---------------------------------------------------------------------------

--- a/crunevo/templates/forum/list.html
+++ b/crunevo/templates/forum/list.html
@@ -456,7 +456,7 @@
           <div class="cta-icon">🎮</div>
           <h6 class="cta-title">¡Sube de nivel!</h6>
           <p class="cta-description">Responde preguntas, gana puntos y desbloquea insignias</p>
-          <a href="{{ url_for('forum.gamification_dashboard') }}" class="btn btn-primary btn-sm modern-btn">Ver mi progreso</a>
+          <a href="{{ url_for('forum.init_gamification') }}" class="btn btn-primary btn-sm modern-btn">Ver mi progreso</a>
         </div>
       </div>
       {% endif %}


### PR DESCRIPTION
## Summary
- fix broken forum gamification link by referencing the existing init endpoint
- provide sample insights helper for personal space analytics dashboard

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d0e90b66c8325af6682eb4528dd63