### PR TITLE
feat: unify objective block icon

### DIFF
--- a/crunevo/static/css/personal-space-optimized.css
+++ b/crunevo/static/css/personal-space-optimized.css
@@ -1390,6 +1390,11 @@ select:focus {
     color: var(--ps-blue);
 }
 
+.stat-icon.violet {
+    background: rgba(139, 92, 246, 0.1);
+    color: #8b5cf6;
+}
+
 .stat-value {
     font-size: 2rem;
     font-weight: 700;

--- a/crunevo/static/css/workspace-unified.css
+++ b/crunevo/static/css/workspace-unified.css
@@ -424,8 +424,8 @@
 }
 
 .block-icon.objective {
-    background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
-    box-shadow: 0 2px 8px rgba(245, 158, 11, 0.2);
+    background: linear-gradient(135deg, #a855f7 0%, #7e22ce 100%);
+    box-shadow: 0 2px 8px rgba(168, 85, 247, 0.2);
 }
 
 .block-icon.note {

--- a/crunevo/static/js/personal-space.js
+++ b/crunevo/static/js/personal-space.js
@@ -20,13 +20,14 @@ const DEFAULT_ICONS = {
     'nota_enriquecida': 'bi-file-richtext',
     'bitacora': 'bi-journal-text',
     'lista': 'bi-check2-square',
-    'meta': 'bi-target',
+    'meta': 'bi-bullseye',
     'recordatorio': 'bi-alarm',
     'frase': 'bi-quote',
     'enlace': 'bi-link-45deg',
     'tarea': 'bi-clipboard-check',
     'kanban': 'bi-kanban',
-    'objetivo': 'bi-trophy',
+    'objetivo': 'bi-bullseye',
+    'objective': 'bi-bullseye',
     'bloque': 'bi-grid-3x3'
 };
 

--- a/crunevo/static/js/workspace-unified.js
+++ b/crunevo/static/js/workspace-unified.js
@@ -429,7 +429,7 @@ window.WorkspaceManager = {
             task: 'check-square',
             note: 'journal-text',
             kanban: 'kanban',
-            objective: 'target',
+            objective: 'bullseye',
             calendar: 'calendar3',
             habit: 'arrow-repeat'
         };

--- a/crunevo/templates/personal_space/components/layout/DashboardLayout.html
+++ b/crunevo/templates/personal_space/components/layout/DashboardLayout.html
@@ -88,8 +88,8 @@
                 {% call render_stat_card(
                     title='Objetivos en Progreso',
                     value=stats.active_objectives,
-                    icon='bi-target',
-                    color='info',
+                    icon='bi-bullseye',
+                    color='primary',
                     trend=stats.objectives_trend
                 ) %}{% endcall %}
             </div>
@@ -150,7 +150,7 @@
                                     <i class="{{ {
                                         'nota': 'bi-file-text',
                                         'tarea': 'bi-check-square',
-                                        'objetivo': 'bi-target',
+                                        'objetivo': 'bi-bullseye',
                                         'kanban': 'bi-kanban'
                                     }.get(block.type, 'bi-square') }}"></i>
                                 </div>

--- a/crunevo/templates/personal_space/components/layout/WorkspaceLayout.html
+++ b/crunevo/templates/personal_space/components/layout/WorkspaceLayout.html
@@ -264,7 +264,7 @@
                             <i class="{{ {
                                 'nota': 'bi-file-text',
                                 'tarea': 'bi-check-square',
-                                'objetivo': 'bi-target',
+                                'objetivo': 'bi-bullseye',
                                 'kanban': 'bi-kanban'
                             }.get(block.type, 'bi-square') }}"></i>
                         </div>
@@ -307,7 +307,7 @@
                     
                     <div class="sidebar-block create-block" onclick="createNewBlock('objetivo')">
                         <div class="block-icon">
-                            <i class="bi bi-target"></i>
+                            <i class="bi bi-bullseye"></i>
                         </div>
                         <div class="block-info">
                             <div class="block-title">Nuevo Objetivo</div>

--- a/crunevo/templates/personal_space/components/widgets/AnalyticsDashboard.html
+++ b/crunevo/templates/personal_space/components/widgets/AnalyticsDashboard.html
@@ -171,7 +171,7 @@
                 <div class="analytics-card">
                     <div class="card-header">
                         <h5 class="card-title mb-0">
