### PR TITLE
feat: minimal personal space blocks API and workspace bridge

### DIFF
--- a/crunevo/api/__init__.py
+++ b/crunevo/api/__init__.py
@@ -2,6 +2,7 @@ from .feed import feed_api_bp
 from .notes import notes_api_bp
 from .users import users_api_bp
 from .search import search_api_bp
+from .personal_space_api import personal_space_api_bp
 
 
 def init_api(app):
@@ -9,3 +10,5 @@ def init_api(app):
     app.register_blueprint(notes_api_bp)
     app.register_blueprint(users_api_bp)
     app.register_blueprint(search_api_bp)
+    if "personal_space_api" not in app.blueprints:
+        app.register_blueprint(personal_space_api_bp)

--- a/crunevo/api/personal_space_api.py
+++ b/crunevo/api/personal_space_api.py
@@ -1,0 +1,77 @@
+from flask import Blueprint, jsonify, request
+from datetime import datetime
+from uuid import uuid4
+
+personal_space_api_bp = Blueprint(
+    "personal_space_api", __name__, url_prefix="/api/personal-space"
+)
+
+# In-memory store for development/testing
+STORE = {"blocks": []}
+
+
+def _normalize_payload(payload: dict) -> dict:
+    """Normalize incoming block payload from the front-end."""
+    now = datetime.utcnow().isoformat()
+
+    # Base fields
+    block_type = payload.get("type") or payload.get("wizard", {}).get("selectedType")
+    title = payload.get("title", "")
+    content = payload.get("description") or payload.get("content", "")
+
+    # Defaults
+    size = payload.get("size", "medium")
+    color = payload.get("color", "primary")
+    is_public = payload.get("public", False)
+
+    # Start with provided metadata then overlay normalized fields
+    metadata = dict(payload.get("metadata") or {})
+    metadata.update(
+        {
+            k: v
+            for k, v in payload.items()
+            if k
+            not in {
+                "type",
+                "title",
+                "description",
+                "content",
+                "color",
+                "size",
+                "public",
+                "metadata",
+            }
+        }
+    )
+    metadata.setdefault("size", size)
+    metadata.setdefault("theme_color", color)
+    metadata.setdefault("public_view", is_public)
+
+    block = {
+        "id": str(uuid4()),
+        "type": block_type,
+        "title": title,
+        "content": content,
+        "metadata": metadata,
+        "created_at": now,
+        "updated_at": now,
+    }
+    return block
+
+
+@personal_space_api_bp.route("/blocks", methods=["GET"])
+def list_blocks():
+    """Return all blocks in the in-memory store."""
+    return jsonify({"blocks": STORE["blocks"]})
+
+
+@personal_space_api_bp.route("/blocks", methods=["POST"])
+def create_block():
+    """Create a new block, normalizing the payload before storing."""
+    # Read CSRF header if present (compatibility with front-end)
+    request.headers.get("X-CSRFToken")
+
+    payload = request.get_json(silent=True) or {}
+    block = _normalize_payload(payload)
+    STORE["blocks"].append(block)
+    return jsonify(block), 201

