### PR TITLE
fix: add Heroicons dependency for successful build

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -20,6 +20,10 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Additional Dependencies
+
+The mobile navigation relies on [Heroicons](https://github.com/tailwindlabs/heroicons). Run `npm install` to ensure the icons are available before executing `npm run build`.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from "next";
+import Link from "next/link";
+import { HomeIcon, MagnifyingGlassIcon, BellIcon, UserIcon, RssIcon } from '@heroicons/react/24/outline';
 import { Inter } from "next/font/google";
 import "./globals.css";
 
@@ -29,7 +31,7 @@ export default function RootLayout({
             <span className="text-xs">Feed</span>
           </Link>
           <Link href="/search" className="flex flex-col items-center">
-            <SearchIcon className="w-6 h-6" />
+            <MagnifyingGlassIcon className="w-6 h-6" />
             <span className="text-xs">Buscar</span>
           </Link>
           <Link href="/notifications" className="flex flex-col items-center">
@@ -45,5 +47,3 @@ export default function RootLayout({
     </html>
   );
 }
-import Link from "next/link";
-import { HomeIcon, SearchIcon, BellIcon, UserIcon, RssIcon } from '@heroicons/react/24/outline';

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@heroicons/react": "^2.2.0",
         "next": "15.4.4",
         "react": "19.1.0",
         "react-dom": "19.1.0"
@@ -56,6 +57,15 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,9 +9,10 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@heroicons/react": "^2.2.0",
+    "next": "15.4.4",
     "react": "19.1.0",
-    "react-dom": "19.1.0",
-    "next": "15.4.4"
+    "react-dom": "19.1.0"
   },
   "devDependencies": {
     "typescript": "^5",


### PR DESCRIPTION
## Summary
- replace deprecated SearchIcon with MagnifyingGlassIcon
- add `@heroicons/react` dependency to frontend and document it
- ensure `npm run build` runs without errors

## Testing
- `npm run build`
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b392c8f0948321a086942f50de6301