### PR TITLE
Fix Template Gallery modal references in personal space

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1321,3 +1321,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Fixed BlockFactory modal invocation to use 'modal_id' and call syntax, preventing keyword argument errors in render_base_modal. (PR block-factory-modal-id-fix)
 - Addressed remaining ruff lint errors by removing unused variables, replacing `== True` checks with direct attribute access, importing missing modules and capturing exception messages. (PR ruff-lint-cleanup)
 - Reworked BaseModal to accept body and footer parameters and updated BlockFactory and TemplateGallery templates accordingly, fixing caller argument errors on `/personal-space/`. (PR render-base-modal-caller-fix)
+- Added `render_template_gallery_modal` wrapper and corrected template imports to prevent 500 errors on `/personal-space/`. (PR personal-space-gallery-modal-fix)

--- a/crunevo/templates/personal_space/components/widgets/TemplateGallery.html
+++ b/crunevo/templates/personal_space/components/widgets/TemplateGallery.html
@@ -159,12 +159,6 @@
         </div>
     </div>
 </div>
-
-<!-- Template Creator Modal -->
-{{ render_template_creator_modal() }}
-
-<!-- Template Preview Modal -->
-{{ render_template_preview_modal() }}
 {% endmacro %}
 
 <!-- Template Grid -->
@@ -541,6 +535,18 @@
     body=body,
     footer=footer
 ) }}
+{% endmacro %}
+
+<!-- Template Gallery Modal Wrapper -->
+{% macro render_template_gallery_modal(templates=none, user_templates=none, categories=none) %}
+{{ render_base_modal(
+    modal_id='template-gallery-modal',
+    title='Galería de Plantillas',
+    size='xl',
+    body=render_template_gallery(templates, user_templates, categories)
+) }}
+{{ render_template_creator_modal() }}
+{{ render_template_preview_modal() }}
 {% endmacro %}
 
 <style>

--- a/crunevo/templates/personal_space/templates.html
+++ b/crunevo/templates/personal_space/templates.html
@@ -1,6 +1,6 @@
 <!-- Personal Space Templates - Template management and gallery -->
 {% extends "base.html" %}
-{% from 'personal_space/components/widgets/TemplateGallery.html' import render_template_gallery, render_template_creation_modal, render_template_preview_modal %}
+{% from 'personal_space/components/widgets/TemplateGallery.html' import render_template_gallery, render_template_creator_modal, render_template_preview_modal %}
 {% from 'personal_space/components/base/BaseCard.html' import render_stat_card, render_info_card %}
 {% from 'personal_space/components/base/BaseModal.html' import render_confirmation_modal %}
 
@@ -864,7 +864,7 @@
 </div>
 
 <!-- Modals -->
-{{ render_template_creation_modal() }}
+{{ render_template_creator_modal() }}
 {{ render_template_preview_modal() }}
 {{ render_confirmation_modal(
     id='delete-template-modal',


### PR DESCRIPTION
## Summary
- add `render_template_gallery_modal` wrapper to TemplateGallery widget
- fix template imports and calls to use `render_template_creator_modal`
- document personal space gallery modal fix in AGENTS instructions

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_689d383e5ff083258b74a4b7069184ee