### PR TITLE
Fix BlockFactory modal id argument

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1318,3 +1318,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Updated forum gamification CTA to point to dashboard instead of init API to avoid 405 errors on `/api/gamification/init`.
 - Enhanced `render_form_field` macro to accept `name` and extra attributes, fixing Personal Space form rendering.
 - Replaced unsupported `**attrs` with an `attrs` dict in `render_form_field` and updated BlockFactory calls to resolve Jinja syntax errors on `/personal-space/`. (PR personal-space-form-attrs-fix)
+- Fixed BlockFactory modal invocation to use 'modal_id' and call syntax, preventing keyword argument errors in render_base_modal. (PR block-factory-modal-id-fix)

--- a/crunevo/templates/personal_space/components/widgets/BlockFactory.html
+++ b/crunevo/templates/personal_space/components/widgets/BlockFactory.html
@@ -4,13 +4,17 @@
 
 <!-- Block Factory Modal -->
 {% macro render_block_factory_modal() %}
-{{ render_base_modal(
-    id='block-factory-modal',
+{% call render_base_modal(
+    modal_id='block-factory-modal',
     title='Crear Nuevo Bloque',
-    size='lg',
-    content=render_block_factory_content(),
-    footer=render_block_factory_footer()
-) }}
+    size='lg'
+) %}
+    {{ render_block_factory_content() }}
+
+    <div slot="footer">
+        {{ render_block_factory_footer() }}
+    </div>
+{% endcall %}
 {% endmacro %}
 
 <!-- Block Factory Content -->


### PR DESCRIPTION
## Summary
- use `modal_id` param with call syntax for BlockFactory modal to avoid render_base_modal keyword errors
- document change in AGENTS.md

## Testing
- `pre-commit run --files crunevo/templates/personal_space/components/widgets/BlockFactory.html AGENTS.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d2acf7e288325b9bae5f020816aaf