### PR TITLE
Fix workspace initialization and layout

### DIFF
--- a/crunevo/static/css/workspace-unified.css
+++ b/crunevo/static/css/workspace-unified.css
@@ -36,16 +36,19 @@
 
 /* Workspace Container - Unified with Dashboard */
 .workspace-container {
+    display: flex;
+    flex-direction: column;
     min-height: 100vh;
-    background: linear-gradient(135deg, var(--ps-bg-light) 0%, #f1f5f9 100%);
+    overflow: hidden;
+    background-color: #fff;
     color: var(--ps-text-primary-light);
     transition: var(--workspace-transition);
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 }
 
 [data-bs-theme="dark"] .workspace-container {
-    background: linear-gradient(135deg, #1e293b 0%, var(--ps-bg-dark) 100%);
-    color: var(--ps-text-primary-dark);
+    background-color: #fff;
+    color: var(--ps-text-primary-light);
 }
 
 /* Workspace Header - Unified with Personal Space */
@@ -260,16 +263,19 @@
 /* Workspace Main Layout */
 .workspace-main {
     display: flex;
-    min-height: calc(100vh - 120px);
+    flex: 1 1 auto;
+    min-height: 0;
+    min-width: 0;
     gap: 1.5rem;
     padding: 1.5rem 2rem;
     overflow: hidden;
+    background-color: #fff;
 }
 
 /* Workspace Sidebar - Consistent with Dashboard Sidebar */
 .workspace-sidebar {
     width: var(--workspace-sidebar-width);
-    background: var(--ps-card-bg-light);
+    background: #fff;
     border-right: 1px solid var(--ps-border-light);
     padding: 1.5rem;
     overflow-y: auto;
@@ -469,10 +475,19 @@
 
 /* Workspace Area - Grid Container */
 .workspace-area {
-    flex: 1;
-    min-height: 100%;
+    flex: 1 1 auto;
+    min-width: 0;
     display: flex;
     flex-direction: column;
+    overflow: auto;
+    background-color: #fff;
+}
+
+[data-bs-theme="dark"] .workspace-main,
+[data-bs-theme="dark"] .workspace-area,
+[data-bs-theme="dark"] #workspace-sidebar {
+    background-color: #fff;
+    color: var(--ps-text-primary-light);
 }
 
 .grid-container {

--- a/crunevo/static/js/personal-space.js
+++ b/crunevo/static/js/personal-space.js
@@ -118,7 +118,7 @@ function initializeFocusMode() {
 }
 
 function initializeSortable() {
-    const grid = document.getElementById('blocksGrid');
+    const grid = document.getElementById('blocks-grid');
     if (!grid) return;
 
     sortableInstance = Sortable.create(grid, {
@@ -203,7 +203,7 @@ function initializeEventListeners() {
         });
 
         // Centralized block interaction delegation with improved handling
-        const grid = document.getElementById('blocksGrid');
+        const grid = document.getElementById('blocks-grid');
         if (grid && !grid.dataset.bound) {
             grid.addEventListener('click', handleBlockInteractions);
             grid.addEventListener('dblclick', handleBlockInteractions);
@@ -232,13 +232,20 @@ function initializeAutoSave() {
 
 // Block Management Functions
 function loadBlocks() {
-    // Show loading state
-    const grid = document.getElementById('blocksGrid');
-    if (grid) {
-        grid.innerHTML = '<div class="text-center p-4"><div class="spinner-border" role="status"><span class="visually-hidden">Cargando...</span></div></div>';
+    const grid = document.getElementById('blocks-grid');
+    if (!grid) {
+        console.warn('Blocks grid not found');
+        return;
     }
-    
-    csrfFetch('/api/personal-space/blocks')
+
+    grid.innerHTML = '<div class="text-center p-4"><div class="spinner-border" role="status"><span class="visually-hidden">Cargando...</span></div></div>';
+
+    const fetchFn = window.csrfFetch || window.fetch.bind(window);
+    if (!window.csrfFetch) {
+        console.warn('csrfFetch not defined, using fetch');
+    }
+
+    fetchFn('/api/personal-space/blocks')
         .then(response => {
             if (!response.ok) {
                 throw new Error(`HTTP error! status: ${response.status}`);
@@ -253,29 +260,15 @@ function loadBlocks() {
             }
         })
         .catch(error => {
-            console.error('Error loading blocks:', error);
-            showNotification('Error al cargar los bloques: ' + error.message, 'error');
-            
-            // Show error state
-            if (grid) {
-                grid.innerHTML = `
-                    <div class="empty-state">
-                        <div class="empty-state-icon">
-                            <i class="bi bi-exclamation-triangle"></i>
-                        </div>
-                        <h3>Error al cargar bloques</h3>
-                        <p>No se pudieron cargar los bloques. Intenta recargar la página.</p>
-                        <button class="modern-btn modern-btn-primary" onclick="loadBlocks()">Reintentar</button>
-                    </div>
-                `;
-            }
+            console.warn('Error loading blocks:', error);
+            renderEmptyState(grid);
         });
 }
 
 function renderBlocks(blocks) {
-    const grid = document.getElementById('blocksGrid');
+    const grid = document.getElementById('blocks-grid');
     if (!grid) {
-        console.error('Blocks grid not found');
+        console.warn('Blocks grid not found');
         return;
     }
 
@@ -677,7 +670,7 @@ function createNewBlock(type) {
                 if (blockElement) {
                     blockElement.classList.add('new-block');
 
-                    const grid = document.getElementById('blocksGrid');
+                    const grid = document.getElementById('blocks-grid');
                     if (grid) {
                         const emptyState = grid.querySelector('.empty-state');
                         if (emptyState) {
@@ -1136,7 +1129,7 @@ function updateBlockInUI(blockData) {
 }
 
 function addBlockToUI(blockData) {
-    const grid = document.getElementById('blocksGrid');
+    const grid = document.getElementById('blocks-grid');
     if (!grid) return;
     const block = convertBlock(blockData);
     const element = createBlockElement(block);
@@ -1173,7 +1166,7 @@ function deleteBlock(blockId) {
                     blockCard.remove();
 
                     // Show empty state if no blocks left
-                    const grid = document.getElementById('blocksGrid');
+                    const grid = document.getElementById('blocks-grid');
                     if (grid.children.length === 0) {
                         grid.innerHTML = `
                             <div class="empty-state">
@@ -2077,7 +2070,7 @@ function saveQuickNote() {
                 // Add to grid
                 const blockElement = createBlockElement(data.block);
                 if (blockElement) {
-                    const grid = document.getElementById('blocksGrid');
+                    const grid = document.getElementById('blocks-grid');
                     if (grid) {
                         const emptyState = grid.querySelector('.empty-state');
                         if (emptyState) emptyState.remove();
@@ -2183,13 +2176,13 @@ function initializeQuickNotesIntegration() {
 
 // Improved block grid error handling
 function ensureBlocksGrid() {
-    let grid = document.getElementById('blocksGrid');
+    let grid = document.getElementById('blocks-grid');
     if (!grid) {
         // Create blocks grid if it doesn't exist
         const container = document.querySelector('.blocks-container') || document.querySelector('.dashboard-content') || document.querySelector('main');
         if (container) {
             grid = document.createElement('div');
-            grid.id = 'blocksGrid';
+            grid.id = 'blocks-grid';
             grid.className = 'blocks-grid row g-3';
             container.appendChild(grid);
         } else {
@@ -2219,20 +2212,8 @@ function handleBlockError(error, operation = 'operación') {
 }
 
 // Initialize Personal Space when DOM is ready
-if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', function() {
-        // Small delay to ensure all scripts are loaded
-        setTimeout(() => {
-            if (typeof initPersonalSpace === 'function') {
-                initPersonalSpace();
-            }
-        }, 100);
-    });
-} else {
-    // DOM is already loaded
-    setTimeout(() => {
-        if (typeof initPersonalSpace === 'function') {
-            initPersonalSpace();
-        }
-    }, 100);
-}
+document.addEventListener('DOMContentLoaded', () => {
+    if (document.getElementById('workspace-container') && typeof initPersonalSpace === 'function') {
+        initPersonalSpace();
+    }
+});

--- a/crunevo/static/js/workspace-unified.js
+++ b/crunevo/static/js/workspace-unified.js
@@ -26,6 +26,10 @@ window.WorkspaceManager = {
      * Initialize the workspace manager
      */
     init: function() {
+        if (this.initialized) return;
+        const container = document.getElementById('workspace-container');
+        if (!container) return;
+        this.initialized = true;
         this.initializeGrid();
         this.bindEvents();
         this.loadWorkspaceData();
@@ -39,9 +43,8 @@ window.WorkspaceManager = {
      */
     initializeGrid: function() {
         // Check if grid container exists
-        const gridContainer = document.querySelector('.grid-stack');
+        const gridContainer = document.querySelector('#blocks-grid .grid-stack');
         if (!gridContainer) {
-            console.warn('GridStack container not found. Skipping grid initialization.');
             return;
         }
         
@@ -341,13 +344,17 @@ window.WorkspaceManager = {
      */
     loadWorkspaceData: async function() {
         try {
-            const response = await fetch('/api/personal-space/blocks');
+            const fetchFn = window.csrfFetch || window.fetch.bind(window);
+            if (!window.csrfFetch) {
+                console.warn('csrfFetch not defined, using fetch');
+            }
+            const response = await fetchFn('/api/personal-space/blocks');
             if (response.ok) {
                 const data = await response.json();
                 this.renderWorkspaceBlocks(data.blocks);
             }
         } catch (error) {
-            console.error('Error loading workspace data:', error);
+            console.warn('Error loading workspace data:', error);
         }
     },
     
@@ -480,11 +487,13 @@ window.WorkspaceManager = {
     updateEditModeUI: function() {
         const container = document.getElementById('workspace-container');
         const btn = document.getElementById('edit-mode-btn');
-        
+        const sidebar = document.getElementById('workspace-sidebar');
+        const hasBlocks = document.querySelector('#blocks-grid .grid-stack-item');
+
         if (container) {
             container.classList.toggle('edit-mode', this.isEditMode);
         }
-        
+
         if (btn) {
             if (this.isEditMode) {
                 btn.innerHTML = '<i class="bi bi-check me-1"></i>Finalizar';
@@ -493,6 +502,10 @@ window.WorkspaceManager = {
                 btn.innerHTML = '<i class="bi bi-pencil me-1"></i>Editar';
                 btn.classList.add('secondary');
             }
+        }
+
+        if (sidebar) {
+            sidebar.style.display = this.isEditMode && hasBlocks ? '' : 'none';
         }
     },
     
@@ -774,12 +787,10 @@ window.deleteBlock = function(blockId) {
 };
 
 // Initialize when DOM is ready
-document.addEventListener('DOMContentLoaded', function() {
-    // Initialize Personal Space core functionality
+document.addEventListener('DOMContentLoaded', () => {
+    if (!document.getElementById('workspace-container')) return;
     if (window.initPersonalSpace) {
         window.initPersonalSpace();
     }
-    
-    // Initialize Unified Workspace Manager
     window.WorkspaceManager.init();
 });

--- a/crunevo/templates/personal_space/components/layout/WorkspaceLayout.html
+++ b/crunevo/templates/personal_space/components/layout/WorkspaceLayout.html
@@ -105,8 +105,8 @@
     {% endif %}
     
     <!-- Workspace Grid -->
-    <div class="workspace-grid" 
-         id="workspace-grid" 
+    <div class="workspace-grid"
+         id="blocks-grid"
          data-grid-size="medium" 
          data-snap-enabled="true" 
          data-grid-visible="true">

--- a/crunevo/templates/personal_space/workspace.html
+++ b/crunevo/templates/personal_space/workspace.html
@@ -81,9 +81,9 @@
     </div>
     
     <!-- Workspace Main Area -->
-    <div class="workspace-main">
+        <div class="workspace-main">
         <!-- Sidebar -->
-        <div class="workspace-sidebar" id="workspace-sidebar">
+        <div class="workspace-sidebar d-none tw-hidden" id="workspace-sidebar">
             <div class="sidebar-header">
                 <h3 class="sidebar-title">Bloques Disponibles</h3>
             </div>
@@ -148,10 +148,10 @@
         
         <!-- Workspace Area -->
         <div class="workspace-area">
-            <div class="grid-container">
-                {% if workspace_blocks %}
-                    {{ render_workspace_layout(blocks=workspace_blocks, edit_mode=false) }}
-                {% else %}
+            {% if workspace_blocks %}
+                {{ render_workspace_layout(workspace=workspace, blocks=workspace_blocks, editable=false) }}
+            {% else %}
+                <div id="blocks-grid" class="grid-container">
                     <div class="empty-workspace">
                         <div class="empty-workspace-icon">
                             <i class="bi bi-grid-3x3-gap"></i>
@@ -160,17 +160,17 @@
                         <p class="empty-workspace-description">
                             Arrastra bloques desde la barra lateral o crea nuevos bloques para comenzar a organizar tu espacio de trabajo.
                         </p>
-                        <button type="button" 
-                                class="btn workspace-btn" 
+                        <button type="button"
+                                class="btn workspace-btn"
                                 id="create-first-block-btn"
-                                data-bs-toggle="modal" 
+                                data-bs-toggle="modal"
                                 data-bs-target="#block-factory-modal">
                             <i class="bi bi-plus me-2"></i>
                             Crear tu primer bloque
                         </button>
                     </div>
-                {% endif %}
-            </div>
+                </div>
+            {% endif %}
         </div>
     </div>
     


### PR DESCRIPTION
## Summary
- Ensure Personal Space scripts wait for DOM and fallback to fetch when csrfFetch is missing
- Harden WorkspaceManager initialization and show sidebar only in edit mode with blocks
- Normalize workspace layout to full-height white flex panels and consistent #blocks-grid

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a6496bcf808321b9427acae4ff20d0