### PR TITLE
fix workspace block creation wizard

### DIFF
--- a/crunevo/templates/personal_space/workspace.html
+++ b/crunevo/templates/personal_space/workspace.html
@@ -18,10 +18,6 @@
 <script src="{{ url_for('static', filename='js/personal-space.js') }}" defer></script>
 <!-- BlockFactory JavaScript -->
 <script src="{{ url_for('static', filename='js/BlockFactory.js') }}" defer></script>
-<!-- Workspace bridge -->
-<script src="{{ url_for('static', filename='js/workspace-bridge.js') }}" defer></script>
-<!-- Free drag & drop workspace JS -->
-<script src="{{ url_for('static', filename='js/workspace-free.js') }}" defer></script>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## Summary
- remove legacy workspace bridge scripts that overwrote WorkspaceBlocks and broke block loading
- cleanup workspace template so only unified workspace manager is used

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68ab64b8ac10832185c33469ebc29632