### PR TITLE
Fix personal space template grid initialization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1322,3 +1322,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Addressed remaining ruff lint errors by removing unused variables, replacing `== True` checks with direct attribute access, importing missing modules and capturing exception messages. (PR ruff-lint-cleanup)
 - Reworked BaseModal to accept body and footer parameters and updated BlockFactory and TemplateGallery templates accordingly, fixing caller argument errors on `/personal-space/`. (PR render-base-modal-caller-fix)
 - Added `render_template_gallery_modal` wrapper and corrected template imports to prevent 500 errors on `/personal-space/`. (PR personal-space-gallery-modal-fix)
+- Removed undefined Jinja calls to get_featured_templates and get_community_templates in TemplateGallery, rendering empty grids by default to avoid 500 errors on /personal-space/. (PR personal-space-template-grid-fallback)

--- a/crunevo/templates/personal_space/components/widgets/TemplateGallery.html
+++ b/crunevo/templates/personal_space/components/widgets/TemplateGallery.html
@@ -132,7 +132,7 @@
              id="featured-templates" 
              role="tabpanel">
             <div class="templates-grid" id="featured-grid">
-                {{ render_template_grid(templates or get_featured_templates()) }}
+                {{ render_template_grid(templates or []) }}
             </div>
         </div>
         
@@ -141,7 +141,7 @@
              id="community-templates" 
              role="tabpanel">
             <div class="templates-grid" id="community-grid">
-                {{ render_template_grid(get_community_templates()) }}
+                {{ render_template_grid([]) }}
             </div>
         </div>
         


### PR DESCRIPTION
## Summary
- Prevent Jinja from calling undefined `get_featured_templates` and `get_community_templates`
- Render empty template grids by default to avoid `/personal-space/` errors
- Log update in AGENTS

## Testing
- `pytest tests/test_personal_space_views.py -q`
- `pytest tests/test_personal_space_block_types.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d3be0889c83259276cf9f87c21206