### PR TITLE
fix: remove JavaScript comments from Jinja template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1324,3 +1324,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Added `render_template_gallery_modal` wrapper and corrected template imports to prevent 500 errors on `/personal-space/`. (PR personal-space-gallery-modal-fix)
 - Removed undefined Jinja calls to get_featured_templates and get_community_templates in TemplateGallery, rendering empty grids by default to avoid 500 errors on /personal-space/. (PR personal-space-template-grid-fallback)
 - Normalized personal space API with RESTful block/template endpoints, added template favorite/import stubs, aligned wizard JS payloads/routes, and exposed closeWizardModal. (PR personal-space-rest-wizard)
+- Replaced JavaScript-style comment within sample goals list in AnalyticsDashboard template with Jinja comment to resolve unexpected '//' errors on `/personal-space/`. (PR personal-space-jinja-comment)

--- a/crunevo/templates/personal_space/components/widgets/AnalyticsDashboard.html
+++ b/crunevo/templates/personal_space/components/widgets/AnalyticsDashboard.html
@@ -175,9 +175,9 @@
                         </h5>
                     </div>
                     <div class="card-body">
+                        {# Goals will be loaded dynamically from API #}
                         {% set sample_goals = [
                             {'title': 'Completar proyecto Q1', 'progress': 75, 'due_date': '2024-03-31'},
-                            // Goals will be loaded dynamically from API
                             {'title': 'Ejercicio 3x por semana', 'progress': 60, 'due_date': None}
                         ] %}
                         <div class="goals-progress" id="goals-progress">


### PR DESCRIPTION
## Summary
- replace JS-style comment in AnalyticsDashboard sample goals with Jinja comment to avoid template syntax errors
- log change in AGENTS

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e5717df9c8325a40ea80f72545c27