-                            <i class="bi bi-target me-2"></i>
+                            <i class="bi bi-bullseye me-2"></i>
                             Progreso de Objetivos
                         </h5>
                     </div>
@@ -278,7 +278,7 @@
     {% endfor %}
 {% else %}
     <div class="empty-goals text-center py-4">
-        <i class="bi bi-target text-muted" style="font-size: 2rem;"></i>
+        <i class="bi bi-bullseye text-muted" style="font-size: 2rem;"></i>
         <p class="text-muted mt-2 mb-0">No hay objetivos activos</p>
         <button type="button" class="btn btn-sm btn-primary mt-2" onclick="createNewGoal()">
             Crear objetivo

--- a/crunevo/templates/personal_space/components/widgets/BlockFactory.html
+++ b/crunevo/templates/personal_space/components/widgets/BlockFactory.html
@@ -66,7 +66,7 @@
                             
                             <div class="block-type-card" data-block-type="objective" data-action="select-block-type">
                                 <div class="block-type-icon">
-                                    <i class="bi bi-target"></i>
+                                    <i class="bi bi-bullseye"></i>
                                 </div>
                                 <div class="block-type-info">
                                     <h6 class="block-type-title">Objetivos</h6>

--- a/crunevo/templates/personal_space/components/widgets/TemplateGallery.html
+++ b/crunevo/templates/personal_space/components/widgets/TemplateGallery.html
@@ -377,7 +377,7 @@
                                value="objetivo">
                         <label for="include-objectives" class="block-label">
                             <div class="block-icon">
-                                <i class="bi bi-target"></i>
+                                <i class="bi bi-bullseye"></i>
                             </div>
                             <span>Objetivos</span>
                         </label>
@@ -1206,7 +1206,7 @@ window.TemplateGallery = {
             const icons = {
                 nota: 'bi-file-text',
                 tarea: 'bi-check-square',
-                objetivo: 'bi-target',
+                objetivo: 'bi-bullseye',
                 kanban: 'bi-kanban'
             };
             
@@ -1314,7 +1314,7 @@ window.TemplateGallery = {
                                     {
                                         nota: 'bi-file-text',
                                         tarea: 'bi-check-square',
-                                        objetivo: 'bi-target',
+                                        objetivo: 'bi-bullseye',
                                         kanban: 'bi-kanban'
                                     }[block] || 'bi-square'
                                 }"></i>

--- a/crunevo/templates/personal_space/dashboard.html
+++ b/crunevo/templates/personal_space/dashboard.html
@@ -102,8 +102,8 @@
                 </div>
                 
                 <div class="stat-card">
-                    <div class="stat-icon success">
-                        <i class="bi bi-target"></i>
+                    <div class="stat-icon violet">
+                        <i class="bi bi-bullseye"></i>
                     </div>
                     <div class="stat-value">{{ active_objectives or 0 }}</div>
                     <div class="stat-label">Objetivos activos</div>

--- a/crunevo/templates/personal_space/index.html
+++ b/crunevo/templates/personal_space/index.html
@@ -136,7 +136,7 @@
                     
                     <div class="feature-card">
                         <div class="feature-icon">
-                            <i class="bi bi-target"></i>
+                            <i class="bi bi-bullseye"></i>
                         </div>
                         <h3 class="feature-title">Seguimiento de Objetivos</h3>
                         <p class="feature-description">

--- a/crunevo/templates/personal_space/workspace.html
+++ b/crunevo/templates/personal_space/workspace.html
@@ -108,7 +108,7 @@
                     </div>
                     <div class="block-item" data-block-type="objectives">
                         <div class="block-item-header">
-                            <i class="block-icon bi bi-target"></i>
+                            <i class="block-icon bi bi-bullseye"></i>
                             <span>Objetivos</span>
                         </div>
                         <small>Seguimiento de metas</small>


### PR DESCRIPTION
## Summary
- use Bootstrap bullseye icon for objective blocks across Personal Space
- map objective block icon centrally and add violet styling
- update workspace icon map to render bullseye symbol

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68a652c80df48321b5734ee05ca02410