### PR TITLE
fix: restore template gallery macros

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1321,3 +1321,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Fixed BlockFactory modal invocation to use 'modal_id' and call syntax, preventing keyword argument errors in render_base_modal. (PR block-factory-modal-id-fix)
 - Addressed remaining ruff lint errors by removing unused variables, replacing `== True` checks with direct attribute access, importing missing modules and capturing exception messages. (PR ruff-lint-cleanup)
 - Reworked BaseModal to accept body and footer parameters and updated BlockFactory and TemplateGallery templates accordingly, fixing caller argument errors on `/personal-space/`. (PR render-base-modal-caller-fix)
+- Added `render_template_gallery_modal` and renamed template creation macro to resolve import errors on `/personal-space/`. (PR personal-space-template-gallery-fix)

--- a/crunevo/templates/personal_space/components/widgets/TemplateGallery.html
+++ b/crunevo/templates/personal_space/components/widgets/TemplateGallery.html
@@ -159,12 +159,6 @@
         </div>
     </div>
 </div>
-
-<!-- Template Creator Modal -->
-{{ render_template_creator_modal() }}
-
-<!-- Template Preview Modal -->
-{{ render_template_preview_modal() }}
 {% endmacro %}
 
 <!-- Template Grid -->
@@ -298,8 +292,8 @@
 </div>
 {% endmacro %}
 
-<!-- Template Creator Modal -->
-{% macro render_template_creator_modal() %}
+<!-- Template Creation Modal -->
+{% macro render_template_creation_modal() %}
 {% set body %}
     <form id="template-creator-form" onsubmit="createTemplate(event)">
         <!-- Basic Info -->
@@ -541,6 +535,18 @@
     body=body,
     footer=footer
 ) }}
+{% endmacro %}
+
+<!-- Template Gallery Modal -->
+{% macro render_template_gallery_modal(templates=none, user_templates=none, categories=none) %}
+{{ render_base_modal(
+    modal_id='template-gallery-modal',
+    title='Galería de Plantillas',
+    size='xl',
+    body=render_template_gallery(templates, user_templates, categories)
+) }}
+{{ render_template_creation_modal() }}
+{{ render_template_preview_modal() }}
 {% endmacro %}
 
 <style>


### PR DESCRIPTION
## Summary
- add `render_template_gallery_modal` macro for personal space templates
- rename creation macro to `render_template_creation_modal` to fix imports

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689d383e5ff083258b74a4b7069184ee