### PR TITLE
Fix personal space form macro attrs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1317,3 +1317,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Corrected forum gamification link to use existing endpoint and added sample insights template global to prevent Personal Space dashboard errors. (PR forum-personal-space-fixes)
 - Updated forum gamification CTA to point to dashboard instead of init API to avoid 405 errors on `/api/gamification/init`.
 - Enhanced `render_form_field` macro to accept `name` and extra attributes, fixing Personal Space form rendering.
+- Replaced unsupported `**attrs` with an `attrs` dict in `render_form_field` and updated BlockFactory calls to resolve Jinja syntax errors on `/personal-space/`. (PR personal-space-form-attrs-fix)

--- a/crunevo/templates/personal_space/components/base/BaseForm.html
+++ b/crunevo/templates/personal_space/components/base/BaseForm.html
@@ -1,5 +1,5 @@
 <!-- BaseForm Component - Reusable form foundation -->
-{% macro render_form_field(name, label, type='text', placeholder='', required=false, help_text='', icon='', validation_rules={}, value='', options=None, **attrs) %}
+{% macro render_form_field(name, label, type='text', placeholder='', required=false, help_text='', icon='', validation_rules=None, value='', options=None, attrs=None) %}
 <div class="form-group mb-3">
     {% if label %}
     <label for="{{ name }}" class="form-label fw-medium">
@@ -22,10 +22,10 @@
             name="{{ name }}"
             placeholder="{{ placeholder }}"
             {{ 'required' if required else '' }}
-            {% for rule, val in validation_rules.items() %}
+            {% for rule, val in (validation_rules or {}).items() %}
             {{ rule }}="{{ val }}"
             {% endfor %}
-            {% for attr, val in attrs.items() %}
+            {% for attr, val in (attrs or {}).items() %}
             {{ attr }}="{{ val }}"
             {% endfor %}
         >{{ value }}</textarea>
@@ -35,7 +35,7 @@
             id="{{ name }}"
             name="{{ name }}"
             {{ 'required' if required else '' }}
-            {% for attr, val in attrs.items() %}
+            {% for attr, val in (attrs or {}).items() %}
             {{ attr }}="{{ val }}"
             {% endfor %}
         >
@@ -54,10 +54,10 @@
             id="{{ name }}"
             name="{{ name }}"
             {{ 'required' if required else '' }}
-            {% for rule, val in validation_rules.items() %}
+            {% for rule, val in (validation_rules or {}).items() %}
             {{ rule }}="{{ val }}"
             {% endfor %}
-            {% for attr, val in attrs.items() %}
+            {% for attr, val in (attrs or {}).items() %}
             {{ attr }}="{{ val }}"
             {% endfor %}
         >
@@ -69,7 +69,7 @@
                 id="{{ name }}"
                 name="{{ name }}"
                 {{ 'required' if required else '' }}
-                {% for attr, val in attrs.items() %}
+                {% for attr, val in (attrs or {}).items() %}
                 {{ attr }}="{{ val }}"
                 {% endfor %}
             >
@@ -90,10 +90,10 @@
             placeholder="{{ placeholder }}"
             value="{{ value }}"
             {{ 'required' if required else '' }}
-            {% for rule, val in validation_rules.items() %}
+            {% for rule, val in (validation_rules or {}).items() %}
             {{ rule }}="{{ val }}"
             {% endfor %}
-            {% for attr, val in attrs.items() %}
+            {% for attr, val in (attrs or {}).items() %}
             {{ attr }}="{{ val }}"
             {% endfor %}
         >

--- a/crunevo/templates/personal_space/components/widgets/BlockFactory.html
+++ b/crunevo/templates/personal_space/components/widgets/BlockFactory.html
@@ -167,7 +167,7 @@
                     name='description',
                     label='Descripción (opcional)',
                     placeholder='Describe el propósito de este bloque...',
-                    rows=3
+                    attrs={'rows': 3}
                 ) }}
                 
                 <div class="row">
@@ -232,22 +232,22 @@
                         ) }}
                     </div>
                     <div class="col-md-4">
-                        {{ render_form_field(
-                            type='number',
-                            name='position_x',
-                            label='Posición X',
-                            value=0,
-                            min=0
-                        ) }}
+                          {{ render_form_field(
+                              type='number',
+                              name='position_x',
+                              label='Posición X',
+                              value=0,
+                              attrs={'min': 0}
+                          ) }}
                     </div>
                     <div class="col-md-4">
-                        {{ render_form_field(
-                            type='number',
-                            name='position_y',
-                            label='Posición Y',
-                            value=0,
-                            min=0
-                        ) }}
+                          {{ render_form_field(
+                              type='number',
+                              name='position_y',
+                              label='Posición Y',
+                              value=0,
+                              attrs={'min': 0}
+                          ) }}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- replace unsupported `**attrs` in form field macro with `attrs` dict
- pass extra field attributes via `attrs` in BlockFactory
- document fix in AGENTS

## Testing
- `pytest tests/test_personal_space_api.py tests/test_personal_space_block_types.py tests/test_personal_space_views.py -q`
- `pre-commit run --files crunevo/templates/personal_space/components/base/BaseForm.html crunevo/templates/personal_space/components/widgets/BlockFactory.html AGENTS.md`


------
https://chatgpt.com/codex/tasks/task_e_689d20bf212c8325a545f13104e64f27