--- a/crunevo/static/js/BlockFactory.js
+++ b/crunevo/static/js/BlockFactory.js
@@ -688,29 +688,30 @@ window.BlockFactory = {
 
     // Collect all block data
     collectBlockData: function() {
-        const data = {
-            type: this.wizard.selectedType,
-            title: document.querySelector('input[name="title"]')?.value || '',
-            content: document.querySelector('textarea[name="description"]')?.value || '',
+        const type = this.wizard.selectedType;
+        const title = document.getElementById('block-title')?.value?.trim() || '';
+        const description = document.getElementById('block-description')?.value?.trim() || '';
+        const color = document.getElementById('block-color')?.value || 'primary';
+        const size = document.getElementById('block-size')?.value || 'medium';
+        const isPublic = !!document.getElementById('block-public')?.checked;
+
+        const typeConfig = this.collectTypeSpecificConfig();
+
+        return {
+            type,
+            title,
+            description,
             metadata: {
-                category: document.querySelector('select[name="category"]')?.value || 'personal',
-                priority: document.querySelector('select[name="priority"]')?.value || 'medium',
-                size: document.querySelector('select[name="size"]')?.value || 'medium',
-                position_x: parseInt(document.querySelector('input[name="position_x"]')?.value) || 0,
-                position_y: parseInt(document.querySelector('input[name="position_y"]')?.value) || 0,
-                theme_color: document.getElementById('theme_color')?.value || 'purple',
-                header_style: document.querySelector('select[name="header_style"]')?.value || 'default',
-                show_border: document.getElementById('show_border')?.checked || false,
-                show_shadow: document.getElementById('show_shadow')?.checked || false,
-                auto_save: document.getElementById('auto_save')?.checked || false,
-                notifications: document.getElementById('notifications')?.checked || false,
-                collaborative: document.getElementById('collaborative')?.checked || false,
-                public_view: document.getElementById('public_view')?.checked || false,
-                ...this.collectTypeSpecificConfig()
-            }
+                size,
+                theme_color: color,
+                public_view: isPublic,
+                ...typeConfig
+            },
+            color,
+            size,
+            public: isPublic,
+            ...typeConfig
         };
-        
-        return data;
     },
 
     // Collect type-specific configuration

--- a/crunevo/static/js/workspace-bridge.js
+++ b/crunevo/static/js/workspace-bridge.js
@@ -1,0 +1,70 @@
+(function() {
+  function renderGrid(blocks) {
+    const grid = document.getElementById('blocks-grid');
+    if (!grid) return;
+    grid.innerHTML = '';
+    blocks.forEach(insertCard);
+    if (blocks.length) {
+      hideEmptyState();
+    }
+  }
+
+  function insertCard(block) {
+    const grid = document.getElementById('blocks-grid');
+    if (!grid) return;
+    const card = document.createElement('div');
+    card.className = 'card mb-3';
+    card.tabIndex = 0;
+    const color = block?.metadata?.theme_color || 'primary';
+    card.innerHTML = `<div class="card-body border-${color}">` +
+      `<h5 class="card-title">${block.title || ''}</h5>` +
+      `<p class="card-text text-muted">${block.type}</p>` +
+      `</div>`;
+    grid.appendChild(card);
+  }
+
+  function hideEmptyState() {
+    const empty = document.querySelector('.empty-workspace');
+    if (empty) empty.classList.add('d-none');
+  }
+
+  function updateFooter(n) {
+    const el = document.querySelector('.workspace-info div:nth-child(2)');
+    if (el) el.textContent = `${n} bloques`;
+  }
+
+  window.WorkspaceBlocks = {
+    _blocks: [],
+    async load() {
+      const res = await fetch('/api/personal-space/blocks');
+      const data = await res.json();
+      this._blocks = Array.isArray(data.blocks) ? data.blocks : [];
+      renderGrid(this._blocks);
+      if (!this._blocks.length) {
+        const empty = document.querySelector('.empty-workspace');
+        if (empty) empty.classList.remove('d-none');
+      }
+      updateFooter(this._blocks.length);
+    },
+    addBlock(block) {
+      const b = block && (block.block || block);
+      if (!b) return;
+      this._blocks.push(b);
+      insertCard(b);
+      hideEmptyState();
+      updateFooter(this._blocks.length);
+    }
+  };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    if (document.getElementById('blocks-grid')) {
+      window.WorkspaceBlocks.load().catch(console.error);
+    }
+  });
+
+  window.WorkspaceLayout = {
+    refreshBlocks() {
+      window.WorkspaceBlocks.load();
+    }
+  };
+})();

--- a/crunevo/templates/personal_space/workspace.html
+++ b/crunevo/templates/personal_space/workspace.html
@@ -18,6 +18,8 @@
 <script src="{{ url_for('static', filename='js/personal-space.js') }}" defer></script>
 <!-- BlockFactory JavaScript -->
 <script src="{{ url_for('static', filename='js/BlockFactory.js') }}" defer></script>
+<!-- Workspace bridge -->
+<script src="{{ url_for('static', filename='js/workspace-bridge.js') }}" defer></script>
 <!-- Free drag & drop workspace JS -->
 <script src="{{ url_for('static', filename='js/workspace-free.js') }}" defer></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add in-memory `/api/personal-space/blocks` GET/POST endpoints
- normalize BlockFactory payload and wire workspace bridge
- load bridge in workspace template to render blocks without reload

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68a6c53159348321b2b7370f8e20a7af