### PR TITLE
Load personal space config stylesheet

### DIFF
--- a/crunevo/static/css/personal-space-config.css
+++ b/crunevo/static/css/personal-space-config.css
@@ -1,4 +1,13 @@
 /* Personal Space Configuration styles */
+:root {
+    --ps-card-bg-light: #fff;
+    --ps-card-bg-dark: #1f1f1f;
+    --ps-border-light: #e5e7eb;
+    --ps-border-dark: #2d2f31;
+    --ps-shadow-sm: 0 2px 6px rgba(0, 0, 0, 0.06);
+    --ps-shadow-md: 0 6px 16px rgba(0, 0, 0, 0.12);
+}
+
 #personal-space-config .stats-grid {
     display: grid;
     gap: 1rem;
@@ -64,7 +73,7 @@
 }
 
 #personal-space-config .stat-label {
-    color: #111827;
+    color: var(--bs-body-color);
     font-size: 0.875rem;
     margin-top: 0.25rem;
     font-weight: 600;

--- a/crunevo/templates/personal_space/configuracion.html
+++ b/crunevo/templates/personal_space/configuracion.html
@@ -5,8 +5,8 @@
 
 {% block title %}Personal Space - Configuración{% endblock %}
 
-{% block extra_head %}
-<link rel="stylesheet" href="{{ url_for('static', filename='css/personal-space-config.css') }}">
+{% block head_extra %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/personal-space-config.css', v=20240821) }}">
 <!-- Configuration Page Styles -->
 <style>
 .config-container {

--- a/crunevo/templates/personal_space/index.html
+++ b/crunevo/templates/personal_space/index.html
@@ -5,7 +5,7 @@
 
 {% block title %}Personal Space{% endblock %}
 
-{% block extra_head %}
+{% block head_extra %}
 <!-- Personal Space Optimized CSS -->
 <link rel="stylesheet" href="{{ url_for('static', filename='css/personal-space-optimized.css') }}">
 <!-- Block Factory Enhanced CSS -->

--- a/crunevo/templates/personal_space/templates.html
+++ b/crunevo/templates/personal_space/templates.html
@@ -6,7 +6,7 @@
 
 {% block title %}Personal Space - Plantillas{% endblock %}
 
-{% block extra_head %}
+{% block head_extra %}
 <!-- Custom CSS -->
 <style>
 /* Templates Page Specific Styles */


### PR DESCRIPTION
## Summary
- Ensure personal space configuration styles are loaded via `head_extra`
- Normalize personal space templates to use `head_extra` block
- Add CSS token fallbacks and theme-aware stat label color

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68a6bc48c1f08321b98ac824d3466aac