### PR TITLE
Fix BlockFactory template includes for personal space pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1328,3 +1328,4 @@ Todos los cambios mantienen la funcionalidad original mientras mejoran significa
 - Corrected personal space dashboard dropdown link to use existing `analytics_dashboard` endpoint and verified quick notes tables migration. (PR personal-space-analytics-link-fix)
 - Redesigned Quick Notes to open as Bootstrap modal appended to body with portal, replacing anchor trigger and persisting preferences. (PR quick-notes-modal-fix)
 - Made Personal Space analytics dashboard load real metrics from AnalyticsService and added view test. (PR personal-space-analytics-data)
+- Replaced BlockFactory macro imports with includes in personal space templates to prevent missing template errors on dashboard and workspace. (PR blockfactory-include-fix)

--- a/crunevo/templates/personal_space/dashboard.html
+++ b/crunevo/templates/personal_space/dashboard.html
@@ -2,7 +2,6 @@
 {% extends "base.html" %}
 {% from 'personal_space/components/layout/DashboardLayout.html' import render_dashboard_layout with context %}
 {% from 'personal_space/components/widgets/TemplateGallery.html' import render_template_gallery_modal %}
-{% from 'personal_space/components/widgets/BlockFactory.html' import render_block_factory_modal %}
 {% from 'personal_space/components/widgets/AnalyticsDashboard.html' import render_analytics_dashboard %}
 
 {% block title %}Personal Space - Dashboard{% endblock %}
@@ -259,7 +258,7 @@
 </button>
 
 <!-- Modals placeholders -->
-{{ render_block_factory_modal() }}
+{% include 'personal_space/components/widgets/BlockFactory.html' %}
 {{ render_template_gallery_modal() }}
 
 <!-- Quick Notes Modal -->

--- a/crunevo/templates/personal_space/index.html
+++ b/crunevo/templates/personal_space/index.html
@@ -1,7 +1,6 @@
 <!-- Personal Space Index - Main entry point for redesigned personal space -->
 {% extends "base.html" %}
 {% from 'personal_space/components/base/BaseCard.html' import render_info_card, render_stat_card %}
-{% from 'personal_space/components/widgets/BlockFactory.html' import render_block_factory_modal %}
 {% from 'personal_space/components/widgets/TemplateGallery.html' import render_template_gallery_modal %}
 
 {% block title %}Personal Space{% endblock %}
@@ -224,7 +223,7 @@
 </div>
 
 <!-- Modals -->
-{{ render_block_factory_modal() }}
+{% include 'personal_space/components/widgets/BlockFactory.html' %}
 {{ render_template_gallery_modal() }}
 {% endblock %}
 

--- a/crunevo/templates/personal_space/workspace.html
+++ b/crunevo/templates/personal_space/workspace.html
@@ -1,7 +1,6 @@
 <!-- Personal Space Workspace - Dynamic drag-and-drop workspace -->
 {% extends "base.html" %}
 {% from 'personal_space/components/layout/WorkspaceLayout.html' import render_workspace_layout %}
-{% from 'personal_space/components/widgets/BlockFactory.html' import render_block_factory_modal %}
 {% from 'personal_space/components/widgets/TemplateGallery.html' import render_template_gallery_modal %}
 
 {% block title %}Personal Space - Workspace{% endblock %}
@@ -249,7 +248,7 @@
 </div>
 
 <!-- Modals -->
-{{ render_block_factory_modal() }}
+{% include 'personal_space/components/widgets/BlockFactory.html' %}
 {{ render_template_gallery_modal() }}
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Fix `/personal-space/` 500s by including `BlockFactory.html` directly instead of importing a missing macro
- Update personal space index, dashboard, and workspace templates accordingly
- Document BlockFactory include fix in AGENTS.md

## Testing
- `pre-commit run --files crunevo/templates/personal_space/index.html crunevo/templates/personal_space/workspace.html crunevo/templates/personal_space/dashboard.html`
- `pytest tests/test_personal_space_views.py tests/test_personal_space_block_types.py tests/test_personal_space_api.py`

------
https://chatgpt.com/codex/tasks/task_e_689f9ed373ec8325a261414216b5c199